### PR TITLE
Added missing minimal actions to Pong

### DIFF
--- a/src/games/supported/Pong.cpp
+++ b/src/games/supported/Pong.cpp
@@ -64,8 +64,11 @@ bool PongSettings::isMinimal(const Action &a) const {
 
     switch (a) {
         case PLAYER_A_NOOP:
+        case PLAYER_A_FIRE:
         case PLAYER_A_RIGHT:
         case PLAYER_A_LEFT:
+        case PLAYER_A_RIGHTFIRE:
+        case PLAYER_A_LEFTFIRE:
             return true;
         default:
             return false;


### PR DESCRIPTION
The game 'Pong' (really, 'Video Olympics') was missing the fire button as part of its set of minimal actions. This will affects backward reproducibility somewhat, but most algorithms shouldn't be too affected by this change.