### PR TITLE
Remove case-sensitivity for ROM lookup

### DIFF
--- a/src/games/Roms.cpp
+++ b/src/games/Roms.cpp
@@ -150,6 +150,7 @@ RomSettings *buildRomRLWrapper(const std::string &rom) {
     std::string rom_str = rom.substr(slash_ind + 1);
     size_t dot_idx = rom_str.find_first_of(".");
     rom_str = rom_str.substr(0, dot_idx);
+    std::transform(rom_str.begin(), rom_str.end(), rom_str.begin(), ::tolower);
 
     for (size_t i=0; i < sizeof(roms)/sizeof(roms[0]); i++) {
         if (rom_str == roms[i]->rom()) return roms[i]->clone();


### PR DESCRIPTION
Previously, `Space_Invaders.bin` (note the caps) would exit with the cryptic "Unsupported ROM file:" error.
