### PR TITLE
Add minimally invasive code that checks ROMs against known md5s

### DIFF
--- a/src/ale_interface.cpp
+++ b/src/ale_interface.cpp
@@ -65,6 +65,28 @@ void ALEInterface::createOSystem(std::auto_ptr<OSystem> &theOSystem,
   theOSystem->settings().loadConfig();
 }
 
+
+void checkForUnsupportedRom(std::auto_ptr<OSystem>& theOSystem) {
+  const Properties properties = theOSystem->console().properties();
+  const std::string md5 = properties.get(Cartridge_MD5);
+  bool found = false;
+  std::string rom_candidate = "";
+  std::ifstream ss("md5.txt");
+  std::string item;
+  while (!found && std::getline(ss, item)) {
+    if (!item.compare(0, md5.size(), md5)) {
+      const std::string rom_candidate = item.substr(md5.size() + 1);
+      found = true;
+    }
+  }
+  if (!found) {
+    Logger::Warning << "Warning. Possibly unsupported ROM." << std::endl;
+    Logger::Warning << "Cartridge_MD5: " << md5 << std::endl;
+    const std::string name = properties.get(Cartridge_Name);
+    Logger::Warning << "Cartridge_name: " << name << std::endl;
+  }
+}
+
 void ALEInterface::loadSettings(const string& romfile,
                                 std::auto_ptr<OSystem> &theOSystem) {
   // Load the configuration from a config file (passed on the command
@@ -83,6 +105,7 @@ void ALEInterface::loadSettings(const string& romfile,
               << std::endl;
     exit(1);
   } else if (theOSystem->createConsole(romfile))  {
+    checkForUnsupportedRom(theOSystem);
     Logger::Info << "Running ROM file..." << std::endl;
     theOSystem->settings().setString("rom_file", romfile);
   } else {

--- a/src/ale_interface.cpp
+++ b/src/ale_interface.cpp
@@ -66,11 +66,10 @@ void ALEInterface::createOSystem(std::auto_ptr<OSystem> &theOSystem,
 }
 
 
-void checkForUnsupportedRom(std::auto_ptr<OSystem>& theOSystem) {
+void ALEInterface::checkForUnsupportedRom(std::auto_ptr<OSystem>& theOSystem) {
   const Properties properties = theOSystem->console().properties();
   const std::string md5 = properties.get(Cartridge_MD5);
   bool found = false;
-  std::string rom_candidate = "";
   std::ifstream ss("md5.txt");
   std::string item;
   while (!found && std::getline(ss, item)) {

--- a/src/ale_interface.hpp
+++ b/src/ale_interface.hpp
@@ -164,6 +164,10 @@ public:
                             std::auto_ptr<Settings> &theSettings);
   static void loadSettings(const std::string& romfile,
                            std::auto_ptr<OSystem> &theOSystem);
+
+ private:
+  static void checkForUnsupportedRom(std::auto_ptr<OSystem>& theOSystem);
+
 };
 
 #endif


### PR DESCRIPTION
I've isolated my changes to just those that will add the warning message for unsupported ROMs, hopefully for clarity.