### PR TITLE
Set config properties with __setitem__ and type dispatching

### DIFF
--- a/ale_python_interface/ale_python_interface.py
+++ b/ale_python_interface/ale_python_interface.py
@@ -93,6 +93,10 @@ ale_lib.decodeState.restype = c_void_p
 class ALEInterface(object):
     def __init__(self):
         self.obj = ale_lib.ALE_new()
+        self.props_setters = {float:self.setFloat,
+                int:self.setInt,
+                bool:self.setBool,
+                str:self.setString}
 
     def getString(self, key):
         return ale_lib.getString(self.obj, key)
@@ -111,6 +115,11 @@ class ALEInterface(object):
       ale_lib.setBool(self.obj, key, value)
     def setFloat(self, key, value):
       ale_lib.setFloat(self.obj, key, value)
+
+    def __setitem__(self, key, value):
+        if type(value) not in self.props_setters:
+            raise TypeError
+        self.props_setters[type(value)](key, value)
 
     def loadROM(self, rom_file):
         ale_lib.loadROM(self.obj, rom_file)


### PR DESCRIPTION
The proposed change adds the ability to configure ALE using  [`__setitem__`](https://docs.python.org/2/reference/datamodel.html#object.__setitem__).

The typed nature of C++ has probably motivated the need to write dedicated "setFloat/setInt/setString/setBool" functions. However, a unified access to these methods can be provided in python using dynamic type dispatching. The proposed changes simply checks for the type of the value argument and calls the corresponding setter in the C API. 

Here's an example of the proposed change in action:

```
from ale_python_interface import ale_python_interface as ALE

ale = ALE.ALEInterface()

ale[b'random_seed'] = 2468
ale[b'frame_skip'] = 5
ale[b'color_averaging'] = True

print(ale.getInt(b'random_seed'))
```

which in this case just prints `2468`. Note that the corresponding [`__getitem__`](https://docs.python.org/2/reference/datamodel.html#object.__getitem__) could also be provided. However, it is difficult to implement type dispatching since the type couldn't be inferred from the value (which is the return type, and not an argument anymore). Ideally, `Settings.hxx` should expose all of the available configuration keys and their associated types. The python interface could then read the header and perform the appropriate type dispatching. 

The proposed changes have no effect on the existing interface other than adding a new function. All of the existing functions remain untouched and there should be no backwards compatibility issues. 
