### PR TITLE
Add support for the game Sir Lancelot.

### DIFF
--- a/src/games/Roms.cpp
+++ b/src/games/Roms.cpp
@@ -62,6 +62,7 @@
 #include "supported/RoadRunner.hpp"
 #include "supported/RoboTank.hpp"
 #include "supported/Seaquest.hpp"
+#include "supported/SirLancelot.hpp"
 #include "supported/Skiing.hpp"
 #include "supported/Solaris.hpp"
 #include "supported/SpaceInvaders.hpp"
@@ -128,6 +129,7 @@ static const RomSettings *roms[]  = {
     new RoadRunnerSettings(),
     new RoboTankSettings(),
     new SeaquestSettings(),
+    new SirLancelotSettings(),
     new SkiingSettings(),
     new SolarisSettings(),
     new SpaceInvadersSettings(),

--- a/src/games/module.mk
+++ b/src/games/module.mk
@@ -52,6 +52,7 @@ MODULE_OBJS := \
 	src/games/supported/RoadRunner.o \
 	src/games/supported/RoboTank.o \
 	src/games/supported/Seaquest.o \
+	src/games/supported/SirLancelot.o \
 	src/games/supported/Skiing.o \
 	src/games/supported/Solaris.o \
 	src/games/supported/SpaceInvaders.o \

--- a/src/games/supported/SirLancelot.cpp
+++ b/src/games/supported/SirLancelot.cpp
@@ -1,19 +1,4 @@
 /* *****************************************************************************
- * The lines 61, 102, 110 and 118 are based on Xitari's code, from Google Inc.
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License version 2
- * as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
- * *****************************************************************************
  * A.L.E (Arcade Learning Environment)
  * Copyright (c) 2009-2013 by Yavar Naddaf, Joel Veness, Marc G. Bellemare and 
  *   the Reinforcement Learning and Artificial Intelligence Laboratory

--- a/src/games/supported/SirLancelot.cpp
+++ b/src/games/supported/SirLancelot.cpp
@@ -1,0 +1,118 @@
+/* *****************************************************************************
+ * The lines 61, 102, 110 and 118 are based on Xitari's code, from Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 2
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * *****************************************************************************
+ * A.L.E (Arcade Learning Environment)
+ * Copyright (c) 2009-2013 by Yavar Naddaf, Joel Veness, Marc G. Bellemare and 
+ *   the Reinforcement Learning and Artificial Intelligence Laboratory
+ * Released under the GNU General Public License; see License.txt for details. 
+ *
+ * Based on: Stella  --  "An Atari 2600 VCS Emulator"
+ * Copyright (c) 1995-2007 by Bradford W. Mott and the Stella team
+ *
+ * *****************************************************************************
+ */
+#include "SirLancelot.hpp"
+
+#include "../RomUtils.hpp"
+
+
+SirLancelotSettings::SirLancelotSettings() {
+    reset();
+}
+
+
+/* create a new instance of the rom */
+RomSettings* SirLancelotSettings::clone() const { 
+    RomSettings* rval = new SirLancelotSettings();
+    *rval = *this;
+    return rval;
+}
+
+
+/* process the latest information from ALE */
+void SirLancelotSettings::step(const System& system) {
+    // update the reward
+    int score = getDecimalScore(0xA0, 0x9F, 0x9E, &system);
+    int reward = score - m_score;
+    m_reward = reward;
+    m_score = score;
+
+    // update terminal status
+	m_lives = readRam(&system, 0xA9);
+    m_terminal = (m_lives == 0) && readRam(&system, 0xA7) == 0xA0;
+}
+
+
+/* is end of game */
+bool SirLancelotSettings::isTerminal() const {
+    return m_terminal;
+};
+
+
+/* get the most recently observed reward */
+reward_t SirLancelotSettings::getReward() const { 
+    return m_reward; 
+}
+
+
+/* is an action part of the minimal set? */
+bool SirLancelotSettings::isMinimal(const Action &a) const {
+    switch (a) {
+        case PLAYER_A_NOOP:
+        case PLAYER_A_FIRE:
+        case PLAYER_A_RIGHT:
+        case PLAYER_A_LEFT:
+        case PLAYER_A_RIGHTFIRE:
+        case PLAYER_A_LEFTFIRE:
+            return true;
+        default:
+            return false;
+    }   
+}
+
+
+/* reset the state of the game */
+void SirLancelotSettings::reset() {
+    m_reward   = 0;
+    m_score    = 0;
+    m_terminal = false;
+    m_lives    = 3;
+}
+        
+/* saves the state of the rom settings */
+void SirLancelotSettings::saveState(Serializer & ser) {
+  ser.putInt(m_reward);
+  ser.putInt(m_score);
+  ser.putBool(m_terminal);
+  ser.putInt(m_lives);
+}
+
+// loads the state of the rom settings
+void SirLancelotSettings::loadState(Deserializer & ser) {
+  m_reward = ser.getInt();
+  m_score = ser.getInt();
+  m_terminal = ser.getBool();
+  m_lives = ser.getInt();
+}
+
+ActionVect SirLancelotSettings::getStartingActions() {
+    ActionVect startingActions;
+    startingActions.push_back(RESET);
+    startingActions.push_back(PLAYER_A_LEFT);
+    return startingActions;
+}
+
+

--- a/src/games/supported/SirLancelot.hpp
+++ b/src/games/supported/SirLancelot.hpp
@@ -1,0 +1,79 @@
+/* *****************************************************************************
+ * The lines 70 and 77 are based on Xitari's code, from Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 2
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * *****************************************************************************
+ * A.L.E (Arcade Learning Environment)
+ * Copyright (c) 2009-2013 by Yavar Naddaf, Joel Veness, Marc G. Bellemare and 
+ *   the Reinforcement Learning and Artificial Intelligence Laboratory
+ * Released under the GNU General Public License; see License.txt for details. 
+ *
+ * Based on: Stella  --  "An Atari 2600 VCS Emulator"
+ * Copyright (c) 1995-2007 by Bradford W. Mott and the Stella team
+ *
+ * *****************************************************************************
+ */
+#ifndef __SIRLANCELOT_HPP__
+#define __SIRLANCELOT_HPP__
+
+#include "../RomSettings.hpp"
+
+
+/* RL wrapper for Up N Down */
+class SirLancelotSettings : public RomSettings {
+    public:
+        SirLancelotSettings();
+
+        // reset
+        void reset();
+
+        // is end of game
+        bool isTerminal() const;
+
+        // get the most recently observed reward
+        reward_t getReward() const;
+
+        // the rom-name
+		// MD5 7ead257e8b5a44cac538f5f54c7a0023
+        const char* rom() const { return "sirlancelot"; }
+
+        // create a new instance of the rom
+        RomSettings* clone() const;
+
+        // is an action part of the minimal set?
+        bool isMinimal(const Action& a) const;
+
+        // process the latest information from ALE
+        void step(const System& system);
+
+        // saves the state of the rom settings
+        void saveState(Serializer & ser);
+    
+        // loads the state of the rom settings
+        void loadState(Deserializer & ser);
+
+        // SirLancelot requires the reset+left action to start the game
+        ActionVect getStartingActions();
+
+        virtual const int lives() { return isTerminal() ? 0 : m_lives; }
+
+    private:
+        bool m_terminal;
+        reward_t m_reward;
+        reward_t m_score;
+        int m_lives;
+};
+
+#endif // __SIRLANCELOT_HPP__
+

--- a/src/games/supported/SirLancelot.hpp
+++ b/src/games/supported/SirLancelot.hpp
@@ -1,19 +1,4 @@
 /* *****************************************************************************
- * The lines 70 and 77 are based on Xitari's code, from Google Inc.
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License version 2
- * as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
- * *****************************************************************************
  * A.L.E (Arcade Learning Environment)
  * Copyright (c) 2009-2013 by Yavar Naddaf, Joel Veness, Marc G. Bellemare and 
  *   the Reinforcement Learning and Artificial Intelligence Laboratory


### PR DESCRIPTION
Sir Lancelot, ROM file `sirlancelot.bin`:

```
  Cart Name:       Sir Lancelot (1983) (Xonox) [a1]
  Cart MD5:        7ead257e8b5a44cac538f5f54c7a0023
  Controller 0:    Joystick in left port
  Controller 1:    Joystick in right port
  Display Format:  NTSC*
  Bankswitch Type: F8* (8K) 
```

![Sir Lancelot screenshot](http://www.mobygames.com/images/shots/l/94729-sir-lancelot-atari-2600-screenshot-each-battle-outside-the.png)