### PR TITLE
Adding a version number to the python interface

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ module1 = Extension('ale_python_interface.ale_c_wrapper',
                     extra_compile_args=['-D__STDC_CONSTANT_MACROS'],
                     sources=['ale_python_interface/ale_c_wrapper.cpp'])
 setup(name = 'ale_python_interface',
+      version='0.0.1',
       description = 'Arcade Learning Environment Python Interface',
       url='https://github.com/bbitmaster/ale_python_interface',
       author='Ben Goodrich',


### PR DESCRIPTION
The python interface doesn't have a version number. The current default value is 0.0.0
pip doesn't upgrade and it has to be forced through --upgrade. In addition, it is not clear which version is being used.
I am not sure how you would like to treat version numbers so I am temporarily adding version=0.0.1
