### PR TITLE
MinimalActions - Breakout / Pong

### DIFF
--- a/src/games/supported/Breakout.cpp
+++ b/src/games/supported/Breakout.cpp
@@ -84,8 +84,6 @@ bool BreakoutSettings::isMinimal(const Action &a) const {
         case PLAYER_A_FIRE:
         case PLAYER_A_RIGHT:
         case PLAYER_A_LEFT:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_LEFTFIRE:
             return true;
         default:
             return false;

--- a/src/games/supported/Pong.cpp
+++ b/src/games/supported/Pong.cpp
@@ -64,11 +64,8 @@ bool PongSettings::isMinimal(const Action &a) const {
 
     switch (a) {
         case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
         case PLAYER_A_RIGHT:
         case PLAYER_A_LEFT:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_LEFTFIRE:
             return true;
         default:
             return false;


### PR DESCRIPTION
Hi,
I've been using Nathan Sprague's implementation (deep_q_rl) and I have struggled to achieve results that are consistent with DQN (Deepmind).

I recently noticed that ALE is different from Xitari in several games. In particular, Breakout and Pong declare a different set of minimal actions.

In this PR, I am removing some spurious actions only in Breakout/Pong in order to match Xitari.

I've seen some differences in other games. Maybe you can comment on that. Should we fix those too? Are Atlantis/Frostbite better?

|Game|ALE|Xitari|
|---|---|---|
|Asteroids| | Score wrapping|
|Atlantis|Seems newer/better||
|Breakout|6 actions|4 actions|
|Frostbite|Seems newer/better||
|Kangaroo||Score is taken from different memory regions|
|Pong|6 actions|3 actions|
|Space Invaders|Score wrapping||
|Wizard of Wor||Different bytes for score/lives|
|Zaxxon||Different mask for lives|

I wonder how these differences affect publications that have been using ALE and benchmarking against DQN/Xitari.
