### PR TITLE
Avoid build noise in versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,11 @@
+## ALE
+
+ale
+build
+doc/examples/*Example
+
+## Generic
+
 # Emacs temp files
 *~
 .*

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ The Arcade Learning Environment (ALE) -- a platform for AI research.
 ### To compile:
 
 ```
-$ cmake -DUSE_SDL=ON -DUSE_RLGLUE=OFF -DBUILD_EXAMPLES=ON .
+$ mkdir build && cd build
+$ cmake -DUSE_SDL=ON -DUSE_RLGLUE=OFF -DBUILD_EXAMPLES=ON ..
 $ make -j 4
 ```
 


### PR DESCRIPTION
In ALE master compiling the project generates a number of outputs, like the CMake build files and the `ale` binary itself, that can interfere with hacking on ALE and versioning changes.

For my work I decided to git ignore these generated files and use a build dir to keep the CMake files. This way I don't accidentally commit these generated outputs and I dont see the dirty status in my projects that include ALE. I thought I'd send a PR in case you think this is more convenient too.

Thanks for ALE!