### PR TITLE
Change ptrs fix segfault

### DIFF
--- a/src/ale_interface.cpp
+++ b/src/ale_interface.cpp
@@ -28,7 +28,7 @@
  *  The shared library interface.
  **************************************************************************** */
 #include "ale_interface.hpp"
-
+using namespace std;
 // Display ALE welcome message
 std::string ALEInterface::welcomeMessage() {
   std::ostringstream oss;
@@ -198,7 +198,8 @@ bool ALEInterface::game_over() {
 
 // The remaining number of lives.
 const int ALEInterface::lives() {
-    return romSettings->lives();
+  if (!romSettings.get()){printf("ROM not set\n");exit(1);}
+  return romSettings->lives();
 }
 
 // Applies an action to the game and returns the reward. It is the
@@ -221,12 +222,14 @@ reward_t ALEInterface::act(Action action) {
 // Returns the vector of legal actions. This should be called only
 // after the rom is loaded.
 ActionVect ALEInterface::getLegalActionSet() {
+  if (!romSettings.get()){printf("ROM not set\n");exit(1);}
   return romSettings->getAllActions();
 }
 
 // Returns the vector of the minimal set of actions needed to play
 // the game.
 ActionVect ALEInterface::getMinimalActionSet() {
+  if (!romSettings.get()){printf("ROM not set\n");exit(1);}
   return romSettings->getMinimalActionSet();
 }
 

--- a/src/ale_interface.cpp
+++ b/src/ale_interface.cpp
@@ -48,8 +48,8 @@ void ALEInterface::disableBufferedIO() {
   cout.sync_with_stdio();
 }
 
-void ALEInterface::createOSystem(std::auto_ptr<OSystem> &theOSystem,
-                          std::auto_ptr<Settings> &theSettings) {
+void ALEInterface::createOSystem(std::unique_ptr<OSystem> &theOSystem,
+                          std::unique_ptr<Settings> &theSettings) {
 #ifdef WIN32
   theOSystem.reset(new OSystemWin32());
   theSettings.reset(new SettingsWin32(theOSystem.get()));
@@ -64,7 +64,7 @@ void ALEInterface::createOSystem(std::auto_ptr<OSystem> &theOSystem,
 }
 
 void ALEInterface::loadSettings(const string& romfile,
-                                std::auto_ptr<OSystem> &theOSystem) {
+                                std::unique_ptr<OSystem> &theOSystem) {
   // Load the configuration from a config file (passed on the command
   //  line), if provided
   string configFile = theOSystem->settings().getString("config", false);

--- a/src/ale_interface.hpp
+++ b/src/ale_interface.hpp
@@ -126,20 +126,20 @@ public:
   ScreenExporter *createScreenExporter(const std::string &path) const;
 
  public:
-  std::auto_ptr<OSystem> theOSystem;
-  std::auto_ptr<Settings> theSettings;
-  std::auto_ptr<RomSettings> romSettings;
-  std::auto_ptr<StellaEnvironment> environment;
+  std::unique_ptr<OSystem> theOSystem;
+  std::unique_ptr<Settings> theSettings;
+  std::unique_ptr<RomSettings> romSettings;
+  std::unique_ptr<StellaEnvironment> environment;
   int max_num_frames; // Maximum number of frames for each episode
 
  public:
   // Display ALE welcome message
   static std::string welcomeMessage();
   static void disableBufferedIO();
-  static void createOSystem(std::auto_ptr<OSystem> &theOSystem,
-                            std::auto_ptr<Settings> &theSettings);
+  static void createOSystem(std::unique_ptr<OSystem> &theOSystem,
+                            std::unique_ptr<Settings> &theSettings);
   static void loadSettings(const string& romfile,
-                           std::auto_ptr<OSystem> &theOSystem);
+                           std::unique_ptr<OSystem> &theOSystem);
 };
 
 #endif

--- a/src/common/SoundSDL.hxx
+++ b/src/common/SoundSDL.hxx
@@ -289,7 +289,7 @@ class SoundSDL : public Sound
     // Keeps track of how many samples we still need to record
     int myNumRecordSamplesNeeded; 
 
-    std::auto_ptr<ale::sound::SoundExporter> mySoundExporter; 
+    std::unique_ptr<ale::sound::SoundExporter> mySoundExporter; 
 };
 
 #endif  // SOUND_SUPPORT

--- a/src/controllers/ale_controller.hpp
+++ b/src/controllers/ale_controller.hpp
@@ -40,7 +40,7 @@ class ALEController {
 
   protected:
     OSystem* m_osystem;
-    std::auto_ptr<RomSettings> m_settings;
+    std::unique_ptr<RomSettings> m_settings;
     StellaEnvironment m_environment;
 };
 

--- a/src/environment/stella_environment.hpp
+++ b/src/environment/stella_environment.hpp
@@ -106,7 +106,7 @@ class StellaEnvironment {
     int m_max_num_frames_per_episode; // Maxmimum number of frames per episode 
     size_t m_frame_skip; // How many frames to emulate per act()
     float m_repeat_action_probability; // Stochasticity of the environment
-    std::auto_ptr<ScreenExporter> m_screen_exporter; // Automatic screen recorder
+    std::unique_ptr<ScreenExporter> m_screen_exporter; // Automatic screen recorder
     Random m_rand_gen;
 
     // The last actions taken by our players

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,8 +38,8 @@
 #include "common/Constants.h"
 #include "ale_interface.hpp"
 
-static std::auto_ptr<OSystem> theOSystem(NULL);
-static std::auto_ptr<Settings> theSettings(NULL);
+static std::unique_ptr<OSystem> theOSystem(NULL);
+static std::unique_ptr<Settings> theSettings(NULL);
 
 static ALEController* createController(OSystem* osystem, std::string type) {
   if(type.empty()){
@@ -79,7 +79,7 @@ int main(int argc, char* argv[]) {
 
   // Create the game controller
   std::string controller_type = theOSystem->settings().getString("game_controller");
-  std::auto_ptr<ALEController> controller(createController(theOSystem.get(), controller_type));
+  std::unique_ptr<ALEController> controller(createController(theOSystem.get(), controller_type));
 
   controller->run();
 


### PR DESCRIPTION
This does the following 2 things. 

1. Replace auto_ptr with unique_ptr.
I think it's a good idea to do this now because:
First: auto_ptr has been deprecated, and will actually be deleted in the future, according to Herb Sutter: 
http://herbsutter.com/2014/11/24/updates-to-my-trip-report/
Second: right now it's still a drop-in replacement. unique_ptr has move-only semantics, but you're not doing any copying of auto_ptrs right now. In the future, if you try to do copying of ptrs, the compiler will stop you. If you then still want to do copying, you can switch to shared_ptr. 

2. Instead of segfaulting if someone tries to e.g. get the list of legal actions before a ROM has been loaded, just exit with a message. I think that this is a good change because 
First: segfaulting is always bad
Second: this change would have saved me 5-10 minutes of debugging time, so I expect a similar thing might be true for other people.
