### PR TITLE
Default to deterministic action (set action repeat stochasticity to 0)

### DIFF
--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -432,18 +432,16 @@ command--line argument \verb+-color_averaging+ (or the \verb+setBool+ function).
 
 \subsection{Action Repeat Stochasticity}
 
-Beginning with ALE 0.5.0, there is now an option (enabled by default) to add 
-\emph{action repeat stochasticity} to the environment. With probability $p$ (default: $p = 0.25$),
-the previously executed action is executed again during the next frame, ignoring the agent's
-actual choice. This value can be modified using the option \verb+action_repeat_probability+.
-The default value was chosen as the highest value for which human play-testers
-were unable to detect any delay or control lag.
+Beginning with ALE 0.5.0, there is now an option (disabled by default) to add \emph{action repeat stochasticity} to the environment.
+With probability $p$ (default: $p = 0$), the previously executed action is executed again during the next frame, ignoring the agent's actual choice.
+This value can be modified using the option \verb+action_repeat_probability+.
+If action repeat stochasticity is desired, a value of $0.25$ is suggested; this was chosen as the highest value for which human play-testers were unable to detect any delay or control lag.
 
 The motivation for introducing action repeat stochasticity was to help separate \emph{trajectory
-optimization} research from \emph{robust controller optimization}, the latter often being the 
-desired outcome in reinforcement learning (RL). We strongly encourage RL researchers to use 
-the default stochasticity level in their agents, and clearly report the setting used. More 
-details on the effects of action repeat stochasticity will be made available in future 
+optimization} research from \emph{robust controller optimization}, the latter often being the
+desired outcome in reinforcement learning (RL). We strongly encourage RL researchers to use
+the $0.25$ stochasticity level in their agents, and clearly report the setting used. More
+details on the effects of action repeat stochasticity will be made available in future
 publications.
 
 Note that, beginning with ALE 0.5.0, we have also removed the use of \verb+rand()/srand()+ from

--- a/src/emucore/Settings.cxx
+++ b/src/emucore/Settings.cxx
@@ -707,7 +707,7 @@ void Settings::setDefaultSettings() {
     boolSettings.insert(pair<string, bool>("color_averaging", true));
     boolSettings.insert(pair<string, bool>("send_rgb", false));
     intSettings.insert(pair<string, int>("frame_skip", 1));
-    floatSettings.insert(pair<string, float>("repeat_action_probability", 0.25));
+    floatSettings.insert(pair<string, float>("repeat_action_probability", 0));
     stringSettings.insert(pair<string, string>("rom_file", ""));
 
     // Record settings


### PR DESCRIPTION
This PR makes emulator action deterministic by default. 

I know that this setting was decided at the AAAI-15 workshop and that it discourages "degenerate" policies for certain games. However, I argue that lurking nondeterminism leads to confusion and frustration. While I appreciate the functionality of this option, and the manual's explanation of it, it is a dangerous default that can invalidate experiments and recorded data. Furthermore, when `repeat_action_probability > 0` it is impossible to know which action was in fact taken in the emulator. This is not exposed through the interface (at least as far as I can tell), making it impossible to record true trajectories of agents or humans. For these reasons a default of 0 is the safest, and those concerned with robustness above all else can request it explicitly.

This mirrors the setting in deepmind/xitari to hopefully reduce fragmentation. As the ALE grows in popularity, it could be helpful to unify work on it.

With #168, this better aligns the ALE defaults to the expectation that the agent is interacting with the emulator environment as-is for input and output.

This is an opinionated PR, but it is made with the best intention. Thanks for the ALE!

@rhaps0dy I believe you have also had trouble with this setting.