### PR TITLE
Refactored Export Screen

### DIFF
--- a/doc/examples/sharedLibraryInterfaceExample.cpp
+++ b/doc/examples/sharedLibraryInterfaceExample.cpp
@@ -16,6 +16,7 @@
 
 #include <iostream>
 #include <ale_interface.hpp>
+#include <sstream>
 
 #ifdef __USE_SDL
   #include "SDL/SDL.h"
@@ -54,6 +55,12 @@ int main(int argc, char** argv) {
             // Apply the action and get the resulting reward
             float reward = ale.act(a);
             totalReward += reward;
+            static int frame = 0;
+            std::stringstream ss;
+            ss << "screens/" << setfill('0') << setw(5) <<
+                frame << ".png";
+            ale.saveScreenPNG(ss.str());
+            frame++;
         }
         cout << "Episode " << episode << " ended with score: " << totalReward << endl;
         ale.reset_game();

--- a/doc/examples/sharedLibraryInterfaceExample.cpp
+++ b/doc/examples/sharedLibraryInterfaceExample.cpp
@@ -16,7 +16,6 @@
 
 #include <iostream>
 #include <ale_interface.hpp>
-#include <sstream>
 
 #ifdef __USE_SDL
   #include "SDL/SDL.h"
@@ -55,12 +54,6 @@ int main(int argc, char** argv) {
             // Apply the action and get the resulting reward
             float reward = ale.act(a);
             totalReward += reward;
-            static int frame = 0;
-            std::stringstream ss;
-            ss << "screens/" << setfill('0') << setw(5) <<
-                frame << ".png";
-            ale.saveScreenPNG(ss.str());
-            frame++;
         }
         cout << "Episode " << episode << " ended with score: " << totalReward << endl;
         ale.reset_game();

--- a/src/ale_interface.cpp
+++ b/src/ale_interface.cpp
@@ -250,3 +250,7 @@ ALEState ALEInterface::cloneState() {
 void ALEInterface::restoreState(const ALEState& state) {
   return environment->restoreState(state);
 }
+
+void ALEInterface::saveScreenPNG(const string& filename) {
+  environment->saveScreenPNG(filename);
+}

--- a/src/ale_interface.hpp
+++ b/src/ale_interface.hpp
@@ -99,6 +99,9 @@ public:
 
   void restoreState(const ALEState& state);
 
+  // Save the current screen as a png file
+  void saveScreenPNG(const string& filename);
+
  public:
   std::auto_ptr<OSystem> theOSystem;
   std::auto_ptr<Settings> theSettings;

--- a/src/common/export_screen.h
+++ b/src/common/export_screen.h
@@ -20,8 +20,8 @@
 #define EXPORT_SCREEN_H
 
 #include <vector>
-#include "../emucore/Props.hxx"
 #include "Constants.h"
+#include "ale_screen.hpp"
 
 class OSystem;
 
@@ -29,7 +29,6 @@ class ExportScreen {
     /* *************************************************************************
         This class is responsible for saving the screen matrix to an image file. 
 
-        
         Instance Variables:
             - pi_palette        An array containing the palette
             - p_props           Pointer to a Properties object
@@ -40,16 +39,9 @@ class ExportScreen {
                                 for drawing external info on the screen
     ************************************************************************* */
     public:
-        /* *********************************************************************
-            Constructor
-         ******************************************************************** */
-        ExportScreen(OSystem* osystem);
-
-        /* *********************************************************************
-            Destructor 
-         ******************************************************************** */
+        ExportScreen();
          virtual ~ExportScreen() {}
-        
+
         /* *********************************************************************
             Sets the default palette. This needs to be called before any
             export methods can be called.
@@ -59,35 +51,22 @@ class ExportScreen {
         }
 
         /* *********************************************************************
-            Saves the given screen matrix as a PNG file
-         ******************************************************************** */        
-        void save_png(const IntMatrix* screen_matrix, const string& filename);
+            Saves the given screen as a PNG file
+         ******************************************************************** */
+        void save_png(const ALEScreen& screen, const string& filename);
 
-    /* *********************************************************************
-        Saves a  matrix (e.g. the screen matrix) as a PNG file
-     ******************************************************************** */        
-    void export_any_matrix (    const IntMatrix* screen_matrix, 
-                            const string& filename) const;
-                                         
         /* *********************************************************************
-            Gets the RGB values for a given screen value from the current palette 
-         ******************************************************************** */    
+            Gets the RGB values for a given screen value from the current palette
+         ******************************************************************** */
         void get_rgb_from_palette(int val, int& r, int& g, int& b) const;
 
     protected:
         /* *********************************************************************
-            Initializes the custom palette 
+            Initializes the custom palette
          ******************************************************************** */    
         void init_custom_palette(void);
         void writePNGChunk(ofstream& out, const char* type, uInt8* data, int size) const;
-        void writePNGText(ofstream& out, const string& key, 
-                         const string& text) const;
-
         const uInt32* pi_palette;
-        const Properties* p_props;
-        OSystem* p_osystem;
-        int i_screen_width;      // Width of the screen
-        int i_screen_height;     // Height of the screen
         vector< vector <int> > v_custom_palette;
 };
 

--- a/src/emucore/OSystem.cxx
+++ b/src/emucore/OSystem.cxx
@@ -414,7 +414,7 @@ bool OSystem::createConsole(const string& romfile)
   if(size != -1) {
     delete[] image;
   }
-  p_export_screen = new ExportScreen(this); //ALE
+  p_export_screen = new ExportScreen(); //ALE
 
   if (mySettings->getBool("display_screen", true)) {
 #ifndef __USE_SDL

--- a/src/environment/stella_environment.cpp
+++ b/src/environment/stella_environment.cpp
@@ -197,6 +197,10 @@ const ALEState& StellaEnvironment::getState() const {
   return m_state;
 }
 
+void StellaEnvironment::saveScreenPNG(const string& filename) {
+  m_osystem->p_export_screen->save_png(m_screen, filename);
+}
+
 void StellaEnvironment::processScreen() {
   if (m_colour_averaging) {
     // Perform phosphor averaging; the blender stores its result in the given screen

--- a/src/environment/stella_environment.hpp
+++ b/src/environment/stella_environment.hpp
@@ -66,6 +66,9 @@ class StellaEnvironment {
     const ALEScreen &getScreen() const { return m_screen; }
     const ALERAM &getRAM() const { return m_ram; }
 
+    /** Saves the current screen as a png image. */
+    void saveScreenPNG(const string& filename);
+
     int getFrameNumber() const { return m_state.getFrameNumber(); }
     int getEpisodeFrameNumber() const { return m_state.getEpisodeFrameNumber(); }
 


### PR DESCRIPTION
Updated export screen to save ALEScreen screens rather than IntMatrix screens. Removed dependencies on OSystem from constructor. Added convenience methods to ALEInterface and StellaEnvironment to allow easy saving of the current screen. Hopefully this should take us closer to being able to make videos. One issue that remains is that the saved screens have resolution 160x210...