### PR TITLE
Add support for the game Lost Luggage.

### DIFF
--- a/src/games/Roms.cpp
+++ b/src/games/Roms.cpp
@@ -49,6 +49,7 @@
 #include "supported/Kangaroo.hpp"
 #include "supported/Krull.hpp"
 #include "supported/KungFuMaster.hpp"
+#include "supported/LostLuggage.hpp"
 #include "supported/MontezumaRevenge.hpp"
 #include "supported/MsPacman.hpp"
 #include "supported/NameThisGame.hpp"
@@ -115,6 +116,7 @@ static const RomSettings *roms[]  = {
     new KangarooSettings(),
     new KrullSettings(),
     new KungFuMasterSettings(),
+    new LostLuggageSettings(),
     new MontezumaRevengeSettings(),
     new MsPacmanSettings(),
     new NameThisGameSettings(),

--- a/src/games/module.mk
+++ b/src/games/module.mk
@@ -39,6 +39,7 @@ MODULE_OBJS := \
 	src/games/supported/Kangaroo.o \
 	src/games/supported/Krull.o \
 	src/games/supported/KungFuMaster.o \
+	src/games/supported/LostLuggage.o \
 	src/games/supported/MontezumaRevenge.o \
 	src/games/supported/MsPacman.o \
 	src/games/supported/NameThisGame.o \

--- a/src/games/supported/LostLuggage.cpp
+++ b/src/games/supported/LostLuggage.cpp
@@ -70,6 +70,23 @@ bool LostLuggageSettings::isMinimal(const Action &a) const {
     }   
 }
 
+bool LostLuggageSettings::isLegal(const Action &a) const {
+  switch (a) {
+    // Don't allow pressing 'fire'
+    case PLAYER_A_FIRE:
+    case PLAYER_A_UPFIRE:
+    case PLAYER_A_DOWNFIRE:
+    case PLAYER_A_LEFTFIRE:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_UPLEFTFIRE:
+    case PLAYER_A_UPRIGHTFIRE:
+    case PLAYER_A_DOWNLEFTFIRE:
+    case PLAYER_A_DOWNRIGHTFIRE:
+      return false;
+    default:
+      return true;
+  }
+}
 
 /* reset the state of the game */
 void LostLuggageSettings::reset() {

--- a/src/games/supported/LostLuggage.cpp
+++ b/src/games/supported/LostLuggage.cpp
@@ -1,19 +1,4 @@
 /* *****************************************************************************
- * The lines 61, 102, 110 and 118 are based on Xitari's code, from Google Inc.
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License version 2
- * as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
- * *****************************************************************************
  * A.L.E (Arcade Learning Environment)
  * Copyright (c) 2009-2013 by Yavar Naddaf, Joel Veness, Marc G. Bellemare and 
  *   the Reinforcement Learning and Artificial Intelligence Laboratory

--- a/src/games/supported/LostLuggage.cpp
+++ b/src/games/supported/LostLuggage.cpp
@@ -1,0 +1,118 @@
+/* *****************************************************************************
+ * The lines 61, 102, 110 and 118 are based on Xitari's code, from Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 2
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * *****************************************************************************
+ * A.L.E (Arcade Learning Environment)
+ * Copyright (c) 2009-2013 by Yavar Naddaf, Joel Veness, Marc G. Bellemare and 
+ *   the Reinforcement Learning and Artificial Intelligence Laboratory
+ * Released under the GNU General Public License; see License.txt for details. 
+ *
+ * Based on: Stella  --  "An Atari 2600 VCS Emulator"
+ * Copyright (c) 1995-2007 by Bradford W. Mott and the Stella team
+ *
+ * *****************************************************************************
+ */
+#include "LostLuggage.hpp"
+
+#include "../RomUtils.hpp"
+
+LostLuggageSettings::LostLuggageSettings() {
+    reset();
+}
+
+/* create a new instance of the rom */
+RomSettings* LostLuggageSettings::clone() const { 
+    RomSettings* rval = new LostLuggageSettings();
+    *rval = *this;
+    return rval;
+}
+
+/* process the latest information from ALE */
+void LostLuggageSettings::step(const System& system) {
+    // update the reward
+    int score = getDecimalScore(0x96, 0x95, 0x94, &system);
+    int reward = score - m_score;
+    m_reward = reward;
+    m_score = score;
+
+    // update terminal status
+    m_lives = readRam(&system, 0xCA);
+    m_terminal = (m_lives == 0)
+        && readRam(&system, 0xC8) == 0x0A
+        && readRam(&system, 0xA5) == 0x00
+        && readRam(&system, 0xA9) == 0x00;
+}
+
+/* is end of game */
+bool LostLuggageSettings::isTerminal() const {
+    return m_terminal;
+};
+
+
+/* get the most recently observed reward */
+reward_t LostLuggageSettings::getReward() const { 
+    return m_reward; 
+}
+
+
+/* is an action part of the minimal set? */
+bool LostLuggageSettings::isMinimal(const Action &a) const {
+    switch (a) {
+        case PLAYER_A_NOOP:
+        case PLAYER_A_UP:
+        case PLAYER_A_RIGHT:
+        case PLAYER_A_LEFT:
+        case PLAYER_A_DOWN:
+        case PLAYER_A_UPRIGHT:
+        case PLAYER_A_UPLEFT:
+        case PLAYER_A_DOWNRIGHT:
+        case PLAYER_A_DOWNLEFT:
+            return true;
+        default:
+            return false;
+    }   
+}
+
+
+/* reset the state of the game */
+void LostLuggageSettings::reset() {
+    m_reward   = 0;
+    m_score    = 0;
+    m_terminal = false;
+    m_lives    = 3;
+}
+        
+/* saves the state of the rom settings */
+void LostLuggageSettings::saveState(Serializer & ser) {
+  ser.putInt(m_reward);
+  ser.putInt(m_score);
+  ser.putBool(m_terminal);
+  ser.putInt(m_lives);
+}
+
+// loads the state of the rom settings
+void LostLuggageSettings::loadState(Deserializer & ser) {
+  m_reward = ser.getInt();
+  m_score = ser.getInt();
+  m_terminal = ser.getBool();
+  m_lives = ser.getInt();
+}
+
+ActionVect LostLuggageSettings::getStartingActions() {
+    ActionVect startingActions;
+    startingActions.push_back(RESET);
+    return startingActions;
+}
+

--- a/src/games/supported/LostLuggage.hpp
+++ b/src/games/supported/LostLuggage.hpp
@@ -1,0 +1,78 @@
+/* *****************************************************************************
+ * The lines 70 and 77 are based on Xitari's code, from Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 2
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * *****************************************************************************
+ * A.L.E (Arcade Learning Environment)
+ * Copyright (c) 2009-2013 by Yavar Naddaf, Joel Veness, Marc G. Bellemare and 
+ *   the Reinforcement Learning and Artificial Intelligence Laboratory
+ * Released under the GNU General Public License; see License.txt for details. 
+ *
+ * Based on: Stella  --  "An Atari 2600 VCS Emulator"
+ * Copyright (c) 1995-2007 by Bradford W. Mott and the Stella team
+ *
+ * *****************************************************************************
+ */
+#ifndef __LOSTLUGGAGE_HPP__
+#define __LOSTLUGGAGE_HPP__
+
+#include "../RomSettings.hpp"
+
+/* RL wrapper for Lost Luggage */
+class LostLuggageSettings : public RomSettings {
+    public:
+        LostLuggageSettings();
+
+        // reset
+        void reset();
+
+        // is end of game
+        bool isTerminal() const;
+
+        // get the most recently observed reward
+        reward_t getReward() const;
+
+        // the rom-name
+		// MD5 7c00e7a205d3fda98eb20da7c9c50a55
+        const char* rom() const { return "lostluggage"; }
+
+        // create a new instance of the rom
+        RomSettings* clone() const;
+
+        // is an action part of the minimal set?
+        bool isMinimal(const Action& a) const;
+
+        // process the latest information from ALE
+        void step(const System& system);
+
+        // saves the state of the rom settings
+        void saveState(Serializer & ser);
+    
+        // loads the state of the rom settings
+        void loadState(Deserializer & ser);
+
+        // LostLuggage requires the fire action to start the game
+        ActionVect getStartingActions();
+
+        virtual const int lives() { return isTerminal() ? 0 : m_lives; }
+
+    private:
+        bool m_terminal;
+        reward_t m_reward;
+        reward_t m_score;
+        int m_lives;
+};
+
+#endif // __LOSTLUGGAGE_HPP__
+

--- a/src/games/supported/LostLuggage.hpp
+++ b/src/games/supported/LostLuggage.hpp
@@ -1,19 +1,4 @@
 /* *****************************************************************************
- * The lines 70 and 77 are based on Xitari's code, from Google Inc.
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License version 2
- * as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
- * *****************************************************************************
  * A.L.E (Arcade Learning Environment)
  * Copyright (c) 2009-2013 by Yavar Naddaf, Joel Veness, Marc G. Bellemare and 
  *   the Reinforcement Learning and Artificial Intelligence Laboratory

--- a/src/games/supported/LostLuggage.hpp
+++ b/src/games/supported/LostLuggage.hpp
@@ -38,6 +38,9 @@ class LostLuggageSettings : public RomSettings {
         // is an action part of the minimal set?
         bool isMinimal(const Action& a) const;
 
+		// FIRE resets the game, prevent this
+        bool isLegal(const Action& a) const;
+
         // process the latest information from ALE
         void step(const System& system);
 


### PR DESCRIPTION
The ROM file is `lostluggage.bin`, with the following information:

```
  Cart Name:       Lost Luggage (1981) (Apollo)
  Cart MD5:        7c00e7a205d3fda98eb20da7c9c50a55
  Controller 0:    Joystick in left port
  Controller 1:    Joystick in right port
  Display Format:  NTSC*
  Bankswitch Type: 4K* (4K) 
```

The lives are handled slightly non-standard in this game: with one life (luggage icon in the bottom left) remaining the game ends if you miss a luggage piece.  Is there any guidance on how this should be handled?  (I can subtract 1 of course but the current commit just outputs the in-game display of lives.)

![Lost Luggage screenshot](http://www.8-bitcentral.com/images/reviews/atari2600/lostLuggage2600Screen.jpg)