### PR TITLE
add logger mode interface to python

### DIFF
--- a/ale_python_interface/ale_c_wrapper.h
+++ b/ale_python_interface/ale_c_wrapper.h
@@ -84,6 +84,9 @@ extern "C" {
   void encodeState(ALEState *state, char *buf, int buf_len);
   int encodeStateLen(ALEState *state);
   ALEState *decodeState(const char *serialized, int len);
+
+  // 0: Info, 1: Warning, 2: Error
+  void setLoggerMode(int mode) { ale::Logger::setMode(ale::Logger::mode(mode)); }
 }
 
 #endif

--- a/ale_python_interface/ale_python_interface.py
+++ b/ale_python_interface/ale_python_interface.py
@@ -90,8 +90,17 @@ ale_lib.encodeStateLen.argtypes = [c_void_p]
 ale_lib.encodeStateLen.restype = c_int
 ale_lib.decodeState.argtypes = [c_void_p, c_int]
 ale_lib.decodeState.restype = c_void_p
+ale_lib.setLoggerMode.argtypes = [c_int]
+ale_lib.setLoggerMode.restype = None
 
 class ALEInterface(object):
+    # Logger enum
+    class Logger:
+        Info = 0
+        Warning = 1
+        Error = 2
+
+
     def __init__(self):
         self.obj = ale_lib.ALE_new()
 
@@ -267,3 +276,10 @@ class ALEInterface(object):
 
     def __del__(self):
         ale_lib.ALE_del(self.obj)
+
+    @staticmethod
+    def setLoggerMode(mode):
+        dic = {'info': 0, 'warning': 1, 'error': 2}
+        mode = dic.get(mode, mode)
+        assert mode in [0, 1, 2], "Invalid Mode! Mode must be one of 0: info, 1: warning, 2: error"
+        ale_lib.setLoggerMode(mode)


### PR DESCRIPTION
By having this interface I'll be able to suppress the messages in Python by
```python
ALEInterface.setLoggerMode(ALEInterface.Logger.Warning)
```