### PR TITLE
Quick and dirty compilation instructions

### DIFF
--- a/Readme.txt
+++ b/Readme.txt
@@ -15,6 +15,23 @@ Enjoy,
 The ALE team
 
 ===============================
+Quick start
+===============================
+
+Compilation:
+
+$ cmake -DUSE_SDL=ON -DUSE_RLGLUE=OFF -DBUILD_EXAMPLES=ON .
+$ make -j 4
+
+To install python module:
+
+$ pip install .
+or
+$ pip install --user .
+
+More instructions in the manual under doc/manual
+
+===============================
 List of command-line parameters
 ===============================
 


### PR DESCRIPTION
I compile ALE infrequently enough that I always forget which method it uses and forget where to look. The twin compilation systems don't help.

I think adding this instructions to Readme.txt could help other people too. Might be worth adding them in README.md too, but that one points to the manual already. The manual is a little bit too much for people who just want to compile and play though, so it might still be worth it. 

Thoughts?