### PR TITLE
error: ‘runtime_error’ is not a member of ‘std’

### DIFF
--- a/src/ale_interface.hpp
+++ b/src/ale_interface.hpp
@@ -30,6 +30,7 @@
 #ifndef __ALE_INTERFACE_HPP__
 #define __ALE_INTERFACE_HPP__
 
+#include <stdexcept>
 #include "emucore/FSNode.hxx"
 #include "emucore/OSystem.hxx"
 #include "os_dependent/SettingsWin32.hxx"


### PR DESCRIPTION
A header was missing and I could not build anymore.
