### PR TITLE
Generating pkg-config file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required (VERSION 2.6)
 project(ale)
 
+set(ALEVERSION "0.5dev_b")
+set(PACKAGE_NAME "Arcade Learning Environment")
+
 option(USE_SDL "Use SDL" OFF)
 option(USE_RLGLUE "Use RL-Glue" OFF)
 option(BUILD_EXAMPLES "Build Example Agents" ON)
@@ -93,8 +96,8 @@ if(BUILD_EXAMPLES)
   target_link_libraries(sharedLibraryInterfaceExample ale)
   target_link_libraries(sharedLibraryInterfaceExample ${LINK_LIBS})
   add_dependencies(sharedLibraryInterfaceExample ale-lib)
-  
-  # Fifo interface example. 
+
+  # Fifo interface example.
   link_directories(${CMAKE_CURRENT_SOURCE_DIR})
   add_executable(fifoInterfaceExample ${CMAKE_CURRENT_SOURCE_DIR}/doc/examples/fifoInterfaceExample.cpp)
   set_target_properties(fifoInterfaceExample PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/doc/examples)
@@ -124,3 +127,7 @@ if(USE_RLGLUE)
   target_link_libraries(RLGlueExperiment rlexperiment)
   target_link_libraries(RLGlueExperiment rlgluenetdev)
 endif()
+
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/libale.pc.in
+  ${CMAKE_CURRENT_SOURCE_DIR}/libale.pc @ONLY)

--- a/libale.pc.in
+++ b/libale.pc.in
@@ -1,0 +1,6 @@
+Name: @PACKAGE_NAME@
+Description: The Arcade Learning Environment (ALE) - a platform for AI research.
+URL: http://www.arcadelearningenvironment.org/
+Version: @ALEVERSION@
+Libs: -L@CMAKE_CURRENT_SOURCE_DIR@ -lale -lz -lm
+Cflags: -I@SOURCE_DIR@


### PR DESCRIPTION
This pull requests adds the ability to generate a [pkg-config](https://people.freedesktop.org/~dbn/pkg-config-guide.html) file. Pkg-config simplifies the compilation process by providing the user with the ability to obtain the correct cflags and ldflags. In my case, this results in:

```
$ pkg-config --cflags --libs libale
 -I/home/pierre-luc/workspace/Arcade-Learning-Environment/src  -L/home/pierre- luc/workspace/Arcade-   Learning-Environment -lale -lz -lm
```

Running `cmake CMakelists.txt` with the following changes will automatically create a `libale.pc` from the `libale.pc.in` template. `.pc` files are usually installed somewhere under `/usr/lib/pkgconfig` but since the the current `CMakeLists.txt` lacks install targets, `libale.pc` will simply stay at the root of the source directory. 

In this case, the user can still use the `.pc` file by setting the `PKG_CONFIG_PATH` environment variable. In my case, something like: 

```
$ export PKG_CONFIG_PATH=$HOME/workspace/Arcade-Learning-Environment
```

or upon calling `make` or `gcc`:

```
$ PKG_CONFIG_PATH=$HOME/workspace/Arcade-Learning-Environment make 
```

where `make` here reads a Makefile which uses `pkg-config`. 

On line 4 of `CMakeLists.txt`, I added a variable `ALEVERSION` which is then used in the `.pc.in` template. Note that ideally, we could extract the version number automatically from the `ChangeLog` using a `STRING (REGEX MATCH ...)` cmake command. I try to write this but had no luck to get cmake to understand my regex. Note that just making sure to maintain version numbers in synced between `CMakeLists.txt` and `ChangeLog` would also be a valid solution. It just requires a bit more human involvement. In any cases, unless the user really structure his or her compilation pipeline in such a way that it depends heavily on `pkg-config --modversion`, having an out-of-synced version number should have no consequence. 

I recently wrote a Python wrapper for @mcmachado "shallow" features. Having such a pkg-config feature would make it easier not to hardcode absolutes paths into the `setup.py`. 

The proposed change is expected to work on all platforms, with or without pkg-config. The `.in` business purely depends on `cmake` and does not require `pkg-config` to be installed. 
