### PR TITLE
Updated ale_python_interface for python3.

### DIFF
--- a/ale_python_interface/__init__.py
+++ b/ale_python_interface/__init__.py
@@ -1,1 +1,1 @@
-from ale_python_interface import *
+from .ale_python_interface import *

--- a/doc/examples/python_example.py
+++ b/doc/examples/python_example.py
@@ -9,13 +9,13 @@ from random import randrange
 from ale_python_interface import ALEInterface
 
 if len(sys.argv) < 2:
-  print 'Usage:', sys.argv[0], 'rom_file'
+  print('Usage: %s rom_file' % sys.argv[0])
   sys.exit()
 
 ale = ALEInterface()
 
 # Get & Set the desired settings
-ale.setInt('random_seed', 123)
+ale.setInt(b'random_seed', 123)
 
 # Set USE_SDL to true to display the screen. ALE must be compilied
 # with SDL enabled for this to work. On OSX, pygame init is used to
@@ -31,18 +31,19 @@ if USE_SDL:
   ale.setBool('display_screen', True)
 
 # Load the ROM file
-ale.loadROM(sys.argv[1])
+rom_file = str.encode(sys.argv[1])
+ale.loadROM(rom_file)
 
 # Get the list of legal actions
 legal_actions = ale.getLegalActionSet()
 
 # Play 10 episodes
-for episode in xrange(10):
+for episode in range(10):
   total_reward = 0
   while not ale.game_over():
     a = legal_actions[randrange(len(legal_actions))]
     # Apply an action and get the resulting reward
     reward = ale.act(a);
     total_reward += reward
-  print 'Episode', episode, 'ended with score:', total_reward
+  print('Episode %d ended with score: %d' % (episode, total_reward))
   ale.reset_game()

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,8 @@ import os.path, sys
 
 ale_c_lib = 'ale_python_interface/libale_c.so'
 if not os.path.isfile(ale_c_lib):
-  print 'ERROR: Unable to find required library: %s. Please ensure you\'ve '\
-    'built ALE using CMake.'%(ale_c_lib)
+  print('ERROR: Unable to find required library: %s. Please ensure you\'ve '\
+    'built ALE using CMake.'%(ale_c_lib))
   sys.exit()
 
 module1 = Extension('ale_python_interface.ale_c_wrapper',


### PR DESCRIPTION
Minimal updates required for python2/3 compatibility. I'm unhappy with having to append 'b' in front of strings when interacting with ale (e.g. ale.setInt(b'random_seed', 123)). Reason is because strings in python3 are unicode by default while ctypes expects a byte-encoded string (which used to be default in python 2.7). Adding the b prefix tells python3 to treat the string as bytes. Hopefully ctypes will be updated to play better with python3 unicode strings. Until then, I'm afraid we may be stuck with the b-prefixed strings. 

I've tested the PR on Ubuntu with python 2 and python 3. Both work fine, and pip install is working for both as well.