### PR TITLE
Add support for the game Donkey Kong.

### DIFF
--- a/src/games/Roms.cpp
+++ b/src/games/Roms.cpp
@@ -34,6 +34,7 @@
 #include "supported/CrazyClimber.hpp"
 #include "supported/Defender.hpp"
 #include "supported/DemonAttack.hpp"
+#include "supported/DonkeyKong.hpp"
 #include "supported/DoubleDunk.hpp"
 #include "supported/ElevatorAction.hpp"
 #include "supported/Enduro.hpp"
@@ -100,6 +101,7 @@ static const RomSettings *roms[]  = {
     new CrazyClimberSettings(),
     new DefenderSettings(),
     new DemonAttackSettings(),
+    new DonkeyKongSettings(),
     new DoubleDunkSettings(),
     new ElevatorActionSettings(),
     new EnduroSettings(),

--- a/src/games/module.mk
+++ b/src/games/module.mk
@@ -24,6 +24,7 @@ MODULE_OBJS := \
 	src/games/supported/CrazyClimber.o \
 	src/games/supported/Defender.o \
 	src/games/supported/DemonAttack.o \
+	src/games/supported/DonkeyKong.o \
 	src/games/supported/DoubleDunk.o \
 	src/games/supported/ElevatorAction.o \
 	src/games/supported/Enduro.o \

--- a/src/games/supported/DonkeyKong.cpp
+++ b/src/games/supported/DonkeyKong.cpp
@@ -1,19 +1,4 @@
 /* *****************************************************************************
- * The lines 61, 63, 116, 124 and 132 are based on Xitari's code, from Google Inc.
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License version 2
- * as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
- * *****************************************************************************
  * A.L.E (Arcade Learning Environment)
  * Copyright (c) 2009-2013 by Yavar Naddaf, Joel Veness, Marc G. Bellemare and 
  *   the Reinforcement Learning and Artificial Intelligence Laboratory

--- a/src/games/supported/DonkeyKong.cpp
+++ b/src/games/supported/DonkeyKong.cpp
@@ -1,0 +1,122 @@
+/* *****************************************************************************
+ * The lines 61, 63, 116, 124 and 132 are based on Xitari's code, from Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 2
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * *****************************************************************************
+ * A.L.E (Arcade Learning Environment)
+ * Copyright (c) 2009-2013 by Yavar Naddaf, Joel Veness, Marc G. Bellemare and 
+ *   the Reinforcement Learning and Artificial Intelligence Laboratory
+ * Released under the GNU General Public License; see License.txt for details. 
+ *
+ * Based on: Stella  --  "An Atari 2600 VCS Emulator"
+ * Copyright (c) 1995-2007 by Bradford W. Mott and the Stella team
+ *
+ * *****************************************************************************
+ */
+#include "DonkeyKong.hpp"
+
+#include "../RomUtils.hpp"
+
+
+DonkeyKongSettings::DonkeyKongSettings() {
+    reset();
+}
+
+
+/* create a new instance of the rom */
+RomSettings* DonkeyKongSettings::clone() const { 
+    RomSettings* rval = new DonkeyKongSettings();
+    *rval = *this;
+    return rval;
+}
+
+
+/* process the latest information from ALE */
+void DonkeyKongSettings::step(const System& system) {
+    // update the reward
+    int score = getDecimalScore(0x88, 0x87, &system);
+    score *= 100;
+    int reward = score - m_score;
+    m_reward = reward;
+    m_score = score;
+
+    // update lives and terminal status
+    m_lives = readRam(&system, 0xA3);
+    m_terminal = readRam(&system, 0x8F) == 0x03;
+}
+
+/* is end of game */
+bool DonkeyKongSettings::isTerminal() const {
+    return m_terminal;
+};
+
+
+/* get the most recently observed reward */
+reward_t DonkeyKongSettings::getReward() const { 
+    return m_reward; 
+}
+
+
+/* is an action part of the minimal set? */
+bool DonkeyKongSettings::isMinimal(const Action &a) const {
+    switch (a) {
+        case PLAYER_A_NOOP:
+        case PLAYER_A_FIRE:
+        case PLAYER_A_UP:
+        case PLAYER_A_RIGHT:
+        case PLAYER_A_LEFT:
+        case PLAYER_A_DOWN:
+        case PLAYER_A_UPRIGHT:
+        case PLAYER_A_UPLEFT:
+        case PLAYER_A_DOWNRIGHT:
+        case PLAYER_A_DOWNLEFT:
+        case PLAYER_A_UPFIRE:
+        case PLAYER_A_RIGHTFIRE:
+        case PLAYER_A_LEFTFIRE:
+        case PLAYER_A_DOWNFIRE:
+        case PLAYER_A_UPRIGHTFIRE:
+        case PLAYER_A_UPLEFTFIRE:
+        case PLAYER_A_DOWNRIGHTFIRE:
+        case PLAYER_A_DOWNLEFTFIRE:
+            return true;
+        default:
+            return false;
+    }   
+}
+
+
+/* reset the state of the game */
+void DonkeyKongSettings::reset() {
+    m_reward   = 0;
+    m_score    = 0;
+    m_terminal = false;
+    m_lives    = 2;
+}
+        
+/* saves the state of the rom settings */
+void DonkeyKongSettings::saveState(Serializer & ser) {
+  ser.putInt(m_reward);
+  ser.putInt(m_score);
+  ser.putBool(m_terminal);
+  ser.putInt(m_lives);
+}
+
+// loads the state of the rom settings
+void DonkeyKongSettings::loadState(Deserializer & ser) {
+  m_reward = ser.getInt();
+  m_score = ser.getInt();
+  m_terminal = ser.getBool();
+  m_lives = ser.getInt();
+}
+

--- a/src/games/supported/DonkeyKong.hpp
+++ b/src/games/supported/DonkeyKong.hpp
@@ -1,19 +1,4 @@
 /* *****************************************************************************
- * The lines 67 and 74 are based on Xitari's code, from Google Inc.
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License version 2
- * as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
- * *****************************************************************************
  * A.L.E (Arcade Learning Environment)
  * Copyright (c) 2009-2013 by Yavar Naddaf, Joel Veness, Marc G. Bellemare and 
  *   the Reinforcement Learning and Artificial Intelligence Laboratory

--- a/src/games/supported/DonkeyKong.hpp
+++ b/src/games/supported/DonkeyKong.hpp
@@ -1,0 +1,78 @@
+/* *****************************************************************************
+ * The lines 67 and 74 are based on Xitari's code, from Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 2
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * *****************************************************************************
+ * A.L.E (Arcade Learning Environment)
+ * Copyright (c) 2009-2013 by Yavar Naddaf, Joel Veness, Marc G. Bellemare and 
+ *   the Reinforcement Learning and Artificial Intelligence Laboratory
+ * Released under the GNU General Public License; see License.txt for details. 
+ *
+ * Based on: Stella  --  "An Atari 2600 VCS Emulator"
+ * Copyright (c) 1995-2007 by Bradford W. Mott and the Stella team
+ *
+ * *****************************************************************************
+ */
+#ifndef __DONKEYKONG_HPP__
+#define __DONKEYKONG_HPP__
+
+#include "../RomSettings.hpp"
+
+
+/* RL wrapper for DonkeyKong */
+class DonkeyKongSettings : public RomSettings {
+
+    public:
+
+        DonkeyKongSettings();
+
+        // reset
+        void reset();
+
+        // is end of game
+        bool isTerminal() const;
+
+        // get the most recently observed reward
+        reward_t getReward() const;
+
+        // the rom-name
+		// MD5 36b20c427975760cb9cf4a47e41369e4
+        const char* rom() const { return "donkeykong"; }
+
+        // create a new instance of the rom
+        RomSettings* clone() const;
+
+        // is an action part of the minimal set?
+        bool isMinimal(const Action& a) const;
+
+        // process the latest information from ALE
+        void step(const System& system);
+        
+        // saves the state of the rom settings
+        void saveState(Serializer & ser);
+    
+        // loads the state of the rom settings
+        void loadState(Deserializer & ser);
+
+        virtual const int lives() { return isTerminal() ? 0 : m_lives; }
+
+    private:
+        bool m_terminal;
+        reward_t m_reward;
+        reward_t m_score;
+        int m_lives;
+};
+
+#endif // __DONKEYKONG_HPP__
+


### PR DESCRIPTION
```
  Cart Name:       Donkey Kong (1987) (Atari)
  Cart MD5:        36b20c427975760cb9cf4a47e41369e4
  Controller 0:    Joystick in left port
  Controller 1:    Joystick in right port
  Display Format:  NTSC*
  Bankswitch Type: 4K* (4K) 
```

I minimally tested the game with a random policy, however the game did not complete a level using a random policy.  I am pretty confident the support is solid.

![Donkey Kong screenshot](http://s.emuparadise.org/fup/up/91274-Donkey_Kong_%281982%29_%28Coleco,_Dan_Kitchen,_Garry_Kitchen%29_%282451%29-1.png)