### PR TITLE
Fix installation of Python interface.

### DIFF
--- a/ale_python_interface/ale_python_interface.py
+++ b/ale_python_interface/ale_python_interface.py
@@ -8,8 +8,9 @@ import numpy as np
 from numpy.ctypeslib import as_ctypes
 import os
 
-ale_lib = cdll.LoadLibrary(os.path.join(os.path.dirname(__file__),
-                                        'libale_c.so'))
+lib_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                        'ale_c_wrapper.so')
+ale_lib = cdll.LoadLibrary(lib_path)
 
 ale_lib.ALE_new.argtypes = None
 ale_lib.ALE_new.restype = c_void_p

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,13 @@
 from distutils.core import setup, Extension
+import shutil
+
+shutil.copy('./libale.so', 'ale_python_interface/')
 
 module1 = Extension('ale_python_interface.ale_c_wrapper',
-                    libraries = ['ale_c'],
+                    libraries = ['ale'],
                     include_dirs = ['src'],
-                    library_dirs = ['ale_python_interface'],
+                    library_dirs = ['ale_python_interface/..'],
+                    runtime_library_dirs = ['$ORIGIN'],
                     extra_compile_args=['-D__STDC_CONSTANT_MACROS'],
                     sources=['ale_python_interface/ale_c_wrapper.cpp'])
 setup(name = 'ale_python_interface',
@@ -14,4 +18,5 @@ setup(name = 'ale_python_interface',
       ext_modules = [module1],
       packages=['ale_python_interface'],
       package_dir={'ale_python_interface': 'ale_python_interface'},
-      package_data={'ale_python_interface': ['libale_c.so']})
+      package_data={'ale_python_interface':
+                    ['libale_c_wrapper.so', 'libale.so']})


### PR DESCRIPTION
The instructions in the manual didn't work for me to install the Python wrapper.  This pull request makes some fixes that seem to get things working (at least under Linux).  I've modified the setup.py script to copy the libale.so into the Python package so that users won't need to set LD_LIBRARY_PATH.