### PR TITLE
Avoid spurious imports

### DIFF
--- a/ale_python_interface/ale_python_interface.py
+++ b/ale_python_interface/ale_python_interface.py
@@ -2,6 +2,7 @@
 # Author: Ben Goodrich
 # This directly implements a python version of the arcade learning
 # environment interface.
+__all__ = ['ALEInterface']
 
 from ctypes import *
 import numpy as np


### PR DESCRIPTION
This PR avoids the spurious imports (such as ale_lib in ale_python_interface.py) that can take place through `*`. The `__all__` [directive](https://docs.python.org/2/tutorial/modules.html#importing-from-a-package) allows us to only expose `ALEInterface`, which is the only object of interest to the user.

All of the following variants on `import` should work:

```
from ale_python_interface import ALEInterface
from ale_python_interface.ale_python_interface import ALEInterface
from ale_python_interface.ale_python_interface import *

print(ALEInterface)
print(ale_lib)
```

And result in :
```
$ python test.py 
<class 'ale_python_interface.ale_python_interface.ALEInterface'>
Traceback (most recent call last):
  File "configdict.py", line 6, in <module>
    print(ale_lib)
NameError: name 'ale_lib' is not defined
```

Note that the `NameError` is the expected behavior, since `ale_lib` (from `ale_python_interface.py`) should not be exposed in the imports. 