### PR TITLE
Add support for the game Keystone Kapers.

### DIFF
--- a/src/games/Roms.cpp
+++ b/src/games/Roms.cpp
@@ -47,6 +47,7 @@
 #include "supported/JamesBond.hpp"
 #include "supported/JourneyEscape.hpp"
 #include "supported/Kangaroo.hpp"
+#include "supported/KeystoneKapers.hpp"
 #include "supported/Krull.hpp"
 #include "supported/KungFuMaster.hpp"
 #include "supported/MontezumaRevenge.hpp"
@@ -113,6 +114,7 @@ static const RomSettings *roms[]  = {
     new JamesBondSettings(),
     new JourneyEscapeSettings(),
     new KangarooSettings(),
+    new KeystoneKapersSettings(),
     new KrullSettings(),
     new KungFuMasterSettings(),
     new MontezumaRevengeSettings(),

--- a/src/games/module.mk
+++ b/src/games/module.mk
@@ -37,6 +37,7 @@ MODULE_OBJS := \
 	src/games/supported/JamesBond.o \
 	src/games/supported/JourneyEscape.o \
 	src/games/supported/Kangaroo.o \
+	src/games/supported/KeystoneKapers.o \
 	src/games/supported/Krull.o \
 	src/games/supported/KungFuMaster.o \
 	src/games/supported/MontezumaRevenge.o \

--- a/src/games/supported/KeystoneKapers.cpp
+++ b/src/games/supported/KeystoneKapers.cpp
@@ -1,19 +1,4 @@
 /* *****************************************************************************
- * The lines 61, 63, 116, 124 and 132 are based on Xitari's code, from Google Inc.
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License version 2
- * as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
- * *****************************************************************************
  * A.L.E (Arcade Learning Environment)
  * Copyright (c) 2009-2013 by Yavar Naddaf, Joel Veness, Marc G. Bellemare and 
  *   the Reinforcement Learning and Artificial Intelligence Laboratory

--- a/src/games/supported/KeystoneKapers.cpp
+++ b/src/games/supported/KeystoneKapers.cpp
@@ -1,0 +1,123 @@
+/* *****************************************************************************
+ * The lines 61, 63, 116, 124 and 132 are based on Xitari's code, from Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 2
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * *****************************************************************************
+ * A.L.E (Arcade Learning Environment)
+ * Copyright (c) 2009-2013 by Yavar Naddaf, Joel Veness, Marc G. Bellemare and 
+ *   the Reinforcement Learning and Artificial Intelligence Laboratory
+ * Released under the GNU General Public License; see License.txt for details. 
+ *
+ * Based on: Stella  --  "An Atari 2600 VCS Emulator"
+ * Copyright (c) 1995-2007 by Bradford W. Mott and the Stella team
+ *
+ * *****************************************************************************
+ */
+#include "KeystoneKapers.hpp"
+
+#include "../RomUtils.hpp"
+
+
+KeystoneKapersSettings::KeystoneKapersSettings() {
+    reset();
+}
+
+
+/* create a new instance of the rom */
+RomSettings* KeystoneKapersSettings::clone() const { 
+    RomSettings* rval = new KeystoneKapersSettings();
+    *rval = *this;
+    return rval;
+}
+
+
+/* process the latest information from ALE */
+void KeystoneKapersSettings::step(const System& system) {
+    // update the reward
+    int score = getDecimalScore(0x9C, 0x9B, &system);
+    int reward = score - m_score;
+    m_reward = reward;
+    m_score = score;
+
+    m_lives = readRam(&system, 0x96);
+    m_terminal = (m_lives == 0) && readRam(&system, 0x88) == 0x00;
+}
+
+
+/* is end of game */
+bool KeystoneKapersSettings::isTerminal() const {
+    return m_terminal;
+};
+
+
+/* get the most recently observed reward */
+reward_t KeystoneKapersSettings::getReward() const { 
+    return m_reward; 
+}
+
+
+/* is an action part of the minimal set? */
+bool KeystoneKapersSettings::isMinimal(const Action &a) const {
+    switch (a) {
+        case PLAYER_A_NOOP:
+        case PLAYER_A_FIRE:
+        case PLAYER_A_UP:
+        case PLAYER_A_RIGHT:
+        case PLAYER_A_LEFT:
+        case PLAYER_A_DOWN:
+        case PLAYER_A_UPRIGHT:
+        case PLAYER_A_UPLEFT:
+        case PLAYER_A_DOWNRIGHT:
+        case PLAYER_A_DOWNLEFT:
+        case PLAYER_A_UPFIRE:
+        case PLAYER_A_RIGHTFIRE:
+        case PLAYER_A_LEFTFIRE:
+        case PLAYER_A_DOWNFIRE:
+            return true;
+        default:
+            return false;
+    }   
+}
+
+
+/* reset the state of the game */
+void KeystoneKapersSettings::reset() {
+    m_reward   = 0;
+    m_score    = 0;
+    m_terminal = false;
+    m_lives    = 3;
+}
+        
+/* saves the state of the rom settings */
+void KeystoneKapersSettings::saveState(Serializer & ser) {
+  ser.putInt(m_reward);
+  ser.putInt(m_score);
+  ser.putBool(m_terminal);
+  ser.putInt(m_lives);
+}
+
+// loads the state of the rom settings
+void KeystoneKapersSettings::loadState(Deserializer & ser) {
+  m_reward = ser.getInt();
+  m_score = ser.getInt();
+  m_terminal = ser.getBool();
+  m_lives = ser.getInt();
+}
+
+ActionVect KeystoneKapersSettings::getStartingActions() {
+    ActionVect startingActions;
+    startingActions.push_back(RESET);
+    return startingActions;
+}
+

--- a/src/games/supported/KeystoneKapers.hpp
+++ b/src/games/supported/KeystoneKapers.hpp
@@ -1,0 +1,80 @@
+/* *****************************************************************************
+ * The lines 67 and 74 are based on Xitari's code, from Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 2
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * *****************************************************************************
+ * A.L.E (Arcade Learning Environment)
+ * Copyright (c) 2009-2013 by Yavar Naddaf, Joel Veness, Marc G. Bellemare and 
+ *   the Reinforcement Learning and Artificial Intelligence Laboratory
+ * Released under the GNU General Public License; see License.txt for details. 
+ *
+ * Based on: Stella  --  "An Atari 2600 VCS Emulator"
+ * Copyright (c) 1995-2007 by Bradford W. Mott and the Stella team
+ *
+ * *****************************************************************************
+ */
+#ifndef __KEYSTONEKAPERS_HPP__
+#define __KEYSTONEKAPERS_HPP__
+
+#include "../RomSettings.hpp"
+
+
+/* RL wrapper for KeystoneKapers */
+class KeystoneKapersSettings : public RomSettings {
+
+    public:
+        KeystoneKapersSettings();
+
+        // reset
+        void reset();
+
+        // is end of game
+        bool isTerminal() const;
+
+        // get the most recently observed reward
+        reward_t getReward() const;
+
+        // the rom-name
+		// MD5 be929419902e21bd7830a7a7d746195d
+        const char* rom() const { return "keystonekapers"; }
+
+        // create a new instance of the rom
+        RomSettings* clone() const;
+
+        // is an action part of the minimal set?
+        bool isMinimal(const Action& a) const;
+
+        // process the latest information from ALE
+        void step(const System& system);
+        
+        // saves the state of the rom settings
+        void saveState(Serializer & ser);
+    
+        // loads the state of the rom settings
+        void loadState(Deserializer & ser);
+
+        // Keystone Kapers requires the reset button to start the game
+        ActionVect getStartingActions();
+
+        virtual const int lives() { return isTerminal() ? 0 : m_lives; }
+
+    private:
+        bool m_terminal;
+        reward_t m_reward;
+        reward_t m_score;
+        int m_lives;
+};
+
+#endif // __KEYSTONEKAPERS_HPP__
+

--- a/src/games/supported/KeystoneKapers.hpp
+++ b/src/games/supported/KeystoneKapers.hpp
@@ -1,19 +1,4 @@
 /* *****************************************************************************
- * The lines 67 and 74 are based on Xitari's code, from Google Inc.
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License version 2
- * as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
- * *****************************************************************************
  * A.L.E (Arcade Learning Environment)
  * Copyright (c) 2009-2013 by Yavar Naddaf, Joel Veness, Marc G. Bellemare and 
  *   the Reinforcement Learning and Artificial Intelligence Laboratory


### PR DESCRIPTION
ROM file `keystonekapers.bin`:
```
  Cart Name:       Keystone Kapers (1983) (Activision)
  Cart MD5:        be929419902e21bd7830a7a7d746195d
  Controller 0:    Joystick in left port
  Controller 1:    Joystick in right port
  Display Format:  NTSC*
  Bankswitch Type: 4K* (4K) 
```

Limited testing on random policy agrees with lives and scores.  (This game is difficult for a random policy.)

![Keystone Kapers screenshot](https://atariage.com/2600/screenshots/s_KeystoneKapers_1.png)