### PR TITLE
clone/restoreSystemState

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@
 July 7th, 2015. ALE 0.5dev.
   * Refactored Python getScreenRGB to return unpacked RGB values (@spragunr).
   * Sets the default value of the color_averaging flag to be true. It was true by default in previous versions but was changed in 0.5.0. Reverted for backward compatibility.
+  * Added RNG serialization capability.
   * Bug fixes from ALE 0.5.0.
 
 June 22nd, 2015. ALE 0.5.0.

--- a/ale_python_interface/ale_c_wrapper.h
+++ b/ale_python_interface/ale_c_wrapper.h
@@ -61,6 +61,11 @@ extern "C" {
   }
   void saveState(ALEInterface *ale){ale->saveState();}
   void loadState(ALEInterface *ale){ale->loadState();}
+  ALEState* cloneState(ALEInterface *ale){return new ALEState(ale->cloneState());}
+  void restoreState(ALEInterface *ale, ALEState* state){ale->restoreState(*state);}
+  ALEState* cloneSystemState(ALEInterface *ale){return new ALEState(ale->cloneSystemState());}
+  void restoreSystemState(ALEInterface *ale, ALEState* state){ale->restoreSystemState(*state);}
+  void deleteState(ALEState* state){delete state;}
   void saveScreenPNG(ALEInterface *ale,const char *filename){ale->saveScreenPNG(filename);}
 }
 

--- a/ale_python_interface/ale_python_interface.py
+++ b/ale_python_interface/ale_python_interface.py
@@ -69,6 +69,16 @@ ale_lib.saveState.argtypes = [c_void_p]
 ale_lib.saveState.restype = None
 ale_lib.loadState.argtypes = [c_void_p]
 ale_lib.loadState.restype = None
+ale_lib.cloneState.argtypes = [c_void_p]
+ale_lib.cloneState.restype = c_void_p
+ale_lib.restoreState.argtypes = [c_void_p, c_void_p]
+ale_lib.restoreState.restype = None
+ale_lib.cloneSystemState.argtypes = [c_void_p]
+ale_lib.cloneSystemState.restype = c_void_p
+ale_lib.restoreSystemState.argtypes = [c_void_p, c_void_p]
+ale_lib.restoreSystemState.restype = None
+ale_lib.deleteState.argtypes = [c_void_p]
+ale_lib.deleteState.restype = None
 ale_lib.saveScreenPNG.argtypes = [c_void_p, c_char_p]
 ale_lib.saveScreenPNG.restype = None
 
@@ -134,7 +144,6 @@ class ALEInterface(object):
         height = ale_lib.getScreenHeight(self.obj)
         return (width, height)
 
-
     def getScreen(self, screen_data=None):
         """This function fills screen_data with the RAW Pixel data
         screen_data MUST be a numpy array of uint8/int8. This could be initialized like so:
@@ -181,13 +190,46 @@ class ALEInterface(object):
         return ram
 
     def saveScreenPNG(self, filename):
+        """Save the current screen as a png file"""
         return ale_lib.saveScreenPNG(self.obj, filename)
 
     def saveState(self):
+        """Saves the state of the system"""
         return ale_lib.saveState(self.obj)
 
     def loadState(self):
+        """Loads the state of the system"""
         return ale_lib.loadState(self.obj)
+
+    def cloneState(self):
+        """This makes a copy of the environment state. This copy does *not*
+        include pseudorandomness, making it suitable for planning
+        purposes. By contrast, see cloneSystemState.
+        """
+        return ale_lib.cloneState(self.obj)
+
+    def restoreState(self, state):
+        """Reverse operation of cloneState(). This does not restore
+        pseudorandomness, so that repeated calls to restoreState() in
+        the stochastic controls setting will not lead to the same
+        outcomes.  By contrast, see restoreSystemState.
+        """
+        ale_lib.restoreState(self.obj, state)
+
+    def cloneSystemState(self):
+        """This makes a copy of the system & environment state, suitable for
+        serialization. This includes pseudorandomness and so is *not*
+        suitable for planning purposes.
+        """
+        return ale_lib.cloneSystemState(self.obj)
+
+    def restoreSystemState(self, state):
+        """Reverse operation of cloneSystemState."""
+        ale_lib.restoreSystemState(self.obj, state)
+
+    def deleteState(self, state):
+        """ Deallocates the ALEState """
+        ale_lib.deleteState(state)
 
     def __del__(self):
         ale_lib.ALE_del(self.obj)

--- a/src/ale_interface.cpp
+++ b/src/ale_interface.cpp
@@ -262,6 +262,14 @@ void ALEInterface::restoreState(const ALEState& state) {
   return environment->restoreState(state);
 }
 
+ALEState ALEInterface::cloneSystemState() {
+  return environment->cloneSystemState();
+}
+
+void ALEInterface::restoreSystemState(const ALEState& state) {
+  return environment->restoreSystemState(state);
+}
+
 void ALEInterface::saveScreenPNG(const string& filename) {
   
   ScreenExporter exporter(theOSystem->colourPalette());

--- a/src/ale_interface.hpp
+++ b/src/ale_interface.hpp
@@ -113,9 +113,21 @@ public:
   // Loads the state of the system
   void loadState();
 
+  // This makes a copy of the environment state. This copy does *not* include pseudorandomness,
+  // making it suitable for planning purposes. By contrast, see cloneSystemState.
   ALEState cloneState();
 
+  // Reverse operation of cloneState(). This does not restore pseudorandomness, so that repeated
+  // calls to restoreState() in the stochastic controls setting will not lead to the same outcomes.
+  // By contrast, see restoreSystemState.
   void restoreState(const ALEState& state);
+
+  // This makes a copy of the system & environment state, suitable for serialization. This includes
+  // pseudorandomness and so is *not* suitable for planning purposes.
+  ALEState cloneSystemState();
+
+  // Reverse operation of cloneSystemState.
+  void restoreSystemState(const ALEState& state);
 
   // Save the current screen as a png file
   void saveScreenPNG(const string& filename);

--- a/src/environment/ale_state.hpp
+++ b/src/environment/ale_state.hpp
@@ -68,12 +68,14 @@ class ALEState {
     friend class StellaEnvironment;
 
     // The two methods below are meant to be used by StellaEnvironment.
-    /** Restores the environment to a previously saved state. */ 
-    void load(OSystem* osystem, RomSettings* settings, std::string md5, const ALEState &rhs);
+    /** Restores the environment to a previously saved state. If load_system == true, we also
+        restore system-specific information (such as the RNG state). */ 
+    void load(OSystem* osystem, RomSettings* settings, std::string md5, const ALEState &rhs,
+              bool load_system);
 
     /** Returns a "copy" of the current state, including the information necessary to restore
-      *  the emulator. */
-    ALEState save(OSystem* osystem, RomSettings* settings, std::string md5);
+      *  the emulator. If save_system == true, this includes the RNG state. */
+    ALEState save(OSystem* osystem, RomSettings* settings, std::string md5, bool save_system);
 
     /** Reset key presses */
     void resetKeys(Event* event_obj);

--- a/src/environment/stella_environment.cpp
+++ b/src/environment/stella_environment.cpp
@@ -103,16 +103,21 @@ void StellaEnvironment::load() {
   m_saved_states.pop();
 }
 
-/** Returns a copy of the current emulator state. */
 ALEState StellaEnvironment::cloneState() {
-  return m_state.save(m_osystem, m_settings, m_cartridge_md5);
+  return m_state.save(m_osystem, m_settings, m_cartridge_md5, false);
 }
 
-/** Restores a previously saved copy of the state. */
 void StellaEnvironment::restoreState(const ALEState& target_state) {
-  m_state.load(m_osystem, m_settings, m_cartridge_md5, target_state);
+  m_state.load(m_osystem, m_settings, m_cartridge_md5, target_state, false);
 }
 
+ALEState StellaEnvironment::cloneSystemState() {
+  return m_state.save(m_osystem, m_settings, m_cartridge_md5, true);
+}
+
+void StellaEnvironment::restoreSystemState(const ALEState& target_state) {
+  m_state.load(m_osystem, m_settings, m_cartridge_md5, target_state, true);
+}
 
 void StellaEnvironment::noopIllegalActions(Action & player_a_action, Action & player_b_action) {
   if (player_a_action < (Action)PLAYER_B_NOOP && 

--- a/src/environment/stella_environment.hpp
+++ b/src/environment/stella_environment.hpp
@@ -43,10 +43,17 @@ class StellaEnvironment {
     void save();
     void load();
 
-    /** Returns a copy of the current emulator state. */
+    /** Returns a copy of the current emulator state. Note that this doesn't include
+        pseudorandomness, so that clone/restoreState are suitable for planning. */
     ALEState cloneState();
     /** Restores a previously saved copy of the state. */
     void restoreState(const ALEState&);
+
+    /** Returns a copy of the current emulator state. This includes RNG state information, and
+        more generally should lead to exactly reproducibility. */
+    ALEState cloneSystemState();
+    /** Restores a previously saved copy of the state, including RNG state information. */
+    void restoreSystemState(const ALEState&);
 
     /** Applies the given actions (e.g. updating paddle positions when the paddle is used)
       *  and performs one simulation step in Stella. Returns the resultant reward. When 


### PR DESCRIPTION
Adds two new methods, clone/restoreSystemState, for explicitly saving the RNG state along with the environment state. Fixes #70