### PR TITLE
Automatic handling of str differences in Python 2 vs 3

### DIFF
--- a/ale_python_interface/ale_python_interface.py
+++ b/ale_python_interface/ale_python_interface.py
@@ -7,6 +7,12 @@ from ctypes import *
 import numpy as np
 from numpy.ctypeslib import as_ctypes
 import os
+import sys
+
+if sys.version_info < (3,):
+     tobytes = lambda s: s
+else:
+     tobytes = lambda s: bytes(s, 'UTF-8')
 
 ale_lib = cdll.LoadLibrary(os.path.join(os.path.dirname(__file__),
                                         'libale_c.so'))
@@ -95,22 +101,22 @@ class ALEInterface(object):
         self.obj = ale_lib.ALE_new()
 
     def getString(self, key):
-        return ale_lib.getString(self.obj, key)
+        return ale_lib.getString(self.obj, tobytes(key))
     def getInt(self, key):
-        return ale_lib.getInt(self.obj, key)
+        return ale_lib.getInt(self.obj, tobytes(key))
     def getBool(self, key):
-        return ale_lib.getBool(self.obj, key)
+        return ale_lib.getBool(self.obj, tobytes(key))
     def getFloat(self, key):
-        return ale_lib.getFloat(self.obj, key)
+        return ale_lib.getFloat(self.obj, tobytes(key))
 
     def setString(self, key, value):
-      ale_lib.setString(self.obj, key, value)
+      ale_lib.setString(self.obj, tobytes(key), tobytes(value))
     def setInt(self, key, value):
-      ale_lib.setInt(self.obj, key, value)
+      ale_lib.setInt(self.obj, tobytes(key), value)
     def setBool(self, key, value):
-      ale_lib.setBool(self.obj, key, value)
+      ale_lib.setBool(self.obj, tobytes(key), value)
     def setFloat(self, key, value):
-      ale_lib.setFloat(self.obj, key, value)
+      ale_lib.setFloat(self.obj, tobytes(key), value)
 
     def loadROM(self, rom_file):
         ale_lib.loadROM(self.obj, rom_file)


### PR DESCRIPTION
The proposed changes are meant to blur the distinctions between string types in Python 2 and 3. In this way, we can avoid explicit use of the `b''` literal from Python 3.

Note that a dedicated module such as [six](https://pypi.python.org/pypi/six) could have been used for this task. However, in order to avoid adding more dependencies, I chose to write a custom solution. 

The solution consists in checking the Python version from `sys`. In the case of Python 2, string types correspond to `bytes` unless `unicode`  types are used explicitly. Note that the `bytes` type corresponds to the `c_char_p` ctype which is used in this wrapper.  If we are under Python 3, since strings are by default in unicode, we need to use the `bytes(s, 'UTF-8')` conversion. 

The following code should work under both Python 2 and 3:

```
from ale_python_interface import ale_python_interface as ALE

ale = ALE.ALEInterface()

ale.setInt('random_seed', 2468)
ale.setBool('color_averaging', True)
ale.setFloat('repeat_action_probability', 0.1)
ale.setString('record_screen_dir', '/out')

print(ale.getInt('random_seed'),
    ale.getBool('color_averaging'),
    ale.getFloat('repeat_action_probability'),
    ale.getString('record_screen_dir'))
```

Under Python 2:

```
$ /usr/bin/python2.7 example.py 
A.L.E: Arcade Learning Environment (version 0.5.1)
[Powered by Stella]
Use -help for help screen.
(2468, True, 0.10000000149011612, '/out')
```

Under Python 3:

```
$ /usr/bin/python3.4 example.py 
A.L.E: Arcade Learning Environment (version 0.5.1)
[Powered by Stella]
Use -help for help screen.
(2468, True, 0.10000000149011612, '/out')
```
