### PR TITLE
Add Kaboom! rom

### DIFF
--- a/src/games/Roms.cpp
+++ b/src/games/Roms.cpp
@@ -49,6 +49,7 @@
 #include "supported/IceHockey.hpp"
 #include "supported/JamesBond.hpp"
 #include "supported/JourneyEscape.hpp"
+#include "supported/Kaboom.hpp"
 #include "supported/Kangaroo.hpp"
 #include "supported/Koolaid.hpp"
 #include "supported/KeystoneKapers.hpp"
@@ -127,6 +128,7 @@ static const RomSettings *roms[]  = {
     new IceHockeySettings(),
     new JamesBondSettings(),
     new JourneyEscapeSettings(),
+    new KaboomSettings(),
     new KangarooSettings(),
     new KoolaidSettings(),
     new KeystoneKapersSettings(),

--- a/src/games/module.mk
+++ b/src/games/module.mk
@@ -39,6 +39,7 @@ MODULE_OBJS := \
 	src/games/supported/IceHockey.o \
 	src/games/supported/JamesBond.o \
 	src/games/supported/JourneyEscape.o \
+	src/games/supported/Kaboom.o \
 	src/games/supported/Kangaroo.o \
 	src/games/supported/Koolaid.o \
 	src/games/supported/KeystoneKapers.o \

--- a/src/games/supported/Kaboom.cpp
+++ b/src/games/supported/Kaboom.cpp
@@ -1,0 +1,99 @@
+/* *****************************************************************************
+ * A.L.E (Arcade Learning Environment)
+ * Copyright (c) 2009-2013 by Yavar Naddaf, Joel Veness, Marc G. Bellemare and 
+ *   the Reinforcement Learning and Artificial Intelligence Laboratory
+ * Released under the GNU General Public License; see License.txt for details. 
+ *
+ * Based on: Stella  --  "An Atari 2600 VCS Emulator"
+ * Copyright (c) 1995-2007 by Bradford W. Mott and the Stella team
+ *
+ * *****************************************************************************
+ */
+#include "Kaboom.hpp"
+
+#include "../RomUtils.hpp"
+#include <iostream>
+
+KaboomSettings::KaboomSettings() {
+    reset();
+}
+
+
+/* create a new instance of the rom */
+RomSettings* KaboomSettings::clone() const {
+    
+    RomSettings* rval = new KaboomSettings();
+    *rval = *this;
+    return rval;
+}
+
+
+/* process the latest information from ALE */
+void KaboomSettings::step(const System& system) {
+
+    // update the reward
+    reward_t score = getDecimalScore(0xA5, 0xA4, 0xA3, &system);
+    m_reward = score - m_score;
+    m_score = score;
+
+    // update terminal status
+    int lives = readRam(&system, 0xA1);
+    m_terminal = lives == 0x0 || m_score == 999999;
+}
+
+
+/* is end of game */
+bool KaboomSettings::isTerminal() const {
+
+    return m_terminal;
+};
+
+
+/* get the most recently observed reward */
+reward_t KaboomSettings::getReward() const {
+     return m_reward;
+}
+
+
+/* is an action part of the minimal set? */
+bool KaboomSettings::isMinimal(const Action &a) const {
+
+    switch (a) {
+        case PLAYER_A_NOOP:
+        case PLAYER_A_FIRE:
+        case PLAYER_A_RIGHT:
+        case PLAYER_A_LEFT:
+             return true;
+        default:
+            return false;
+    }   
+}
+
+
+/* reset the state of the game */
+void KaboomSettings::reset() {
+    
+    m_reward   = 0;
+    m_score    = 0;
+    m_terminal = false;
+}
+        
+/* saves the state of the rom settings */
+void KaboomSettings::saveState(Serializer & ser) {
+  ser.putInt(m_reward);
+  ser.putInt(m_score);
+  ser.putBool(m_terminal);
+}
+
+// loads the state of the rom settings
+void KaboomSettings::loadState(Deserializer & ser) {
+  m_reward = ser.getInt();
+  m_score = ser.getInt();
+  m_terminal = ser.getBool();
+}
+
+ActionVect KaboomSettings::getStartingActions() {
+    ActionVect startingActions;
+    startingActions.push_back(PLAYER_A_FIRE);
+    return startingActions;
+}

--- a/src/games/supported/Kaboom.hpp
+++ b/src/games/supported/Kaboom.hpp
@@ -1,0 +1,65 @@
+/* *****************************************************************************
+ * A.L.E (Arcade Learning Environment)
+ * Copyright (c) 2009-2013 by Yavar Naddaf, Joel Veness, Marc G. Bellemare and 
+ *   the Reinforcement Learning and Artificial Intelligence Laboratory
+ * Released under the GNU General Public License; see License.txt for details. 
+ *
+ * Based on: Stella  --  "An Atari 2600 VCS Emulator"
+ * Copyright (c) 1995-2007 by Bradford W. Mott and the Stella team
+ *
+ * *****************************************************************************
+ */
+#ifndef __KABOOM_HPP__
+#define __KABOOM_HPP__
+
+#include "../RomSettings.hpp"
+
+/* RL wrapper for Kaboom settings */
+class KaboomSettings: public RomSettings
+{
+
+public:
+
+  KaboomSettings();
+
+  // reset
+  void reset();
+
+  // is end of game
+  bool isTerminal() const;
+
+  // get the most recently observed reward
+  reward_t getReward() const;
+
+  // the rom-name
+  const char* rom() const
+  {
+    return "kaboom";
+  }
+
+  // create a new instance of the rom
+  RomSettings* clone() const;
+
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
+
+  // process the latest information from ALE
+  void step(const System& system);
+
+  // saves the state of the rom settings
+  void saveState(Serializer & ser);
+
+  // loads the state of the rom settings
+  void loadState(Deserializer & ser);
+
+  ActionVect getStartingActions();
+
+private:
+
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+};
+
+#endif // __KABOOM__
+


### PR DESCRIPTION
I figured out where and how [Kaboom!](https://en.wikipedia.org/wiki/Kaboom!_(video_game)) stores the score and the number of "lives" (buckets), with help from the Stella debugger and this disassembly: http://www.bjars.com/source/Kaboom.asm.

When the score reaches 999,999 points, the game freezes, so I used that as a terminal condition (in addition to the regular one in which you have no more lives left).

