### PR TITLE
Fix Python getScreenRGB to split color channels.

### DIFF
--- a/ale_python_interface/ale_c_wrapper.h
+++ b/ale_python_interface/ale_c_wrapper.h
@@ -51,12 +51,20 @@ extern "C" {
   int getRAMSize(ALEInterface *ale){return ale->getRAM().size();}
   int getScreenWidth(ALEInterface *ale){return ale->getScreen().width();}
   int getScreenHeight(ALEInterface *ale){return ale->getScreen().height();}
-  void getScreenRGB(ALEInterface *ale,int *screen_data){
+  void getScreenRGB(ALEInterface *ale, unsigned char *screen_data){
     int w = ale->getScreen().width();
     int h = ale->getScreen().height();
+    int index = 0;
+    int r, g, b;
     pixel_t *ale_screen_data = (pixel_t *)ale->getScreen().getArray();
     for(int i = 0;i < w*h;i++){
-      screen_data[i] = rgb_palette[ale_screen_data[i]];
+      r = (rgb_palette[ale_screen_data[i]] >> 16) & 0xFF;
+      g = (rgb_palette[ale_screen_data[i]] >>  8) & 0xFF;
+      b = (rgb_palette[ale_screen_data[i]] >>  0) & 0xFF;
+      screen_data[index++] = r;
+      screen_data[index++] = g;
+      screen_data[index++] = b;
+
     }
   }
   void saveState(ALEInterface *ale){ale->saveState();}

--- a/ale_python_interface/ale_python_interface.py
+++ b/ale_python_interface/ale_python_interface.py
@@ -138,7 +138,7 @@ class ALEInterface(object):
     def getScreen(self, screen_data=None):
         """This function fills screen_data with the RAW Pixel data
         screen_data MUST be a numpy array of uint8/int8. This could be initialized like so:
-        screen_data = np.array(w*h, dtype=np.uint8)
+        screen_data = np.empty(w*h, dtype=np.uint8)
         Notice,  it must be width*height in size also
         If it is None,  then this function will initialize it
         Note: This is the raw pixel values from the atari,  before any RGB palette transformation takes place
@@ -152,16 +152,15 @@ class ALEInterface(object):
 
     def getScreenRGB(self, screen_data=None):
         """This function fills screen_data with the data
-        screen_data MUST be a numpy array of uint/int. This can be initialized like so:
-        screen_data = np.array(w*h, dtype=np.intc)
-        Notice,  it must be width*height in size also
-        If it is None,  then this function will initialize it
+        screen_data MUST be a numpy array of uint8. This can be initialized like so:
+        screen_data = np.empty((height,width,3), dtype=np.uint8)
+        If it is None,  then this function will initialize it.
         """
         if(screen_data is None):
             width = ale_lib.getScreenWidth(self.obj)
             height = ale_lib.getScreenHeight(self.obj)
-            screen_data = np.zeros(width*height, dtype=np.intc)
-        ale_lib.getScreenRGB(self.obj, as_ctypes(screen_data))
+            screen_data = np.empty((height, width,3), dtype=np.uint8)
+        ale_lib.getScreenRGB(self.obj, as_ctypes(screen_data[:]))
         return screen_data
 
     def getRAMSize(self):


### PR DESCRIPTION
The existing version of getScreenRGB returns a length 33600 numpy array of 32-bit integers, where the three color channels are embedded as 8-bit fields inside the integer values.  This requires the user to know the bitwise layout of the color channels and write Python code to extract the individual color values. 

This pull request modifies the Python interface so that getScreenRGB returns a height x width x 3 numpy array of type uint8, where each entry represents a single color value in the range 0-255.  