### PR TITLE
Fixed issue with colour averaging where greys would not be correctly …

### DIFF
--- a/src/common/ColourPalette.cpp
+++ b/src/common/ColourPalette.cpp
@@ -34,7 +34,7 @@ inline uInt32 convertGrayscale(uInt32 packedRGBValue)
     double g = (packedRGBValue >> 8)  & 0xff;
     double b = (packedRGBValue >> 0)  & 0xff;
 
-    uInt8 lum = (uInt8) round(r * 0.2989 + g * 0.5870 + b * 0.1140 );
+    uInt8 lum = (uInt8) round(r * 0.2989 + g * 0.5870 + b * 0.1140);
 
     return packRGB(lum, lum, lum);
 }
@@ -45,8 +45,10 @@ ColourPalette::ColourPalette(): m_palette(NULL) {
 
 void ColourPalette::getRGB(int val, int &r, int &g, int &b) const
 {
-    assert (m_palette != NULL);
+    assert(m_palette != NULL);
     assert(val >= 0 && val <= 0xFF);
+    // Make sure we are reading from RGB, not grayscale.
+    assert((val & 0x01) == 0);
     
     // Set the RGB components accordingly
     r = (m_palette[val] >> 16) & 0xFF;
@@ -56,9 +58,10 @@ void ColourPalette::getRGB(int val, int &r, int &g, int &b) const
 
 uInt8 ColourPalette::getGrayscale(int val) const
 {
-    assert (m_palette != NULL);
+    assert(m_palette != NULL);
     assert(val >= 0 && val < 0xFF);
-    
+    assert((val & 0x01) == 1);
+
     // Set the RGB components accordingly
     return (m_palette[val+1] >> 0) & 0xFF;
 }

--- a/src/environment/phosphor_blend.cpp
+++ b/src/environment/phosphor_blend.cpp
@@ -49,9 +49,9 @@ void PhosphorBlend::makeAveragePalette() {
   
   ColourPalette &palette = m_osystem->colourPalette();
 
-  // Precompute the average RGB values for phosphor-averaged colors c1 and c2
-  for (int c1 = 0; c1 < 256; c1++) {
-    for (int c2 = 0; c2 < 256; c2++) {
+  // Precompute the average RGB values for phosphor-averaged colors c1 and c2.
+  for (int c1 = 0; c1 < 256; c1 += 2) {
+    for (int c2 = 0; c2 < 256; c2 += 2) {
       int r1, g1, b1;
       int r2, g2, b2;
       palette.getRGB(c1, r1, g1, b1);
@@ -64,7 +64,8 @@ void PhosphorBlend::makeAveragePalette() {
     }
   }
   
-  // Also make a RGB to NTSC color map
+  // Also make a RGB to NTSC color map. We drop the lowest two bits to speed
+  // the initialization a little. TODO(mgbellemare): Find a better solution.
   for (int r = 0; r < 256; r += 4) {
     for (int g = 0; g < 256; g += 4) {  
       for (int b = 0; b < 256; b += 4) {
@@ -72,7 +73,9 @@ void PhosphorBlend::makeAveragePalette() {
         int minDist = 256 * 3 + 1;
         int minIndex = -1;
 
-        for (int c1 = 0; c1 < 256; c1++) {
+        // Look for the closest NTSC value matching (r,g,b). Odd palette
+        // entries correspond to grayscale values and are ignored.
+        for (int c1 = 0; c1 < 256; c1 += 2) {
           // Get the RGB corresponding to c1
           int r1, g1, b1;
           palette.getRGB(c1, r1, g1, b1);


### PR DESCRIPTION
…averaged. Fixes #181 

@mcmachado please take a quick look. Going forward we should consider deprecating colour averaging out of the ALE. Reasons:
- The NTSC -> RGB -> NTSC transform is inaccurate
- Better solutions exist
- This is an agent rather than environment component
