### PR TITLE
Added clone/restore state methods to ale_python_interface.

### DIFF
--- a/ale_python_interface/ale_c_wrapper.h
+++ b/ale_python_interface/ale_c_wrapper.h
@@ -61,6 +61,11 @@ extern "C" {
   }
   void saveState(ALEInterface *ale){ale->saveState();}
   void loadState(ALEInterface *ale){ale->loadState();}
+  ALEState* cloneState(ALEInterface *ale){return new ALEState(ale->cloneState());}
+  void restoreState(ALEInterface *ale, ALEState* state){ale->restoreState(*state);}
+  ALEState* cloneSystemState(ALEInterface *ale){return new ALEState(ale->cloneSystemState());}
+  void restoreSystemState(ALEInterface *ale, ALEState* state){ale->restoreSystemState(*state);}
+  void deleteState(ALEState* state){delete state;}
   void saveScreenPNG(ALEInterface *ale,const char *filename){ale->saveScreenPNG(filename);}
 }
 

--- a/ale_python_interface/ale_python_interface.py
+++ b/ale_python_interface/ale_python_interface.py
@@ -69,6 +69,16 @@ ale_lib.saveState.argtypes = [c_void_p]
 ale_lib.saveState.restype = None
 ale_lib.loadState.argtypes = [c_void_p]
 ale_lib.loadState.restype = None
+ale_lib.cloneState.argtypes = [c_void_p]
+ale_lib.cloneState.restype = c_void_p
+ale_lib.restoreState.argtypes = [c_void_p, c_void_p]
+ale_lib.restoreState.restype = None
+ale_lib.cloneSystemState.argtypes = [c_void_p]
+ale_lib.cloneSystemState.restype = c_void_p
+ale_lib.restoreSystemState.argtypes = [c_void_p, c_void_p]
+ale_lib.restoreSystemState.restype = None
+ale_lib.deleteState.argtypes = [c_void_p]
+ale_lib.deleteState.restype = None
 ale_lib.saveScreenPNG.argtypes = [c_void_p, c_char_p]
 ale_lib.saveScreenPNG.restype = None
 
@@ -134,7 +144,6 @@ class ALEInterface(object):
         height = ale_lib.getScreenHeight(self.obj)
         return (width, height)
 
-
     def getScreen(self, screen_data=None):
         """This function fills screen_data with the RAW Pixel data
         screen_data MUST be a numpy array of uint8/int8. This could be initialized like so:
@@ -181,13 +190,46 @@ class ALEInterface(object):
         return ram
 
     def saveScreenPNG(self, filename):
+        """Save the current screen as a png file"""
         return ale_lib.saveScreenPNG(self.obj, filename)
 
     def saveState(self):
+        """Saves the state of the system"""
         return ale_lib.saveState(self.obj)
 
     def loadState(self):
+        """Loads the state of the system"""
         return ale_lib.loadState(self.obj)
+
+    def cloneState(self):
+        """This makes a copy of the environment state. This copy does *not*
+        include pseudorandomness, making it suitable for planning
+        purposes. By contrast, see cloneSystemState.
+        """
+        return ale_lib.cloneState(self.obj)
+
+    def restoreState(self, state):
+        """Reverse operation of cloneState(). This does not restore
+        pseudorandomness, so that repeated calls to restoreState() in
+        the stochastic controls setting will not lead to the same
+        outcomes.  By contrast, see restoreSystemState.
+        """
+        ale_lib.restoreState(self.obj, state)
+
+    def cloneSystemState(self):
+        """This makes a copy of the system & environment state, suitable for
+        serialization. This includes pseudorandomness and so is *not*
+        suitable for planning purposes.
+        """
+        return ale_lib.cloneState(self.obj)
+
+    def restoreSystemState(self, state):
+        """Reverse operation of cloneSystemState."""
+        ale_lib.restoreState(self.obj, state)
+
+    def deleteState(self, state):
+        """ Deallocates the ALEState """
+        ale_lib.deleteState(state)
 
     def __del__(self):
         ale_lib.ALE_del(self.obj)

--- a/ale_python_interface/ale_python_interface.py
+++ b/ale_python_interface/ale_python_interface.py
@@ -221,11 +221,11 @@ class ALEInterface(object):
         serialization. This includes pseudorandomness and so is *not*
         suitable for planning purposes.
         """
-        return ale_lib.cloneState(self.obj)
+        return ale_lib.cloneSystemState(self.obj)
 
     def restoreSystemState(self, state):
         """Reverse operation of cloneSystemState."""
-        ale_lib.restoreState(self.obj, state)
+        ale_lib.restoreSystemState(self.obj, state)
 
     def deleteState(self, state):
         """ Deallocates the ALEState """


### PR DESCRIPTION
Tested that clone/restore works correctly on Ubuntu. Not sure how to verify the integrity of RNG serialization, but if it's working in the ALE_inteface, it'll be working in the python as well.