### PR TITLE
Make StellaEnvironment::isTerminal and ALEInterface::game_over const

### DIFF
--- a/src/ale_interface.cpp
+++ b/src/ale_interface.cpp
@@ -188,9 +188,8 @@ void ALEInterface::reset_game() {
 }
 
 // Indicates if the game has ended.
-bool ALEInterface::game_over() {
-  return (environment->isTerminal() ||
-          (max_num_frames > 0 && getEpisodeFrameNumber() >= max_num_frames));
+bool ALEInterface::game_over() const {
+  return environment->isTerminal();
 }
 
 // The remaining number of lives.
@@ -242,7 +241,7 @@ int ALEInterface::getFrameNumber() {
 }
 
 // Returns the frame number since the start of the current episode
-int ALEInterface::getEpisodeFrameNumber() {
+int ALEInterface::getEpisodeFrameNumber() const {
   return environment->getEpisodeFrameNumber();
 }
 

--- a/src/ale_interface.hpp
+++ b/src/ale_interface.hpp
@@ -82,7 +82,7 @@ public:
   reward_t act(Action action);
 
   // Indicates if the game has ended.
-  bool game_over();
+  bool game_over() const;
 
   // Resets the game, but not the full system.
   void reset_game();
@@ -102,7 +102,7 @@ public:
   const int lives();
 
   // Returns the frame number since the start of the current episode
-  int getEpisodeFrameNumber();
+  int getEpisodeFrameNumber() const;
 
   // Returns the current game screen
   const ALEScreen &getScreen();

--- a/src/environment/stella_environment.cpp
+++ b/src/environment/stella_environment.cpp
@@ -189,7 +189,7 @@ reward_t StellaEnvironment::oneStepAct(Action player_a_action, Action player_b_a
   return m_settings->getReward();
 }
 
-bool StellaEnvironment::isTerminal() {
+bool StellaEnvironment::isTerminal() const {
   return (m_settings->isTerminal() || 
     (m_max_num_frames_per_episode > 0 && 
      m_state.getEpisodeFrameNumber() >= m_max_num_frames_per_episode));

--- a/src/environment/stella_environment.hpp
+++ b/src/environment/stella_environment.hpp
@@ -65,7 +65,7 @@ class StellaEnvironment {
     reward_t act(Action player_a_action, Action player_b_action);
 
     /** Returns true once we reach a terminal state */
-    bool isTerminal();
+    bool isTerminal() const;
 
     /** Accessor methods for the environment state. */
     void setState(const ALEState & state);


### PR DESCRIPTION
It came up when I was using ALEInterface in an old MDP class. Not very useful but it costs little effort.

Also removed unnecessary duplicate checks on ALEInterface::game_over