### PR TITLE
Add support for the game Frogger.

### DIFF
--- a/src/games/Roms.cpp
+++ b/src/games/Roms.cpp
@@ -39,6 +39,7 @@
 #include "supported/Enduro.hpp"
 #include "supported/FishingDerby.hpp"
 #include "supported/Freeway.hpp"
+#include "supported/Frogger.hpp"
 #include "supported/Frostbite.hpp"
 #include "supported/Gopher.hpp"
 #include "supported/Gravitar.hpp"
@@ -105,6 +106,7 @@ static const RomSettings *roms[]  = {
     new EnduroSettings(),
     new FishingDerbySettings(),
     new FreewaySettings(),
+    new FroggerSettings(),
     new FrostbiteSettings(),
     new GopherSettings(),
     new GravitarSettings(),

--- a/src/games/module.mk
+++ b/src/games/module.mk
@@ -29,6 +29,7 @@ MODULE_OBJS := \
 	src/games/supported/Enduro.o \
 	src/games/supported/FishingDerby.o \
 	src/games/supported/Freeway.o \
+	src/games/supported/Frogger.o \
 	src/games/supported/Frostbite.o \
 	src/games/supported/Gopher.o \
 	src/games/supported/Gravitar.o \

--- a/src/games/supported/Frogger.cpp
+++ b/src/games/supported/Frogger.cpp
@@ -1,19 +1,4 @@
 /* *****************************************************************************
- * The lines 61, 63, 116, 124 and 132 are based on Xitari's code, from Google Inc.
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License version 2
- * as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
- * *****************************************************************************
  * A.L.E (Arcade Learning Environment)
  * Copyright (c) 2009-2013 by Yavar Naddaf, Joel Veness, Marc G. Bellemare and 
  *   the Reinforcement Learning and Artificial Intelligence Laboratory

--- a/src/games/supported/Frogger.cpp
+++ b/src/games/supported/Frogger.cpp
@@ -1,0 +1,111 @@
+/* *****************************************************************************
+ * The lines 61, 63, 116, 124 and 132 are based on Xitari's code, from Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 2
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * *****************************************************************************
+ * A.L.E (Arcade Learning Environment)
+ * Copyright (c) 2009-2013 by Yavar Naddaf, Joel Veness, Marc G. Bellemare and 
+ *   the Reinforcement Learning and Artificial Intelligence Laboratory
+ * Released under the GNU General Public License; see License.txt for details. 
+ *
+ * Based on: Stella  --  "An Atari 2600 VCS Emulator"
+ * Copyright (c) 1995-2007 by Bradford W. Mott and the Stella team
+ *
+ * *****************************************************************************
+ */
+#include "Frogger.hpp"
+
+#include "../RomUtils.hpp"
+
+FroggerSettings::FroggerSettings() {
+    reset();
+}
+
+/* create a new instance of the rom */
+RomSettings* FroggerSettings::clone() const { 
+    RomSettings* rval = new FroggerSettings();
+    *rval = *this;
+    return rval;
+}
+
+
+/* process the latest information from ALE */
+void FroggerSettings::step(const System& system) {
+    // update the reward
+    int score = getDecimalScore(0xCE, 0xCC, &system);
+    int reward = score - m_score;
+    m_reward = reward;
+    m_score = score;
+
+    // update terminal status
+	m_lives = readRam(&system, 0xD0);
+    m_terminal = readRam(&system, 0xD0) == 0xFF;
+}
+
+
+/* is end of game */
+bool FroggerSettings::isTerminal() const {
+    return m_terminal;
+};
+
+
+/* get the most recently observed reward */
+reward_t FroggerSettings::getReward() const { 
+    return m_reward; 
+}
+
+/* is an action part of the minimal set? */
+bool FroggerSettings::isMinimal(const Action &a) const {
+    switch (a) {
+        case PLAYER_A_NOOP:
+        case PLAYER_A_UP:
+        case PLAYER_A_RIGHT:
+        case PLAYER_A_LEFT:
+        case PLAYER_A_DOWN:
+            return true;
+        default:
+            return false;
+    }   
+}
+
+
+/* reset the state of the game */
+void FroggerSettings::reset() {
+    m_reward   = 0;
+    m_score    = 0;
+    m_terminal = false;
+    m_lives    = 4;
+}
+        
+/* saves the state of the rom settings */
+void FroggerSettings::saveState(Serializer & ser) {
+  ser.putInt(m_reward);
+  ser.putInt(m_score);
+  ser.putBool(m_terminal);
+  ser.putInt(m_lives);
+}
+
+// loads the state of the rom settings
+void FroggerSettings::loadState(Deserializer & ser) {
+  m_reward = ser.getInt();
+  m_score = ser.getInt();
+  m_terminal = ser.getBool();
+  m_lives = ser.getInt();
+}
+
+ActionVect FroggerSettings::getStartingActions() {
+    ActionVect startingActions;
+    startingActions.push_back(RESET);
+    return startingActions;
+}

--- a/src/games/supported/Frogger.hpp
+++ b/src/games/supported/Frogger.hpp
@@ -1,0 +1,79 @@
+/* *****************************************************************************
+ * The lines 67 and 74 are based on Xitari's code, from Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 2
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * *****************************************************************************
+ * A.L.E (Arcade Learning Environment)
+ * Copyright (c) 2009-2013 by Yavar Naddaf, Joel Veness, Marc G. Bellemare and 
+ *   the Reinforcement Learning and Artificial Intelligence Laboratory
+ * Released under the GNU General Public License; see License.txt for details. 
+ *
+ * Based on: Stella  --  "An Atari 2600 VCS Emulator"
+ * Copyright (c) 1995-2007 by Bradford W. Mott and the Stella team
+ *
+ * *****************************************************************************
+ */
+#ifndef __FROGGER_HPP__
+#define __FROGGER_HPP__
+
+#include "../RomSettings.hpp"
+
+
+/* RL wrapper for Frogger */
+class FroggerSettings : public RomSettings {
+    public:
+        FroggerSettings();
+
+        // reset
+        void reset();
+
+        // is end of game
+        bool isTerminal() const;
+
+        // get the most recently observed reward
+        reward_t getReward() const;
+
+        // the rom-name
+		// MD5 081e2c114c9c20b61acf25fc95c71bf4
+        const char* rom() const { return "frogger"; }
+
+        // create a new instance of the rom
+        RomSettings* clone() const;
+
+        // is an action part of the minimal set?
+        bool isMinimal(const Action& a) const;
+
+        // process the latest information from ALE
+        void step(const System& system);
+        
+        // saves the state of the rom settings
+        void saveState(Serializer & ser);
+    
+        // loads the state of the rom settings
+        void loadState(Deserializer & ser);
+
+        // Frogger requires the RESET action to start the game
+        ActionVect getStartingActions();
+
+        virtual const int lives() { return isTerminal() ? 0 : m_lives; }
+
+    private:
+        bool m_terminal;
+        reward_t m_reward;
+        reward_t m_score;
+        int m_lives;
+};
+
+#endif // __FROGGER_HPP__
+

--- a/src/games/supported/Frogger.hpp
+++ b/src/games/supported/Frogger.hpp
@@ -1,19 +1,4 @@
 /* *****************************************************************************
- * The lines 67 and 74 are based on Xitari's code, from Google Inc.
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License version 2
- * as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
- * *****************************************************************************
  * A.L.E (Arcade Learning Environment)
  * Copyright (c) 2009-2013 by Yavar Naddaf, Joel Veness, Marc G. Bellemare and 
  *   the Reinforcement Learning and Artificial Intelligence Laboratory


### PR DESCRIPTION
Full support for the game Frogger.  The ROM file `frogger.bin` has the following information:
```
  Cart Name:       Frogger (1982) (Parker Bros)
  Cart MD5:        081e2c114c9c20b61acf25fc95c71bf4
  Controller 0:    Joystick in left port
  Controller 1:    Joystick in right port
  Display Format:  NTSC*
  Bankswitch Type: 4K* (4K) 
```

![Frogger screenshot](http://atariage.com/2600/screenshots/s_Frogger_2.png)