### PR TITLE
Added code necessary to support Surround

### DIFF
--- a/src/ale_interface.cpp
+++ b/src/ale_interface.cpp
@@ -127,6 +127,8 @@ void ALEInterface::loadROM(string rom_file = "") {
   environment.reset(new StellaEnvironment(theOSystem.get(), romSettings.get()));
   max_num_frames = theOSystem->settings().getInt("max_num_frames_per_episode");
   environment->reset();
+  applyRomSettings(romSettings.get(), theOSystem.get());
+
 #ifndef __USE_SDL
   if (theOSystem->p_display_screen != NULL) {
     Logger::Error << "Screen display requires directive __USE_SDL to be defined." << endl;

--- a/src/common/Constants.h
+++ b/src/common/Constants.h
@@ -68,6 +68,7 @@ enum Action {
     SAVE_STATE              = 43,
     LOAD_STATE              = 44,
     SYSTEM_RESET            = 45,
+    SELECT                  = 46,
     LAST_ACTION_INDEX       = 50
 };
 

--- a/src/controllers/ale_controller.cpp
+++ b/src/controllers/ale_controller.cpp
@@ -32,6 +32,7 @@ ALEController::ALEController(OSystem* osystem):
     exit(1);
   }
   else {
+    applyRomSettings(m_settings.get(), m_osystem);
     m_environment.reset();
   }
 }

--- a/src/emucore/Console.cxx
+++ b/src/emucore/Console.cxx
@@ -238,6 +238,13 @@ Console::~Console()
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+void Console::toggleSwapPorts() {
+
+  // Swaps the left and right ports
+  std::swap(myControllers[0], myControllers[1]);
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Console::toggleFormat()
 {
   int framerate = 60;

--- a/src/emucore/Console.hxx
+++ b/src/emucore/Console.hxx
@@ -168,6 +168,11 @@ class Console
     void togglePhosphor();
 
     /**
+      Swap ports (or un-swaps them if they were swapped). 
+    */
+    void toggleSwapPorts();
+
+    /**
       Initialize the video subsystem wrt this class.
       This is required for changing window size, title, etc.
 

--- a/src/environment/ale_state.cpp
+++ b/src/environment/ale_state.cpp
@@ -222,6 +222,8 @@ void ALEState::applyActionPaddles(Event* event, int player_a_action, int player_
   // Handle reset
   if (player_a_action == RESET || player_b_action == RESET) 
     event->set(Event::ConsoleReset, 1);
+  if (player_a_action == SELECT || player_b_action == SELECT) 
+    event->set(Event::ConsoleReset, 1);
 
   // Now add the fire event 
   switch (player_a_action) {
@@ -353,6 +355,9 @@ void ALEState::setActionJoysticks(Event* event, int player_a_action, int player_
       case RESET:
           event->set(Event::ConsoleReset, 1);
           break;
+      case SELECT:
+          event->set(Event::ConsoleSelect, 1);
+          break;
       default: 
           ale::Logger::Error << "Invalid Player A Action: " << player_a_action;
           exit(-1); 
@@ -462,6 +467,7 @@ void ALEState::setActionJoysticks(Event* event, int player_a_action, int player_
  * ***************************************************************************/
 void ALEState::resetKeys(Event* event) {
     event->set(Event::ConsoleReset, 0);
+    event->set(Event::ConsoleSelect, 0);
     event->set(Event::JoystickZeroFire, 0);
     event->set(Event::JoystickZeroUp, 0);
     event->set(Event::JoystickZeroDown, 0);

--- a/src/games/RomSettings.hpp
+++ b/src/games/RomSettings.hpp
@@ -77,6 +77,8 @@ struct RomSettings {
     // Remaining lives.
     virtual const int lives() { return isTerminal() ? 0 : 1; }
 
+    virtual bool swapPorts() const { return false; }
+
     // Returns a restricted (minimal) set of actions. If not overriden, this is all actions.
     virtual ActionVect getMinimalActionSet();
 

--- a/src/games/Roms.cpp
+++ b/src/games/Roms.cpp
@@ -76,6 +76,7 @@
 #include "supported/Solaris.hpp"
 #include "supported/SpaceInvaders.hpp"
 #include "supported/StarGunner.hpp"
+#include "supported/Surround.hpp"
 #include "supported/Tennis.hpp"
 #include "supported/Tetris.hpp"
 #include "supported/TimePilot.hpp"
@@ -154,6 +155,7 @@ static const RomSettings *roms[]  = {
     new SolarisSettings(),
     new SpaceInvadersSettings(),
     new StarGunnerSettings(),
+    new SurroundSettings(),
     new TennisSettings(),
     new TetrisSettings(),
     new TimePilotSettings(),
@@ -170,7 +172,7 @@ static const RomSettings *roms[]  = {
 
 
 /* looks for the RL wrapper corresponding to a particular rom title */
-RomSettings *buildRomRLWrapper(const std::string &rom) {
+RomSettings *buildRomRLWrapper(const std::string& rom) {
 
     size_t slash_ind = rom.find_last_of("/\\");
     std::string rom_str = rom.substr(slash_ind + 1);
@@ -185,3 +187,11 @@ RomSettings *buildRomRLWrapper(const std::string &rom) {
     return NULL;
 }
 
+// Taken from Xitari.
+void applyRomSettings(RomSettings* settings, OSystem* osystem) {
+
+    assert(settings != NULL && osystem != NULL);
+
+    if (settings->swapPorts())
+        osystem->console().toggleSwapPorts();
+}

--- a/src/games/Roms.hpp
+++ b/src/games/Roms.hpp
@@ -13,6 +13,7 @@
 #define __ROMS_HPP__
 
 #include <string>
+#include <OSystem.hxx>
 
 struct RomSettings;
 
@@ -20,6 +21,8 @@ struct RomSettings;
 // looks for the RL wrapper corresponding to a particular rom title 
 extern RomSettings *buildRomRLWrapper(const std::string &rom);
 
+// applies emulator-relevant settings (from Xitari)
+extern void applyRomSettings(RomSettings *, OSystem *);
 
 #endif // __ROMS_HPP__
 

--- a/src/games/supported/Surround.cpp
+++ b/src/games/supported/Surround.cpp
@@ -1,0 +1,125 @@
+/* *****************************************************************************
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 2
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * *****************************************************************************
+ * A.L.E (Arcade Learning Environment)
+ * Copyright (c) 2009-2013 by Yavar Naddaf, Joel Veness, Marc G. Bellemare and 
+ *   the Reinforcement Learning and Artificial Intelligence Laboratory
+ * Released under the GNU General Public License; see License.txt for details. 
+ *
+ * Based on: Stella  --  "An Atari 2600 VCS Emulator"
+ * Copyright (c) 1995-2007 by Bradford W. Mott and the Stella team
+ *
+ * *****************************************************************************
+ */
+#include "Surround.hpp"
+
+#include "../RomUtils.hpp"
+
+
+SurroundSettings::SurroundSettings() {
+
+    reset();
+}
+
+
+/* create a new instance of the rom */
+RomSettings* SurroundSettings::clone() const { 
+    
+    RomSettings* rval = new SurroundSettings();
+    *rval = *this;
+    return rval;
+}
+
+
+/* process the latest information from ALE */
+void SurroundSettings::step(const System& system) {
+
+    int oppt_score = getDecimalScore(0xF6, &system);
+    int my_score = getDecimalScore(0xF7, &system);
+
+    int delta_score = my_score - oppt_score;
+    m_reward = delta_score - m_score;
+    
+    // "Score" really is the difference between raw scores
+    m_score = delta_score;
+
+    // Game ends when one of the players reaches 10.
+    m_terminal = (oppt_score == 10 || my_score == 10);
+}
+
+
+/* is end of game */
+bool SurroundSettings::isTerminal() const {
+
+    return m_terminal;
+};
+
+
+/* get the most recently observed reward */
+reward_t SurroundSettings::getReward() const { 
+
+    return m_reward; 
+}
+
+
+/* is an action part of the minimal set? */
+bool SurroundSettings::isMinimal(const Action &a) const {
+
+    switch (a) {
+        case PLAYER_A_NOOP:
+        case PLAYER_A_UP:
+        case PLAYER_A_RIGHT:
+        case PLAYER_A_LEFT:
+        case PLAYER_A_DOWN:
+            return true;
+        default:
+            return false;
+    }   
+}
+
+
+/* reset the state of the game */
+void SurroundSettings::reset() {
+    
+    m_reward   = 0;
+    m_score    = 0;
+    m_terminal = false;
+}
+        
+/* saves the state of the rom settings */
+void SurroundSettings::saveState(Serializer & ser) {
+  ser.putInt(m_reward);
+  ser.putInt(m_score);
+  ser.putBool(m_terminal);
+}
+
+// loads the state of the rom settings
+void SurroundSettings::loadState(Deserializer & ser) {
+  m_reward = ser.getInt();
+  m_score = ser.getInt();
+  m_terminal = ser.getBool();
+}
+
+ActionVect SurroundSettings::getStartingActions() {
+
+    ActionVect vec;
+
+    // We want to play vs the CPU.
+    // TODO(bellemare): When modes/difficulties are brought in, this will need to be updated. 
+    vec.push_back(SELECT);
+    vec.push_back(RESET);
+
+    return vec;
+}

--- a/src/games/supported/Surround.hpp
+++ b/src/games/supported/Surround.hpp
@@ -1,0 +1,82 @@
+/* *****************************************************************************
+ * swapPorts() based on Xitari's code, from Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 2
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * *****************************************************************************
+ * A.L.E (Arcade Learning Environment)
+ * Copyright (c) 2009-2013 by Yavar Naddaf, Joel Veness, Marc G. Bellemare and 
+ *   the Reinforcement Learning and Artificial Intelligence Laboratory
+ * Released under the GNU General Public License; see License.txt for details. 
+ *
+ * Based on: Stella  --  "An Atari 2600 VCS Emulator"
+ * Copyright (c) 1995-2007 by Bradford W. Mott and the Stella team
+ *
+ * *****************************************************************************
+ */
+#ifndef __SURROUND_HPP__
+#define __SURROUND_HPP__
+
+#include "../RomSettings.hpp"
+
+
+/* RL wrapper for Surround */
+class SurroundSettings : public RomSettings {
+
+    public:
+
+        SurroundSettings();
+
+        // reset
+        void reset();
+
+        // is end of game
+        bool isTerminal() const;
+
+        // get the most recently observed reward
+        reward_t getReward() const;
+
+        // the rom-name
+        const char* rom() const { return "surround"; }
+
+        // create a new instance of the rom
+        RomSettings* clone() const;
+
+        // is an action part of the minimal set?
+        bool isMinimal(const Action& a) const;
+
+        // process the latest information from ALE
+        void step(const System& system);
+
+        // saves the state of the rom settings
+        void saveState(Serializer & ser);
+    
+        // loads the state of the rom settings
+        void loadState(Deserializer & ser);
+
+        virtual const int lives() { return 0; } 
+
+        virtual ActionVect getStartingActions();
+
+        // This is required for Surround, since the 2nd player plays. 
+        virtual bool swapPorts() const { return true; }
+
+    private:
+
+        bool m_terminal;
+        reward_t m_reward;
+        reward_t m_score;
+};
+
+#endif // __SURROUND_HPP__
+


### PR DESCRIPTION
This is adding support for Surround. This requires adding the select button, leading to a little bit of redundancy between the modes PR and this one. When the modes PR is complete, we'll need to remove the starting actions from this game's settings.