### PR TITLE
Dev video recording fix

### DIFF
--- a/doc/examples/videoRecordingExample.cpp
+++ b/doc/examples/videoRecordingExample.cpp
@@ -49,6 +49,8 @@ int main(int argc, char** argv) {
     // Set record flags
     ale.setString("record_screen_dir", recordPath.c_str());
     ale.setString("record_sound_filename", (recordPath + "/sound.wav").c_str());
+    // We set fragsize to 64 to ensure proper sound sync 
+    ale.setInt("fragsize", 64);
 
     // Not completely portable, but will work in most cases
     std::string cmd = "mkdir ";
@@ -71,7 +73,8 @@ int main(int argc, char** argv) {
     }
 
     std::cout << std::endl;
-    std::cout << "Recording complete. See manual for instructions on creating a video." << std::endl;
+    std::cout << "Recording complete. To create a video, you may want to run \n"
+        "  doc/scripts/videoRecordingExampleJoinXXX.sh. See manual for details.." << std::endl;
 
     return 0;
 }

--- a/src/common/SoundExporter.cpp
+++ b/src/common/SoundExporter.cpp
@@ -4,8 +4,9 @@
 namespace ale {
 namespace sound {
 
-// Sample rate is 60Hz x 512 bytes
-static const int SampleRate = 60 * 512; 
+// Sample rate is 60Hz x SamplesPerFrame bytes
+// TODO(mgb): in reality this should be 31,400 Hz, but currently we are just short of this
+static const int SampleRate = 60 * SoundExporter::SamplesPerFrame; 
 // Save wav file every 30 seconds
 static const int WriteInterval = SampleRate * 30;
 

--- a/src/common/SoundExporter.hpp
+++ b/src/common/SoundExporter.hpp
@@ -38,6 +38,8 @@ class SoundExporter {
 
     public:
     
+        static const int SamplesPerFrame = 512;
+
         typedef uInt8 SampleType;
   
         /** Create a new sound exporter which, on program termination, will write out a wav file. */

--- a/src/common/SoundNull.hxx
+++ b/src/common/SoundNull.hxx
@@ -136,6 +136,11 @@ class SoundNull : public Sound
     */
     void adjustVolume(Int8 direction) { }
 
+    /**
+      * Tells the sound engine to record one frame's worth of sound.
+      */
+    virtual void recordNextFrame() { }
+
 public:
     /**
       Loads the current state of this device from the given Deserializer.

--- a/src/common/SoundSDL.cxx
+++ b/src/common/SoundSDL.cxx
@@ -136,15 +136,6 @@ void SoundSDL::initialize()
       myIsMuted = false;
       myFragmentSizeLogBase2 = log((double)myHardwareSpec.samples) / log(2.0);
 
-        /*
-        cerr << "Freq: " << (int)myHardwareSpec.freq << endl;
-        cerr << "Format: " << (int)myHardwareSpec.format << endl;
-        cerr << "Channels: " << (int)myHardwareSpec.channels << endl;
-        cerr << "Silence: " << (int)myHardwareSpec.silence << endl;
-        cerr << "Samples: " << (int)myHardwareSpec.samples << endl;
-        cerr << "Size: " << (int)myHardwareSpec.size << endl;
-          */
-
       // Now initialize the TIASound object which will actually generate sound
       myTIASound.outputFrequency(myHardwareSpec.freq);
       myTIASound.tiaFrequency(tiafreq);

--- a/src/common/SoundSDL.hxx
+++ b/src/common/SoundSDL.hxx
@@ -142,6 +142,11 @@ class SoundSDL : public Sound
     */
     void adjustVolume(Int8 direction);
 
+    /**
+      * Tells the sound engine to record one frame's worth of sound.
+      */
+    void recordNextFrame(); 
+
   public:
     /**
       Loads the current state of this device from the given Deserializer.
@@ -281,7 +286,10 @@ class SoundSDL : public Sound
     // Callback function invoked by the SDL Audio library when it needs data
     static void callback(void* udata, uInt8* stream, int len);
 
-    std::auto_ptr<ale::sound::SoundExporter> m_sound_exporter;
+    // Keeps track of how many samples we still need to record
+    int myNumRecordSamplesNeeded; 
+
+    std::auto_ptr<ale::sound::SoundExporter> mySoundExporter; 
 };
 
 #endif  // SOUND_SUPPORT

--- a/src/common/display_screen.cpp
+++ b/src/common/display_screen.cpp
@@ -111,7 +111,7 @@ void DisplayScreen::handleSDLEvent(const SDL_Event& event) {
                     manual_control_active = !manual_control_active;
                     if (manual_control_active) {
                         fprintf(stderr, "Manual Control Enabled: [Move] "
-                                "Arrow keys [Shoot] Space [NO-OP] Return.\n");
+                                "Arrow keys [Fire] Space [NO-OP] Return.\n");
                     } else {
                         fprintf(stderr, "Manual Control Disabled\n");
                     }

--- a/src/emucore/Sound.hxx
+++ b/src/emucore/Sound.hxx
@@ -134,6 +134,11 @@ class Sound
     */
     virtual void adjustVolume(Int8 direction) = 0;
 
+    /**
+      * Tells the sound engine to record one frame's worth of sound.
+      */
+    virtual void recordNextFrame() = 0;
+
 public:
     /**
       Loads the current state of this device from the given Deserializer.

--- a/src/environment/stella_environment.cpp
+++ b/src/environment/stella_environment.cpp
@@ -147,6 +147,10 @@ reward_t StellaEnvironment::act(Action player_a_action, Action player_b_action) 
     if (rand() / double(RAND_MAX + 1.0) >= repeat_prob)
       m_player_b_action = player_b_action;
 
+    // If so desired, request one frame's worth of sound (this does nothing if recording
+    // is not enabled)
+    m_osystem->sound().recordNextFrame();
+
     // Use the stored actions, which may or may not have changed this frame
     sum_rewards += oneStepAct(m_player_a_action, m_player_b_action);
   }


### PR DESCRIPTION
Fixed synchronization issues with sound recording. I had it wrong all along. The current fix is only a 
90% solution. It still requires the SDL display to be running at the right speed. As a result the sound isn't quite as good as it should be. A better solution is to emulate the TIA/sound buffer, i.e. replicate the code
inside SoundSDL and TIASnd to avoid real-time constraints. This will have to wait until ALE 0.6.