### PR TITLE
Default color averaging to false, making observations single frames

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+Inter-release notes:
+  * color_averaging is now off by default so that environment observations correspond to emulator frames unless requested otherwise.
+
 October 4th, 2015. ALE 0.5dev_b.
   * Enforce flags existence (@mcmachado).
   * Fix RNG issues introduced in 0.5.0.

--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -422,13 +422,13 @@ is preserved.
 This functionality is provided in the fifo, shared library and CTypes interfaces. The shared
 library interface additionally provides state cloning/restoring capabilities.
 
-\subsection{Colour Averaging}
+\subsection{Color Averaging}
 
 Many Atari 2600 games display objects on alternating frames (sometimes even less frequently).
-This can be an issue for agents that do not consider the whole screen history. By default, 
-\emph{colour averaging} is not enabled. If enabled, the environment output (as observed by agents)
-is a weighted blend of the last two frames. This behaviour can be turned on using the
-command--line argument \verb+-color_averaging+ (or the \verb+setBool+ function).
+This can be an issue for agents that do not consider the whole screen history.
+By default, \emph{color averaging} is not enabled, that is, the environment output is the actual frame from the emulator.
+If enabled, the environment output (as observed by agents) is a weighted blend of the last two frames.
+This behaviour can be turned on using the command--line argument \verb+-color_averaging+ (or the \verb+setBool+ function).
 
 \subsection{Action Repeat Stochasticity}
 

--- a/src/emucore/Settings.cxx
+++ b/src/emucore/Settings.cxx
@@ -704,7 +704,7 @@ void Settings::setDefaultSettings() {
     // Environment customization settings
     boolSettings.insert(pair<string, bool>("restricted_action_set", false));
     intSettings.insert(pair<string, int>("random_seed", 0));
-    boolSettings.insert(pair<string, bool>("color_averaging", true));
+    boolSettings.insert(pair<string, bool>("color_averaging", false));
     boolSettings.insert(pair<string, bool>("send_rgb", false));
     intSettings.insert(pair<string, int>("frame_skip", 1));
     floatSettings.insert(pair<string, float>("repeat_action_probability", 0.25));


### PR DESCRIPTION
This turns off color averaging by default.

By default, and counter to the documentation, ALE blends frames together to make environment observations. I would like to argue that it is better to define an observation as a single frame by default as it more closely corresponds to the "true" emulator screen. This is the approach taken by deepmind/xitari for instance, and it might be nice to align settings in this case to help avoid fragmentation.

I was burned by this misdocumented default, rendering certain experiments less than perfectly comparable, so I'm sending this PR in case it is accepted and helps others avoid this issue.

I included a slight doc change and a changelog notice in case these are helpful and desired, but I could leave these out too if you prefer.

This is an opinionated PR, but it is made with the best intention. Thanks for the ALE!