### PR TITLE
Add support for the game Mr. Do.

### DIFF
--- a/src/games/Roms.cpp
+++ b/src/games/Roms.cpp
@@ -50,6 +50,7 @@
 #include "supported/Krull.hpp"
 #include "supported/KungFuMaster.hpp"
 #include "supported/MontezumaRevenge.hpp"
+#include "supported/MrDo.hpp"
 #include "supported/MsPacman.hpp"
 #include "supported/NameThisGame.hpp"
 #include "supported/Phoenix.hpp"
@@ -116,6 +117,7 @@ static const RomSettings *roms[]  = {
     new KrullSettings(),
     new KungFuMasterSettings(),
     new MontezumaRevengeSettings(),
+    new MrDoSettings(),
     new MsPacmanSettings(),
     new NameThisGameSettings(),
     new PhoenixSettings(),

--- a/src/games/module.mk
+++ b/src/games/module.mk
@@ -40,6 +40,7 @@ MODULE_OBJS := \
 	src/games/supported/Krull.o \
 	src/games/supported/KungFuMaster.o \
 	src/games/supported/MontezumaRevenge.o \
+	src/games/supported/MrDo.o \
 	src/games/supported/MsPacman.o \
 	src/games/supported/NameThisGame.o \
 	src/games/supported/Phoenix.o \

--- a/src/games/supported/MrDo.cpp
+++ b/src/games/supported/MrDo.cpp
@@ -1,19 +1,4 @@
 /* *****************************************************************************
- * The lines 61, 63, 116, 124 and 132 are based on Xitari's code, from Google Inc.
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License version 2
- * as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
- * *****************************************************************************
  * A.L.E (Arcade Learning Environment)
  * Copyright (c) 2009-2013 by Yavar Naddaf, Joel Veness, Marc G. Bellemare and 
  *   the Reinforcement Learning and Artificial Intelligence Laboratory

--- a/src/games/supported/MrDo.cpp
+++ b/src/games/supported/MrDo.cpp
@@ -118,3 +118,9 @@ void MrDoSettings::loadState(Deserializer & ser) {
   m_lives = ser.getInt();
 }
 
+ActionVect MrDoSettings::getStartingActions() {
+    ActionVect startingActions;
+    startingActions.push_back(PLAYER_A_FIRE);
+    return startingActions;
+}
+

--- a/src/games/supported/MrDo.cpp
+++ b/src/games/supported/MrDo.cpp
@@ -1,0 +1,120 @@
+/* *****************************************************************************
+ * The lines 61, 63, 116, 124 and 132 are based on Xitari's code, from Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 2
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * *****************************************************************************
+ * A.L.E (Arcade Learning Environment)
+ * Copyright (c) 2009-2013 by Yavar Naddaf, Joel Veness, Marc G. Bellemare and 
+ *   the Reinforcement Learning and Artificial Intelligence Laboratory
+ * Released under the GNU General Public License; see License.txt for details. 
+ *
+ * Based on: Stella  --  "An Atari 2600 VCS Emulator"
+ * Copyright (c) 1995-2007 by Bradford W. Mott and the Stella team
+ *
+ * *****************************************************************************
+ */
+#include "MrDo.hpp"
+
+#include "../RomUtils.hpp"
+
+
+MrDoSettings::MrDoSettings() {
+
+    reset();
+}
+
+
+/* create a new instance of the rom */
+RomSettings* MrDoSettings::clone() const { 
+    
+    RomSettings* rval = new MrDoSettings();
+    *rval = *this;
+    return rval;
+}
+
+
+/* process the latest information from ALE */
+void MrDoSettings::step(const System& system) {
+
+    // update the reward
+    int score = getDecimalScore(0x82, 0x83, &system);
+    score *= 10;
+    int reward = score - m_score;
+    m_reward = reward;
+    m_score = score;
+
+    // update terminal status
+    m_lives = readRam(&system, 0xDB);
+    m_terminal = readRam(&system, 0xDA) == 0x40;
+}
+
+
+/* is end of game */
+bool MrDoSettings::isTerminal() const {
+    return m_terminal;
+};
+
+
+/* get the most recently observed reward */
+reward_t MrDoSettings::getReward() const { 
+    return m_reward; 
+}
+
+
+/* is an action part of the minimal set? */
+bool MrDoSettings::isMinimal(const Action &a) const {
+
+    switch (a) {
+        case PLAYER_A_NOOP:
+        case PLAYER_A_FIRE:
+        case PLAYER_A_UP:
+        case PLAYER_A_RIGHT:
+        case PLAYER_A_LEFT:
+        case PLAYER_A_DOWN:
+        case PLAYER_A_UPFIRE:
+        case PLAYER_A_RIGHTFIRE:
+        case PLAYER_A_LEFTFIRE:
+        case PLAYER_A_DOWNFIRE:
+            return true;
+        default:
+            return false;
+    }   
+}
+
+
+/* reset the state of the game */
+void MrDoSettings::reset() {
+    
+    m_reward   = 0;
+    m_score    = 0;
+    m_terminal = false;
+    m_lives    = 4;
+}
+        
+/* saves the state of the rom settings */
+void MrDoSettings::saveState(Serializer & ser) {
+  ser.putInt(m_reward);
+  ser.putInt(m_score);
+  ser.putBool(m_terminal);
+  ser.putInt(m_lives);
+}
+
+// loads the state of the rom settings
+void MrDoSettings::loadState(Deserializer & ser) {
+  m_reward = ser.getInt();
+  m_score = ser.getInt();
+  m_terminal = ser.getBool();
+  m_lives = ser.getInt();
+}
+

--- a/src/games/supported/MrDo.hpp
+++ b/src/games/supported/MrDo.hpp
@@ -1,0 +1,78 @@
+/* *****************************************************************************
+ * The lines 67 and 74 are based on Xitari's code, from Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 2
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * *****************************************************************************
+ * A.L.E (Arcade Learning Environment)
+ * Copyright (c) 2009-2013 by Yavar Naddaf, Joel Veness, Marc G. Bellemare and 
+ *   the Reinforcement Learning and Artificial Intelligence Laboratory
+ * Released under the GNU General Public License; see License.txt for details. 
+ *
+ * Based on: Stella  --  "An Atari 2600 VCS Emulator"
+ * Copyright (c) 1995-2007 by Bradford W. Mott and the Stella team
+ *
+ * *****************************************************************************
+ */
+#ifndef __MRDO_HPP__
+#define __MRDO_HPP__
+
+#include "../RomSettings.hpp"
+
+
+/* RL wrapper for MrDo */
+class MrDoSettings : public RomSettings {
+
+    public:
+
+        MrDoSettings();
+
+        // reset
+        void reset();
+
+        // is end of game
+        bool isTerminal() const;
+
+        // get the most recently observed reward
+        reward_t getReward() const;
+
+        // the rom-name
+        const char* rom() const { return "mrdo"; }
+
+        // create a new instance of the rom
+        RomSettings* clone() const;
+
+        // is an action part of the minimal set?
+        bool isMinimal(const Action& a) const;
+
+        // process the latest information from ALE
+        void step(const System& system);
+        
+        // saves the state of the rom settings
+        void saveState(Serializer & ser);
+    
+        // loads the state of the rom settings
+        void loadState(Deserializer & ser);
+
+        virtual const int lives() { return isTerminal() ? 0 : m_lives; }
+
+    private:
+
+        bool m_terminal;
+        reward_t m_reward;
+        reward_t m_score;
+        int m_lives;
+};
+
+#endif // __MRDO_HPP__
+

--- a/src/games/supported/MrDo.hpp
+++ b/src/games/supported/MrDo.hpp
@@ -64,6 +64,9 @@ class MrDoSettings : public RomSettings {
         // loads the state of the rom settings
         void loadState(Deserializer & ser);
 
+        // Mr. Do requires the fire action to start the game
+        ActionVect getStartingActions();
+
         virtual const int lives() { return isTerminal() ? 0 : m_lives; }
 
     private:

--- a/src/games/supported/MrDo.hpp
+++ b/src/games/supported/MrDo.hpp
@@ -1,19 +1,4 @@
 /* *****************************************************************************
- * The lines 67 and 74 are based on Xitari's code, from Google Inc.
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License version 2
- * as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
- * *****************************************************************************
  * A.L.E (Arcade Learning Environment)
  * Copyright (c) 2009-2013 by Yavar Naddaf, Joel Veness, Marc G. Bellemare and 
  *   the Reinforcement Learning and Artificial Intelligence Laboratory


### PR DESCRIPTION
This game is actually quite fun, and the popular PC game [_Digger_](https://en.wikipedia.org/wiki/Digger_%28video_game%29) is a clone of Mr. Do.

```
  Cart Name:       Mr. Do! (1983) (Coleco)
  Cart MD5:        0164f26f6b38a34208cd4a2d0212afc3
  Controller 0:    Joystick in left port
  Controller 1:    Joystick in right port
  Display Format:  NTSC*
  Bankswitch Type: F8* (8K) 
```

I verified that scores/lives are agreeing with screenshots over many random plays.

![Mr. Do screenshot](http://videogamecritic.com/images/2600/mr__do!.png)