### PR TITLE
Fixed getScreenRGB, was not sending all three channels.

### DIFF
--- a/src/ale_interface.cpp
+++ b/src/ale_interface.cpp
@@ -259,7 +259,7 @@ void ALEInterface::getScreenGrayscale(std::vector<unsigned char>& grayscale_outp
   size_t screen_size = w*h;
   
   pixel_t *ale_screen_data = environment->getScreen().getArray();
-  theOSystem->colourPalette().applyPaletteGrayscale(grayscale_output_buffer, ale_screen_data, screen_size);
+  theOSystem->colourPalette().applyPaletteGrayscale(grayscale_output_buffer, ale_screen_data, screen_size*3);
 }
 
 //This method should receive a vector to fill it with
@@ -272,7 +272,7 @@ void ALEInterface::getScreenRGB(std::vector<unsigned char>& output_rgb_buffer){
 
   pixel_t *ale_screen_data = environment->getScreen().getArray();
 
-  theOSystem->colourPalette().applyPaletteRGB(output_rgb_buffer, ale_screen_data, screen_size);
+  theOSystem->colourPalette().applyPaletteRGB(output_rgb_buffer, ale_screen_data, screen_size*3);
 }
 
 // Returns the current RAM content

--- a/src/ale_interface.cpp
+++ b/src/ale_interface.cpp
@@ -259,7 +259,7 @@ void ALEInterface::getScreenGrayscale(std::vector<unsigned char>& grayscale_outp
   size_t screen_size = w*h;
   
   pixel_t *ale_screen_data = environment->getScreen().getArray();
-  theOSystem->colourPalette().applyPaletteGrayscale(grayscale_output_buffer, ale_screen_data, screen_size*3);
+  theOSystem->colourPalette().applyPaletteGrayscale(grayscale_output_buffer, ale_screen_data, screen_size);
 }
 
 //This method should receive a vector to fill it with
@@ -272,7 +272,7 @@ void ALEInterface::getScreenRGB(std::vector<unsigned char>& output_rgb_buffer){
 
   pixel_t *ale_screen_data = environment->getScreen().getArray();
 
-  theOSystem->colourPalette().applyPaletteRGB(output_rgb_buffer, ale_screen_data, screen_size*3);
+  theOSystem->colourPalette().applyPaletteRGB(output_rgb_buffer, ale_screen_data, screen_size * 3);
 }
 
 // Returns the current RAM content

--- a/src/common/ColourPalette.cpp
+++ b/src/common/ColourPalette.cpp
@@ -88,7 +88,7 @@ void ColourPalette::applyPaletteRGB(std::vector<unsigned char>& dst_buffer, uInt
 
     uInt8 *p = src_buffer;
 
-    for(size_t i = 0; i < src_size; i += 3, p++){
+    for(size_t i = 0; i < src_size * 3; i += 3, p++){
         int rgb = m_palette[*p];
         dst_buffer[i+0] = (unsigned char) ((rgb >> 16));    // r
         dst_buffer[i+1] = (unsigned char) ((rgb >>  8));    // g


### PR DESCRIPTION
getScreenRGB was only sending the first third of pixels to the buffer because it did not multiply the screen size by the number of channels (3 in case of RGB). Fixed.