### PR TITLE
Avoid spurious imports

### DIFF
--- a/ale_python_interface/__init__.py
+++ b/ale_python_interface/__init__.py
@@ -1,1 +1,3 @@
-from .ale_python_interface import *
+from .ale_python_interface import ALEInterface
+
+__all__ = ['ALEInterface']


### PR DESCRIPTION
This PR avoids the spurious imports (such as `ale_lib` in `ale_python_interface.py`) that can take place through `*` in `__init__.py`. The `__all__` directive has also be added to `__init__.py` in accordance with its intended [semantics](https://docs.python.org/2/tutorial/modules.html#importing-from-a-package). 

With `__all__`, the following becomes valid:

```
from ale_python_interface import *
ale = ALEInterface()
```

as well as :

```
from ale_python_interface import ALEInterface
ale = ALEInterface()
```