### PR TITLE
Added check for RLGLUE_PORT environment variable

### DIFF
--- a/src/controllers/rlglue_controller.cpp
+++ b/src/controllers/rlglue_controller.cpp
@@ -58,6 +58,16 @@ void RLGlueController::initRLGlue() {
   const char* host = kLocalHost;
   short port = kDefaultPort;
 
+  const char* envptr = 0;
+ 
+  envptr = getenv("RLGLUE_PORT");  
+  if (envptr != 0) {
+    port = strtol(envptr, 0, 10);
+    if (port == 0) {
+      port = kDefaultPort;
+    }
+  }
+
   rlBufferCreate(&m_buffer, 4096);
 
   m_connection = rlWaitForConnection(host, port, kRetryTimeout);


### PR DESCRIPTION
The controller would only use the default port number when setting up the rlglue network. The controller now checks to see if the RLGLUE_PORT environment variable is set. If not set, the default port (4096) will be used.
