### PR TITLE
Add support for the game Turmoil.

### DIFF
--- a/src/games/Roms.cpp
+++ b/src/games/Roms.cpp
@@ -69,6 +69,7 @@
 #include "supported/Tennis.hpp"
 #include "supported/Tetris.hpp"
 #include "supported/TimePilot.hpp"
+#include "supported/Turmoil.hpp"
 #include "supported/Tutankham.hpp"
 #include "supported/UpNDown.hpp"
 #include "supported/Venture.hpp"
@@ -135,6 +136,7 @@ static const RomSettings *roms[]  = {
     new TennisSettings(),
     new TetrisSettings(),
     new TimePilotSettings(),
+    new TurmoilSettings(),
     new TutankhamSettings(),
     new UpNDownSettings(),
     new VentureSettings(),

--- a/src/games/module.mk
+++ b/src/games/module.mk
@@ -59,6 +59,7 @@ MODULE_OBJS := \
 	src/games/supported/Tennis.o \
 	src/games/supported/Tetris.o \
 	src/games/supported/TimePilot.o \
+	src/games/supported/Turmoil.o \
 	src/games/supported/Tutankham.o \
 	src/games/supported/UpNDown.o \
 	src/games/supported/Venture.o \

--- a/src/games/supported/Turmoil.cpp
+++ b/src/games/supported/Turmoil.cpp
@@ -1,19 +1,4 @@
 /* *****************************************************************************
- * The lines 61, 63, 116, 124 and 132 are based on Xitari's code, from Google Inc.
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License version 2
- * as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
- * *****************************************************************************
  * A.L.E (Arcade Learning Environment)
  * Copyright (c) 2009-2013 by Yavar Naddaf, Joel Veness, Marc G. Bellemare and 
  *   the Reinforcement Learning and Artificial Intelligence Laboratory

--- a/src/games/supported/Turmoil.cpp
+++ b/src/games/supported/Turmoil.cpp
@@ -1,0 +1,141 @@
+/* *****************************************************************************
+ * The lines 61, 63, 116, 124 and 132 are based on Xitari's code, from Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 2
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * *****************************************************************************
+ * A.L.E (Arcade Learning Environment)
+ * Copyright (c) 2009-2013 by Yavar Naddaf, Joel Veness, Marc G. Bellemare and 
+ *   the Reinforcement Learning and Artificial Intelligence Laboratory
+ * Released under the GNU General Public License; see License.txt for details. 
+ *
+ * Based on: Stella  --  "An Atari 2600 VCS Emulator"
+ * Copyright (c) 1995-2007 by Bradford W. Mott and the Stella team
+ *
+ * *****************************************************************************
+ */
+#include "Turmoil.hpp"
+
+#include "../RomUtils.hpp"
+
+
+TurmoilSettings::TurmoilSettings() {
+
+    reset();
+}
+
+
+/* create a new instance of the rom */
+RomSettings* TurmoilSettings::clone() const { 
+    
+    RomSettings* rval = new TurmoilSettings();
+    *rval = *this;
+    return rval;
+}
+
+
+/* process the latest information from ALE */
+void TurmoilSettings::step(const System& system) {
+
+    // update the reward
+    int score = getDecimalScore(0x89, 0x8A, &system);
+	score += readRam(&system, 0xD3);
+    score *= 10;
+    int reward = score - m_score;
+    m_reward = reward;
+    m_score = score;
+
+    // update terminal status
+    int lives_byte = readRam(&system, 0xB9);
+    // Note - this *requires* a reset at load time; lives are set to 0 before
+    //  reset is pushed
+    m_terminal = (lives_byte == 0);
+
+    m_lives = lives_byte;
+}
+
+
+/* is end of game */
+bool TurmoilSettings::isTerminal() const {
+
+    return m_terminal;
+};
+
+
+/* get the most recently observed reward */
+reward_t TurmoilSettings::getReward() const { 
+
+    return m_reward; 
+}
+
+
+/* is an action part of the minimal set? */
+bool TurmoilSettings::isMinimal(const Action &a) const {
+
+    switch (a) {
+        case PLAYER_A_NOOP:
+        case PLAYER_A_FIRE:
+        case PLAYER_A_UP:
+        case PLAYER_A_RIGHT:
+        case PLAYER_A_LEFT:
+        case PLAYER_A_DOWN:
+        case PLAYER_A_UPRIGHT:
+        case PLAYER_A_UPLEFT:
+        case PLAYER_A_DOWNRIGHT:
+        case PLAYER_A_DOWNLEFT:
+        case PLAYER_A_UPFIRE:
+        case PLAYER_A_RIGHTFIRE:
+        case PLAYER_A_LEFTFIRE:
+        case PLAYER_A_DOWNFIRE:
+        case PLAYER_A_UPRIGHTFIRE:
+        case PLAYER_A_UPLEFTFIRE:
+        case PLAYER_A_DOWNRIGHTFIRE:
+        case PLAYER_A_DOWNLEFTFIRE:
+            return true;
+        default:
+            return false;
+    }   
+}
+
+
+/* reset the state of the game */
+void TurmoilSettings::reset() {
+    
+    m_reward   = 0;
+    m_score    = 0;
+    m_terminal = false;
+    m_lives    = 4;
+}
+
+/* saves the state of the rom settings */
+void TurmoilSettings::saveState(Serializer & ser) {
+  ser.putInt(m_reward);
+  ser.putInt(m_score);
+  ser.putBool(m_terminal);
+  ser.putInt(m_lives);
+}
+
+// loads the state of the rom settings
+void TurmoilSettings::loadState(Deserializer & ser) {
+  m_reward = ser.getInt();
+  m_score = ser.getInt();
+  m_terminal = ser.getBool();
+  m_lives = ser.getInt();
+}
+
+ActionVect TurmoilSettings::getStartingActions() {
+    ActionVect startingActions;
+    startingActions.push_back(PLAYER_A_FIRE);
+    return startingActions;
+}
+

--- a/src/games/supported/Turmoil.cpp
+++ b/src/games/supported/Turmoil.cpp
@@ -57,9 +57,7 @@ void TurmoilSettings::step(const System& system) {
 
     // update terminal status
     int lives_byte = readRam(&system, 0xB9);
-    // Note - this *requires* a reset at load time; lives are set to 0 before
-    //  reset is pushed
-    m_terminal = (lives_byte == 0);
+    m_terminal = (lives_byte == 0) && readRam(&system, 0xC5) == 0x01;
 
     m_lives = lives_byte;
 }
@@ -93,14 +91,8 @@ bool TurmoilSettings::isMinimal(const Action &a) const {
         case PLAYER_A_UPLEFT:
         case PLAYER_A_DOWNRIGHT:
         case PLAYER_A_DOWNLEFT:
-        case PLAYER_A_UPFIRE:
         case PLAYER_A_RIGHTFIRE:
         case PLAYER_A_LEFTFIRE:
-        case PLAYER_A_DOWNFIRE:
-        case PLAYER_A_UPRIGHTFIRE:
-        case PLAYER_A_UPLEFTFIRE:
-        case PLAYER_A_DOWNRIGHTFIRE:
-        case PLAYER_A_DOWNLEFTFIRE:
             return true;
         default:
             return false;

--- a/src/games/supported/Turmoil.hpp
+++ b/src/games/supported/Turmoil.hpp
@@ -1,0 +1,84 @@
+/* *****************************************************************************
+ * The lines 67 and 74 are based on Xitari's code, from Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 2
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * *****************************************************************************
+ * A.L.E (Arcade Learning Environment)
+ * Copyright (c) 2009-2013 by Yavar Naddaf, Joel Veness, Marc G. Bellemare and 
+ *   the Reinforcement Learning and Artificial Intelligence Laboratory
+ * Released under the GNU General Public License; see License.txt for details. 
+ *
+ * Based on: Stella  --  "An Atari 2600 VCS Emulator"
+ * Copyright (c) 1995-2007 by Bradford W. Mott and the Stella team
+ *
+ * *****************************************************************************
+ */
+#ifndef __TURMOIL_HPP__
+#define __TURMOIL_HPP__
+
+#include "../RomSettings.hpp"
+
+
+/* RL wrapper for Turmoil */
+class TurmoilSettings : public RomSettings {
+
+    public:
+
+        TurmoilSettings();
+
+        // reset
+        void reset();
+
+        // is end of game
+        bool isTerminal() const;
+
+        // get the most recently observed reward
+        reward_t getReward() const;
+
+        // the rom-name
+		// MD5 sum of ROM file:
+		// 7a5463545dfb2dcfdafa6074b2f2c15e  Turmoil.bin
+        const char* rom() const { return "turmoil"; }
+
+        // create a new instance of the rom
+        RomSettings* clone() const;
+
+        // is an action part of the minimal set?
+        bool isMinimal(const Action& a) const;
+
+        // process the latest information from ALE
+        void step(const System& system);
+        
+        // saves the state of the rom settings
+        void saveState(Serializer & ser);
+    
+        // loads the state of the rom settings
+        void loadState(Deserializer & ser);
+
+        // Turmoil requires the fire action to start the game
+        ActionVect getStartingActions();
+
+        virtual const int lives() { return isTerminal() ? 0 : m_lives; }
+
+    private:
+
+        bool m_terminal;
+        reward_t m_reward;
+        reward_t m_score;
+        int m_lives;
+};
+
+#endif // __TURMOIL_HPP__
+
+

--- a/src/games/supported/Turmoil.hpp
+++ b/src/games/supported/Turmoil.hpp
@@ -1,19 +1,4 @@
 /* *****************************************************************************
- * The lines 67 and 74 are based on Xitari's code, from Google Inc.
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License version 2
- * as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
- * *****************************************************************************
  * A.L.E (Arcade Learning Environment)
  * Copyright (c) 2009-2013 by Yavar Naddaf, Joel Veness, Marc G. Bellemare and 
  *   the Reinforcement Learning and Artificial Intelligence Laboratory


### PR DESCRIPTION
This adds support for the game Turmoil.

`stella -rominfo turmoil.bin` shows:

```
  Cart Name:       Turmoil (1982) (20th Century Fox)
  Cart MD5:        7a5463545dfb2dcfdafa6074b2f2c15e
  Controller 0:    Joystick in left port
  Controller 1:    Joystick in right port
  Display Format:  NTSC*
  Bankswitch Type: 4K* (4K) 
```

I tested this game using my [Julia wrapper for ALE](https://github.com/nowozin/ArcadeLearningEnvironment.jl) and rewards/scores and lives agree with screenshot values over a large number of random games.

![Turmoil screenshot](http://www.mobygames.com/images/shots/l/134291-turmoil-atari-2600-screenshot-some-of-the-ships-you-destroy.png)