### PR TITLE
Dev

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ option(USE_SDL "Use SDL" OFF)
 option(USE_RLGLUE "Use RL-Glue" OFF)
 option(BUILD_EXAMPLES "Build Example Agents" ON)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wunused -fPIC -O3 -fomit-frame-pointer")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wunused -Wno-multichar -fPIC -O3 -fomit-frame-pointer -D__STDC_CONSTANT_MACROS")
 add_definitions(-DHAVE_INTTYPES)
 set(LINK_LIBS z)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ option(USE_SDL "Use SDL" OFF)
 option(USE_RLGLUE "Use RL-Glue" OFF)
 option(BUILD_EXAMPLES "Build Example Agents" ON)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wunused -Wno-multichar -fPIC -O3 -fomit-frame-pointer -D__STDC_CONSTANT_MACROS")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wunused -fPIC -O3 -fomit-frame-pointer -D__STDC_CONSTANT_MACROS")
 add_definitions(-DHAVE_INTTYPES)
 set(LINK_LIBS z)
 

--- a/src/common/SoundExporter.cpp
+++ b/src/common/SoundExporter.cpp
@@ -8,7 +8,7 @@ namespace sound {
 // TODO(mgb): in reality this should be 31,400 Hz, but currently we are just short of this
 static const int SampleRate = 60 * SoundExporter::SamplesPerFrame; 
 // Save wav file every 30 seconds
-static const int WriteInterval = SampleRate * 30;
+static const unsigned int WriteInterval = SampleRate * 30;
 
 
 SoundExporter::SoundExporter(const std::string &filename, int channels):

--- a/src/common/SoundExporter.cpp
+++ b/src/common/SoundExporter.cpp
@@ -6,7 +6,7 @@ namespace sound {
 
 // Sample rate is 60Hz x SamplesPerFrame bytes
 // TODO(mgb): in reality this should be 31,400 Hz, but currently we are just short of this
-static const int SampleRate = 60 * SoundExporter::SamplesPerFrame; 
+static const unsigned int SampleRate = 60 * SoundExporter::SamplesPerFrame; 
 // Save wav file every 30 seconds
 static const unsigned int WriteInterval = SampleRate * 30;
 

--- a/src/controllers/fifo_controller.cpp
+++ b/src/controllers/fifo_controller.cpp
@@ -106,7 +106,6 @@ void FIFOController::handshake() {
   m_send_ram = atoi(token);
   token = strtok (NULL,",\n");
   // Used to be frame skip; now obsolete
-  atoi(token);
   token = strtok(NULL, ",\n");
   m_send_rl = atoi(token);
 }

--- a/src/external/TinyMT/tinymt32.c
+++ b/src/external/TinyMT/tinymt32.c
@@ -64,13 +64,14 @@ void tinymt32_init(tinymt32_t * random, uint32_t seed) {
     random->status[1] = random->mat1;
     random->status[2] = random->mat2;
     random->status[3] = random->tmat;
-    for (int i = 1; i < MIN_LOOP; i++) {
+    int i;
+    for (i = 1; i < MIN_LOOP; i++) {
 	random->status[i & 3] ^= i + UINT32_C(1812433253)
 	    * (random->status[(i - 1) & 3]
 	       ^ (random->status[(i - 1) & 3] >> 30));
     }
     period_certification(random);
-    for (int i = 0; i < PRE_LOOP; i++) {
+    for (i = 0; i < PRE_LOOP; i++) {
 	tinymt32_next_state(random);
     }
 }

--- a/src/external/TinyMT/tinymt32.c
+++ b/src/external/TinyMT/tinymt32.c
@@ -60,11 +60,11 @@ static void period_certification(tinymt32_t * random) {
  * @param seed a 32-bit unsigned integer used as a seed.
  */
 void tinymt32_init(tinymt32_t * random, uint32_t seed) {
+    int i;
     random->status[0] = seed;
     random->status[1] = random->mat1;
     random->status[2] = random->mat2;
     random->status[3] = random->tmat;
-    int i;
     for (i = 1; i < MIN_LOOP; i++) {
 	random->status[i & 3] ^= i + UINT32_C(1812433253)
 	    * (random->status[(i - 1) & 3]


### PR DESCRIPTION
When compiling ALE in a Linux machine I was getting the following error:

*src/external/TinyMT/tinymt32.h: In function ‘void tinymt32_next_state(tinymt32_t*)’:*
*src/external/TinyMT/tinymt32.h:75: error: ‘UINT32_C’ was not declared in this scope*

I fixed it adding the flag -D__STDC_CONSTANT_MACROS. Then, later, I got the following errors:

*src/external/TinyMT/tinymt32.c: In function ‘tinymt32_init’:*
*src/external/TinyMT/tinymt32.c:67: error: ‘for’ loop initial declarations are only allowed in C99 mode*
*src/external/TinyMT/tinymt32.c:67: note: use option -std=c99 or -std=gnu99 to compile your code*
*src/external/TinyMT/tinymt32.c:73: error: redefinition of ‘i’*
*src/external/TinyMT/tinymt32.c:67: note: previous definition of ‘i’ was here*
*src/external/TinyMT/tinymt32.c:73: error: ‘for’ loop initial declarations are only allowed in C99 mode*

I fixed them by just declaring *int i* outside the for function. Finally, I also fixed some warnings that I was getting:

*warning: multi-character character constant*
Fixed with -Wno-multichar

*src/controllers/fifo_controller.cpp: In member function ‘void FIFOController::handshake()’:*
*src/controllers/fifo_controller.cpp:109: warning: statement has no effect*
Fixed deleting atoi(token).

*src/common/SoundExporter.cpp: In member function ‘void ale::sound::SoundExporter::addSamples(ale::sound::SoundExporter::SampleType*, int)’:
src/common/SoundExporter.cpp:37: warning: comparison between signed and unsigned integer expressions*
Fixed changing its type to unsigned int.

The system/compiler specifications are below:

**uname -a**:
*Linux ip13 2.6.32-504.16.2.el6.x86_64 #1 SMP Wed Apr 22 06:48:29 UTC 2015 x86_64 x86_64 x86_64 GNU/Linux*

**g++ -v**:
*Target: x86_64-redhat-linux
Configured with: ../configure --prefix=/usr --mandir=/usr/share/man --infodir=/usr/share/info --with-bugurl=http://bugzilla.redhat.com/bugzilla --enable-bootstrap --enable-shared --enable-threads=posix --enable-checking=release --with-system-zlib --enable-__cxa_atexit --disable-libunwind-exceptions --enable-gnu-unique-object --enable-languages=c,c++,objc,obj-c++,java,fortran,ada --enable-java-awt=gtk --disable-dssi --with-java-home=/usr/lib/jvm/java-1.5.0-gcj-1.5.0.0/jre --enable-libgcj-multifile --enable-java-maintainer-mode --with-ecj-jar=/usr/share/java/eclipse-ecj.jar --disable-libjava-multilib --with-ppl --with-cloog --with-tune=generic --with-arch_32=i686 --build=x86_64-redhat-linux
Thread model: posix
gcc version 4.4.7 20120313 (Red Hat 4.4.7-11) (GCC) *