### PR TITLE
Add support for the game Koolaid.

### DIFF
--- a/src/games/Roms.cpp
+++ b/src/games/Roms.cpp
@@ -47,6 +47,7 @@
 #include "supported/JamesBond.hpp"
 #include "supported/JourneyEscape.hpp"
 #include "supported/Kangaroo.hpp"
+#include "supported/Koolaid.hpp"
 #include "supported/Krull.hpp"
 #include "supported/KungFuMaster.hpp"
 #include "supported/MontezumaRevenge.hpp"
@@ -113,6 +114,7 @@ static const RomSettings *roms[]  = {
     new JamesBondSettings(),
     new JourneyEscapeSettings(),
     new KangarooSettings(),
+    new KoolaidSettings(),
     new KrullSettings(),
     new KungFuMasterSettings(),
     new MontezumaRevengeSettings(),

--- a/src/games/module.mk
+++ b/src/games/module.mk
@@ -37,6 +37,7 @@ MODULE_OBJS := \
 	src/games/supported/JamesBond.o \
 	src/games/supported/JourneyEscape.o \
 	src/games/supported/Kangaroo.o \
+	src/games/supported/Koolaid.o \
 	src/games/supported/Krull.o \
 	src/games/supported/KungFuMaster.o \
 	src/games/supported/MontezumaRevenge.o \

--- a/src/games/supported/Koolaid.cpp
+++ b/src/games/supported/Koolaid.cpp
@@ -1,19 +1,4 @@
 /* *****************************************************************************
- * The lines 61, 63, 116, 124 and 132 are based on Xitari's code, from Google Inc.
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License version 2
- * as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
- * *****************************************************************************
  * A.L.E (Arcade Learning Environment)
  * Copyright (c) 2009-2013 by Yavar Naddaf, Joel Veness, Marc G. Bellemare and 
  *   the Reinforcement Learning and Artificial Intelligence Laboratory

--- a/src/games/supported/Koolaid.cpp
+++ b/src/games/supported/Koolaid.cpp
@@ -1,0 +1,116 @@
+/* *****************************************************************************
+ * The lines 61, 63, 116, 124 and 132 are based on Xitari's code, from Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 2
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * *****************************************************************************
+ * A.L.E (Arcade Learning Environment)
+ * Copyright (c) 2009-2013 by Yavar Naddaf, Joel Veness, Marc G. Bellemare and 
+ *   the Reinforcement Learning and Artificial Intelligence Laboratory
+ * Released under the GNU General Public License; see License.txt for details. 
+ *
+ * Based on: Stella  --  "An Atari 2600 VCS Emulator"
+ * Copyright (c) 1995-2007 by Bradford W. Mott and the Stella team
+ *
+ * *****************************************************************************
+ */
+#include "Koolaid.hpp"
+
+#include "../RomUtils.hpp"
+
+
+KoolaidSettings::KoolaidSettings() {
+
+    reset();
+}
+
+
+/* create a new instance of the rom */
+RomSettings* KoolaidSettings::clone() const { 
+    
+    RomSettings* rval = new KoolaidSettings();
+    *rval = *this;
+    return rval;
+}
+
+
+/* process the latest information from ALE */
+void KoolaidSettings::step(const System& system) {
+
+    // update the reward
+    int score = getDecimalScore(0x81, 0x80, &system);
+    score *= 100;
+    int reward = score - m_score;
+    m_reward = reward;
+    m_score = score;
+
+    m_terminal = readRam(&system, 0xD1) == 0x80;
+}
+
+
+/* is end of game */
+bool KoolaidSettings::isTerminal() const {
+
+    return m_terminal;
+};
+
+
+/* get the most recently observed reward */
+reward_t KoolaidSettings::getReward() const { 
+
+    return m_reward; 
+}
+
+
+/* is an action part of the minimal set? */
+bool KoolaidSettings::isMinimal(const Action &a) const {
+
+    switch (a) {
+        case PLAYER_A_NOOP:
+        case PLAYER_A_UP:
+        case PLAYER_A_RIGHT:
+        case PLAYER_A_LEFT:
+        case PLAYER_A_DOWN:
+        case PLAYER_A_UPRIGHT:
+        case PLAYER_A_UPLEFT:
+        case PLAYER_A_DOWNRIGHT:
+        case PLAYER_A_DOWNLEFT:
+            return true;
+        default:
+            return false;
+    }   
+}
+
+
+/* reset the state of the game */
+void KoolaidSettings::reset() {
+    
+    m_reward   = 0;
+    m_score    = 0;
+    m_terminal = false;
+}
+        
+/* saves the state of the rom settings */
+void KoolaidSettings::saveState(Serializer & ser) {
+  ser.putInt(m_reward);
+  ser.putInt(m_score);
+  ser.putBool(m_terminal);
+}
+
+// loads the state of the rom settings
+void KoolaidSettings::loadState(Deserializer & ser) {
+  m_reward = ser.getInt();
+  m_score = ser.getInt();
+  m_terminal = ser.getBool();
+}
+

--- a/src/games/supported/Koolaid.hpp
+++ b/src/games/supported/Koolaid.hpp
@@ -1,0 +1,78 @@
+/* *****************************************************************************
+ * The lines 67 and 74 are based on Xitari's code, from Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 2
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * *****************************************************************************
+ * A.L.E (Arcade Learning Environment)
+ * Copyright (c) 2009-2013 by Yavar Naddaf, Joel Veness, Marc G. Bellemare and 
+ *   the Reinforcement Learning and Artificial Intelligence Laboratory
+ * Released under the GNU General Public License; see License.txt for details. 
+ *
+ * Based on: Stella  --  "An Atari 2600 VCS Emulator"
+ * Copyright (c) 1995-2007 by Bradford W. Mott and the Stella team
+ *
+ * *****************************************************************************
+ */
+#ifndef __KOOLAID_HPP__
+#define __KOOLAID_HPP__
+
+#include "../RomSettings.hpp"
+
+
+/* RL wrapper for Koolaid */
+class KoolaidSettings : public RomSettings {
+
+    public:
+
+        KoolaidSettings();
+
+        // reset
+        void reset();
+
+        // is end of game
+        bool isTerminal() const;
+
+        // get the most recently observed reward
+        reward_t getReward() const;
+
+        // the rom-name
+        const char* rom() const { return "koolaid"; }
+
+        // create a new instance of the rom
+        RomSettings* clone() const;
+
+        // is an action part of the minimal set?
+        bool isMinimal(const Action& a) const;
+
+        // process the latest information from ALE
+        void step(const System& system);
+        
+        // saves the state of the rom settings
+        void saveState(Serializer & ser);
+    
+        // loads the state of the rom settings
+        void loadState(Deserializer & ser);
+
+        virtual const int lives() { return 0; }
+
+    private:
+
+        bool m_terminal;
+        reward_t m_reward;
+        reward_t m_score;
+};
+
+#endif // __KOOLAID_HPP__
+
+

--- a/src/games/supported/Koolaid.hpp
+++ b/src/games/supported/Koolaid.hpp
@@ -1,19 +1,4 @@
 /* *****************************************************************************
- * The lines 67 and 74 are based on Xitari's code, from Google Inc.
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License version 2
- * as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
- * *****************************************************************************
  * A.L.E (Arcade Learning Environment)
  * Copyright (c) 2009-2013 by Yavar Naddaf, Joel Veness, Marc G. Bellemare and 
  *   the Reinforcement Learning and Artificial Intelligence Laboratory


### PR DESCRIPTION
Add support for the game _Kool Aid Man_, using the ROM name `koolaid.bin`.

```
  Cart Name:       Kool-Aid Man (1983) (M Network)
  Cart MD5:        534e23210dd1993c828d944c6ac4d9fb
  Controller 0:    Joystick in left port
  Controller 1:    Joystick in right port
  Display Format:  NTSC*
  Bankswitch Type: 4K* (4K) 
```

![Kool Aid Man screenshot](http://videogamecritic.com/images/2600/kool-aid_man.png)