### PR TITLE
Added ALEState serialization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ if(APPLE)
   set(CMAKE_SHARED_LIBRARY_SUFFIX ".so")
 endif()
 
-if(WINDOWS)
+if(WINDOWS OR MINGW)
   list(APPEND SOURCES ${SOURCE_DIR}/os_dependent/SettingsWin32.cxx ${SOURCE_DIR}/os_dependent/OSystemWin32.cxx ${SOURCE_DIR}/os_dependent/FSNodeWin32.cxx)
 else()
   list(APPEND SOURCES ${SOURCE_DIR}/os_dependent/SettingsUNIX.cxx ${SOURCE_DIR}/os_dependent/OSystemUNIX.cxx ${SOURCE_DIR}/os_dependent/FSNodePOSIX.cxx)

--- a/ale_python_interface/ale_c_wrapper.cpp
+++ b/ale_python_interface/ale_c_wrapper.cpp
@@ -11,7 +11,7 @@ int encodeStateLen(ALEState *state) {
 	return state->encode().size();
 }
 
-ALEState *decodeState(const char *serialized, size_t len) {
+ALEState *decodeState(const char *serialized, int len) {
 	std::vector<char> buf;
 	buf.resize(len);
 

--- a/ale_python_interface/ale_c_wrapper.cpp
+++ b/ale_python_interface/ale_c_wrapper.cpp
@@ -2,12 +2,15 @@
 #include<string>
 #include<cstring>
 
-const char *encodeState(ALEState *state) {
+const char *encodeState(ALEState *state, char *buf) {
 	std::string s = state->encode();
-	char *buf = new char[s.length() + 1];
 	std::strcpy(buf,s.c_str());
 
 	return buf;
+}
+
+int encodeStateLen(ALEState *state) {
+	return state->encode().length();
 }
 
 ALEState *decodeState(const char *serialized) {

--- a/ale_python_interface/ale_c_wrapper.cpp
+++ b/ale_python_interface/ale_c_wrapper.cpp
@@ -1,14 +1,11 @@
-//all code is currently in the .h file
 #include "ale_c_wrapper.h"
 #include<string>
 #include<cstring>
 
 const char *encodeState(ALEState *state) {
 	std::string s = state->encode();
-	int len = s.length();
-
-	char *buf = (char *)malloc(len+1);
-	strcpy(buf,s.c_str());
+	char *buf = new char[s.length() + 1];
+	std::strcpy(buf,s.c_str());
 
 	return buf;
 }

--- a/ale_python_interface/ale_c_wrapper.cpp
+++ b/ale_python_interface/ale_c_wrapper.cpp
@@ -1,3 +1,19 @@
 //all code is currently in the .h file
 #include "ale_c_wrapper.h"
+#include<string>
+#include<cstring>
 
+const char *encodeState(ALEState *state) {
+	std::string s = state->encode();
+	int len = s.length();
+
+	char *buf = (char *)malloc(len+1);
+	strcpy(buf,s.c_str());
+
+	return buf;
+}
+
+ALEState *decodeState(const char *serialized) {
+	std::string s(serialized);
+	return new ALEState(s);
+}

--- a/ale_python_interface/ale_c_wrapper.cpp
+++ b/ale_python_interface/ale_c_wrapper.cpp
@@ -1,19 +1,20 @@
 #include "ale_c_wrapper.h"
-#include<string>
+#include<vector>
 #include<cstring>
 
-const char *encodeState(ALEState *state, char *buf) {
-	std::string s = state->encode();
-	std::strcpy(buf,s.c_str());
-
-	return buf;
+void encodeState(ALEState *state, char *buf) {
+	std::vector<char> vec = state->encode();
+	memcpy(buf,vec.data(),vec.size());
 }
 
 int encodeStateLen(ALEState *state) {
-	return state->encode().length();
+	return state->encode().size();
 }
 
-ALEState *decodeState(const char *serialized) {
-	std::string s(serialized);
-	return new ALEState(s);
+ALEState *decodeState(const char *serialized, size_t len) {
+	std::vector<char> buf;
+	buf.resize(len);
+
+	memcpy(buf.data(), serialized, len);
+	return new ALEState(buf);
 }

--- a/ale_python_interface/ale_c_wrapper.h
+++ b/ale_python_interface/ale_c_wrapper.h
@@ -67,6 +67,8 @@ extern "C" {
   void restoreSystemState(ALEInterface *ale, ALEState* state){ale->restoreSystemState(*state);}
   void deleteState(ALEState* state){delete state;}
   void saveScreenPNG(ALEInterface *ale,const char *filename){ale->saveScreenPNG(filename);}
+  const char *encodeState(ALEState *state);
+  ALEState *decodeState(const char* serialized);
 }
 
 #endif

--- a/ale_python_interface/ale_c_wrapper.h
+++ b/ale_python_interface/ale_c_wrapper.h
@@ -67,7 +67,8 @@ extern "C" {
   void restoreSystemState(ALEInterface *ale, ALEState* state){ale->restoreSystemState(*state);}
   void deleteState(ALEState* state){delete state;}
   void saveScreenPNG(ALEInterface *ale,const char *filename){ale->saveScreenPNG(filename);}
-  const char *encodeState(ALEState *state);
+  const char *encodeState(ALEState *state, char *buf);
+  int encodeStateLen(ALEState *state);
   ALEState *decodeState(const char* serialized);
 }
 

--- a/ale_python_interface/ale_c_wrapper.h
+++ b/ale_python_interface/ale_c_wrapper.h
@@ -67,9 +67,12 @@ extern "C" {
   void restoreSystemState(ALEInterface *ale, ALEState* state){ale->restoreSystemState(*state);}
   void deleteState(ALEState* state){delete state;}
   void saveScreenPNG(ALEInterface *ale,const char *filename){ale->saveScreenPNG(filename);}
-  const char *encodeState(ALEState *state, char *buf);
+  // This returns a raw byte stream encoding the state. This is NOT to be interpreted as a C String
+  // and may in fact contain several 0 bytes (null terminators).
+  void encodeState(ALEState *state, char *buf);
+  // Returns the size of the buffer (not the len of the C-String containing it)
   int encodeStateLen(ALEState *state);
-  ALEState *decodeState(const char* serialized);
+  ALEState *decodeState(const char* serialized, size_t len);
 }
 
 #endif

--- a/ale_python_interface/ale_c_wrapper.h
+++ b/ale_python_interface/ale_c_wrapper.h
@@ -72,7 +72,7 @@ extern "C" {
   void encodeState(ALEState *state, char *buf);
   // Returns the size of the buffer (not the len of the C-String containing it)
   int encodeStateLen(ALEState *state);
-  ALEState *decodeState(const char* serialized, size_t len);
+  ALEState *decodeState(const char* serialized, int len);
 }
 
 #endif

--- a/src/ale_interface.cpp
+++ b/src/ale_interface.cpp
@@ -28,6 +28,7 @@
  *  The shared library interface.
  **************************************************************************** */
 #include "ale_interface.hpp"
+#include <ctime>
 
 // Display ALE welcome message
 std::string ALEInterface::welcomeMessage() {
@@ -50,7 +51,7 @@ void ALEInterface::disableBufferedIO() {
 
 void ALEInterface::createOSystem(std::auto_ptr<OSystem> &theOSystem,
                           std::auto_ptr<Settings> &theSettings) {
-#ifdef WIN32
+#if (defined(WIN32) || defined(__MINGW32__))
   theOSystem.reset(new OSystemWin32());
   theSettings.reset(new SettingsWin32(theOSystem.get()));
 #else

--- a/src/common/misc_tools.h
+++ b/src/common/misc_tools.h
@@ -17,7 +17,7 @@
 
 #include "Constants.h"
 
-#ifndef WIN32
++#if (defined(WIN32) || defined(__MINGW32__))
 #include <sys/time.h>
 #endif
 
@@ -54,20 +54,21 @@ inline void bound(int& x, int lower_bound, int upper_bound) {
 /* *****************************************************************************
     Return time in milliseconds. 
  **************************************************************************** */
-#ifndef WIN32
-
-inline long timeMillis() {
-
-    struct timeval ts; 
-  gettimeofday(&ts, NULL);
-  return ts.tv_sec * 1000 + ts.tv_usec/1000;
-}
-
-#else
+#if (defined(WIN32) || defined(__MINGW32__))
 
 #include <windows.h>
 inline long timeMillis() {
     return GetTickCount();
+}
+
+
+#else
+
+inline long timeMillis() {
+
+struct timeval ts; 
+  gettimeofday(&ts, NULL);
+  return ts.tv_sec * 1000 + ts.tv_usec/1000;
 }
 
 #endif

--- a/src/emucore/Console.cxx
+++ b/src/emucore/Console.cxx
@@ -20,6 +20,7 @@
 #include <iostream>
 #include <sstream>
 #include <fstream>
+#include <ctime>
 
 #include "AtariVox.hxx"
 #include "Booster.hxx"

--- a/src/environment/ale_state.cpp
+++ b/src/environment/ale_state.cpp
@@ -32,6 +32,27 @@ ALEState::ALEState(const ALEState &rhs, std::string serialized):
   m_serialized_state(serialized) {
 }
 
+ALEState::ALEState(std::string serialized) {
+  std::stringstream ss(serialized);
+  std::string item;
+
+  std::getline(ss, item);
+  // Using atoi because unfortunately stoi doesn't work
+  // on mingw
+  this->m_left_paddle = atoi(item.c_str());
+
+  std::getline(ss,item);
+  this->m_right_paddle = atoi(item.c_str());
+
+  std::getline(ss,item);
+  this->m_frame_number = atoi(item.c_str());
+
+  std::getline(ss,item);
+  this->m_episode_frame_number = atoi(item.c_str());
+
+  std::getline(ss,this->m_serialized_state);
+}
+
 /** Restores ALE to the given previously saved state. */ 
 void ALEState::load(OSystem* osystem, RomSettings* settings, std::string md5, const ALEState &rhs,
     bool load_system) {
@@ -82,6 +103,15 @@ void ALEState::incrementFrame(int steps /* = 1 */) {
 
 void ALEState::resetEpisodeFrameNumber() {
     m_episode_frame_number = 0;
+}
+
+std::string ALEState::encode() {
+  std::stringstream out;
+  out << this->m_left_paddle << '\n' << this->m_right_paddle << '\n' 
+      << this->m_frame_number << '\n' << this->m_episode_frame_number << '\n' 
+      << this->m_serialized_state;
+
+  return out.str();
 }
 
 

--- a/src/environment/ale_state.cpp
+++ b/src/environment/ale_state.cpp
@@ -106,7 +106,7 @@ void ALEState::resetEpisodeFrameNumber() {
 
 template<typename T>
 void encodeAndIncrement(char **buf, T field) {
-  memcpy(buf, &field, sizeof(T));
+  memcpy(*buf, &field, sizeof(T));
   (*buf) += sizeof(T);
 }
 

--- a/src/environment/ale_state.hpp
+++ b/src/environment/ale_state.hpp
@@ -21,6 +21,7 @@
 #include "../emucore/OSystem.hxx"
 #include "../emucore/Event.hxx"
 #include <string>
+#include <vector>
 #include "../games/RomSettings.hpp"
 
 #define PADDLE_DELTA 23000
@@ -37,7 +38,7 @@ class ALEState {
     // Makes a copy of this state, also storing emulator information provided as a string
     ALEState(const ALEState &rhs, std::string serialized);
     // Deserializes an ALE state from a raw string built via encode.
-    ALEState(std::string serialized);
+    ALEState(std::vector<char> serialized);
 
     /** Resets the system to its start state. numResetSteps 'RESET' actions are taken after the
       *  start. */
@@ -64,8 +65,8 @@ class ALEState {
     //Get the number of frames executed this episode.
     const int getEpisodeFrameNumber() const { return m_episode_frame_number; }
 
-    // Serializes everything, including paddle info, to a string.
-    std::string encode();
+    // Serializes everything, including paddle info, to a byte vector.
+    std::vector<char> encode();
 
 
   protected:

--- a/src/environment/ale_state.hpp
+++ b/src/environment/ale_state.hpp
@@ -36,6 +36,8 @@ class ALEState {
     ALEState();
     // Makes a copy of this state, also storing emulator information provided as a string
     ALEState(const ALEState &rhs, std::string serialized);
+    // Deserializes an ALE state from a raw string built via encode.
+    ALEState(std::string serialized);
 
     /** Resets the system to its start state. numResetSteps 'RESET' actions are taken after the
       *  start. */
@@ -61,6 +63,9 @@ class ALEState {
 
     //Get the number of frames executed this episode.
     const int getEpisodeFrameNumber() const { return m_episode_frame_number; }
+
+    // Serializes everything, including paddle info, to a string.
+    std::string encode();
 
 
   protected:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,7 +24,7 @@
 
 #include "common/Defaults.hpp"
 
-#ifdef WIN32
+#if (defined(WIN32) || defined(__MINGW32__))
 #   include "os_dependent/SettingsWin32.hxx"
 #   include "os_dependent/OSystemWin32.hxx"
 #else


### PR DESCRIPTION
This adds the ability to serialize an `ALEState` to a `vector<char>`, and exposes this as a `char *` in the C interface (with explicit documentation that this is NOT a C-style string). This should address #83 by allowing any user accessing the ALE via the C wrapper or linking directly with the C++ library to grab the raw bits and save them however they please by first performing a `cloneState` or `cloneSystemState`.

The first commit (105623a) is a clone of #97 applied to the dev branch, which I can remove if that commit can somehow be cherry picked into the dev branch. Without it I can't compile this branch on Windows which makes testing this code difficult. This should probably be done before it's merged to avoid merge conflicts when `dev` gets merged with `master`.

PTAL