### PR TITLE
Proposed changes to fix skip-frame bug.

### DIFF
--- a/src/controllers/ale_controller.cpp
+++ b/src/controllers/ale_controller.cpp
@@ -42,7 +42,8 @@ void ALEController::display() {
     display->display_screen(m_osystem->console().mediaSource());
 }
 
-void ALEController::applyActions(Action player_a, Action player_b) {
+reward_t ALEController::applyActions(Action player_a, Action player_b) {
+  reward_t sum_rewards = 0;
   // Perform different operations based on the first player's action 
   switch (player_a) {
     case LOAD_STATE: // Load system state
@@ -58,8 +59,9 @@ void ALEController::applyActions(Action player_a, Action player_b) {
       break;
     default:
       // Pass action to emulator!
-      m_environment.act(player_a, player_b);
+      sum_rewards = m_environment.act(player_a, player_b);
       break;
   }
+  return sum_rewards;
 }
 

--- a/src/controllers/ale_controller.hpp
+++ b/src/controllers/ale_controller.hpp
@@ -34,7 +34,7 @@ class ALEController {
     friend class ALEInterface;
 
     /** Applies the given action to the environment (e.g. by emulating or resetting) */
-    void applyActions(Action a, Action b); 
+    reward_t applyActions(Action a, Action b); 
     /** Support for SDL display... available to all controllers. Simply call it from run(). */
     void display();
 

--- a/src/controllers/fifo_controller.cpp
+++ b/src/controllers/fifo_controller.cpp
@@ -58,7 +58,7 @@ void FIFOController::run() {
     readAction(action_a, action_b);
 
     // Emulate Atari forward
-    applyActions(action_a, action_b);
+    latest_reward = applyActions(action_a, action_b);
 
     // Update display if needed
     display();
@@ -223,7 +223,7 @@ void FIFOController::sendRAM() {
 }
 
 void FIFOController::sendRL() {
-  int r = m_settings->getReward();
+  int r = (int) latest_reward;
   bool is_terminal = m_environment.isTerminal();
 
   fprintf(m_fout, "%d,%d:", is_terminal, r);

--- a/src/controllers/fifo_controller.hpp
+++ b/src/controllers/fifo_controller.hpp
@@ -53,6 +53,7 @@ class FIFOController : public ALEController {
     FILE* m_fout; 
     FILE* m_fin; 
 
+    reward_t latest_reward; // Most recent reward
 };
 
 #endif // __FIFO_CONTROLLER_HPP__

--- a/src/controllers/internal_controller.cpp
+++ b/src/controllers/internal_controller.cpp
@@ -71,9 +71,7 @@ void InternalController::run() {
         episodeStep(action_a, action_b);
     
       // Apply said actions
-      applyActions(action_a, action_b);
-
-      m_episode_score += m_settings->getReward();
+      m_episode_score += applyActions(action_a, action_b);
     }
 
     // Display if necessary

--- a/src/controllers/rlglue_controller.cpp
+++ b/src/controllers/rlglue_controller.cpp
@@ -154,7 +154,8 @@ void RLGlueController::envStart() {
   m_environment.reset();
 
   // Create the observation (we don't need reward/terminal here, but it's easier this way)
-  reward_observation_terminal_t ro = constructRewardObservationTerminal();
+  reward_t reset_reward = 0;
+  reward_observation_terminal_t ro = constructRewardObservationTerminal(reset_reward);
 
   // Copy into buffer
   rlBufferClear(&m_buffer);
@@ -177,9 +178,9 @@ void RLGlueController::envStep() {
   filterActions(player_a_action, player_b_action);
  
   // Pass these actions to ALE
-  applyActions(player_a_action, player_b_action);
+  reward_t reward = applyActions(player_a_action, player_b_action);
 
-  reward_observation_terminal_t ro = constructRewardObservationTerminal();
+  reward_observation_terminal_t ro = constructRewardObservationTerminal(reward);
 
   // Copy relevant data into the buffer
   rlBufferClear(&m_buffer);
@@ -222,7 +223,7 @@ void RLGlueController::filterActions(Action& player_a_action, Action& player_b_a
     player_b_action = PLAYER_B_NOOP;
 }
 
-reward_observation_terminal_t RLGlueController::constructRewardObservationTerminal() {
+reward_observation_terminal_t RLGlueController::constructRewardObservationTerminal(reward_t reward) {
   reward_observation_terminal_t ro;
   
   int index = 0;
@@ -238,7 +239,7 @@ reward_observation_terminal_t RLGlueController::constructRewardObservationTermin
   ro.observation = &m_observation;
 
   // Fetch reward, terminal from the game settings
-  ro.reward = m_settings->getReward();
+  ro.reward = reward;
   ro.terminal = m_settings->isTerminal();
 
   __RL_CHECK_STRUCT(ro.observation)

--- a/src/controllers/rlglue_controller.hpp
+++ b/src/controllers/rlglue_controller.hpp
@@ -58,7 +58,7 @@ class RLGlueController : public ALEController {
 
     /** RL-Glue helper methods. */
 
-    reward_observation_terminal_t constructRewardObservationTerminal();
+    reward_observation_terminal_t constructRewardObservationTerminal(reward_t reward);
     /** Filters the action received by RL-Glue */
     void filterActions(Action& player_a_action, Action& player_b_action);
 


### PR DESCRIPTION
This deals with the skip frame issue by changing the applyActions methods in ale_controller to return a reward_t. It also changes the fifo/internal/rl_glue controllers accordingly. I've tested that it works with the internal controller but not with the fifo or rl_glue controllers.
