### PR TITLE
Accessing other events inside Stella and allowing ALE to change RAM values

### DIFF
--- a/src/ale_interface.hpp
+++ b/src/ale_interface.hpp
@@ -45,7 +45,7 @@
 #include <string>
 #include <memory>
 
-static const std::string Version = "0.5.1";
+static const std::string Version = "0.6.0";
 
 /**
    This class interfaces ALE with external code for controlling agents.

--- a/src/environment/ale_state.cpp
+++ b/src/environment/ale_state.cpp
@@ -475,7 +475,7 @@ void ALEState::setActionJoysticks(Event* event, int player_a_action, int player_
  * ***************************************************************************/
 void ALEState::resetKeys(Event* event) {
     event->set(Event::ConsoleReset, 0);
-    event->set(Event::ConsoleSelect,0);
+    event->set(Event::ConsoleSelect, 0);
     event->set(Event::JoystickZeroFire, 0);
     event->set(Event::JoystickZeroUp, 0);
     event->set(Event::JoystickZeroDown, 0);

--- a/src/environment/ale_state.cpp
+++ b/src/environment/ale_state.cpp
@@ -259,6 +259,19 @@ void ALEState::applyActionPaddles(Event* event, int player_a_action, int player_
   }
 }
 
+void ALEState::pressSelect(Event* event) {
+  resetKeys(event);
+  event->set(Event::ConsoleSelect, 1);
+}
+
+void ALEState::setDifficulty(Event* event, unsigned mask) {
+  resetKeys(event);
+  event->set(Event::ConsoleLeftDifficultyA, mask & 1);
+  event->set(Event::ConsoleLeftDifficultyB, !(mask & 1));
+  event->set(Event::ConsoleRightDifficultyA, (mask & 2) >> 1);
+  event->set(Event::ConsoleRightDifficultyB, !((mask & 2) >> 1));
+}
+
 void ALEState::setActionJoysticks(Event* event, int player_a_action, int player_b_action) {
   // Reset keys
   resetKeys(event);
@@ -462,6 +475,7 @@ void ALEState::setActionJoysticks(Event* event, int player_a_action, int player_
  * ***************************************************************************/
 void ALEState::resetKeys(Event* event) {
     event->set(Event::ConsoleReset, 0);
+    event->set(Event::ConsoleSelect,0);
     event->set(Event::JoystickZeroFire, 0);
     event->set(Event::JoystickZeroUp, 0);
     event->set(Event::JoystickZeroDown, 0);

--- a/src/environment/ale_state.cpp
+++ b/src/environment/ale_state.cpp
@@ -264,7 +264,7 @@ void ALEState::pressSelect(Event* event) {
   event->set(Event::ConsoleSelect, 1);
 }
 
-void ALEState::setDifficulty(Event* event, unsigned mask) {
+void ALEState::setDifficulty(Event* event, unsigned int mask) {
   resetKeys(event);
   event->set(Event::ConsoleLeftDifficultyA, mask & 1);
   event->set(Event::ConsoleLeftDifficultyB, !(mask & 1));

--- a/src/environment/ale_state.hpp
+++ b/src/environment/ale_state.hpp
@@ -50,6 +50,15 @@ class ALEState {
 
     void resetPaddles(Event*);
 
+    //Apply the special select action
+    void pressSelect(Event* event_obj);
+
+    /** set the difficulty according to the mask.
+      * If the first bit is 1, then it will put the left difficulty switch to A (otherwise leave it on B)
+      * If the second bit is 1, then it will put the right difficulty switch to A (otherwise leave it on B)
+      */
+    void setDifficulty(Event* event_obj, unsigned mask);
+
     /** Applies paddle actions. This actually modifies the game state by updating the paddle
       *  resistances. */
     void applyActionPaddles(Event* event_obj, int player_a_action, int player_b_action);
@@ -107,5 +116,4 @@ class ALEState {
 };
 
 #endif // __ALE_STATE_HPP__
-
 

--- a/src/environment/ale_state.hpp
+++ b/src/environment/ale_state.hpp
@@ -57,7 +57,7 @@ class ALEState {
       * If the first bit is 1, then it will put the left difficulty switch to A (otherwise leave it on B)
       * If the second bit is 1, then it will put the right difficulty switch to A (otherwise leave it on B)
       */
-    void setDifficulty(Event* event_obj, unsigned mask);
+    void setDifficulty(Event* event_obj, unsigned int mask);
 
     /** Applies paddle actions. This actually modifies the game state by updating the paddle
       *  resistances. */

--- a/src/games/RomUtils.cpp
+++ b/src/games/RomUtils.cpp
@@ -30,6 +30,12 @@ int readRam(const System* system, int offset) {
 }
 
 
+/* writes a byte at a memory location between 0 and 128 */
+void writeRam(System* system, int offset, unsigned char value) {
+
+    system->poke((offset & 0x7F) + 0x80, value);
+}
+
 /* extracts a decimal value from a byte */
 int getDecimalScore(int index, const System* system) {
     

--- a/src/games/RomUtils.cpp
+++ b/src/games/RomUtils.cpp
@@ -29,13 +29,6 @@ int readRam(const System* system, int offset) {
     return sys->peek((offset & 0x7F) + 0x80);
 }
 
-
-/* writes a byte at a memory location between 0 and 128 */
-void writeRam(System* system, int offset, unsigned char value) {
-
-    system->poke((offset & 0x7F) + 0x80, value);
-}
-
 /* extracts a decimal value from a byte */
 int getDecimalScore(int index, const System* system) {
     

--- a/src/games/RomUtils.hpp
+++ b/src/games/RomUtils.hpp
@@ -22,6 +22,10 @@ class System;
 // reads a byte at a memory location between 0 and 1023
 extern int readRam(const System* system, int offset);
 
+// writes a byte at a memory location between 0 and 128,
+// this method is required to allow one to set a game mode
+extern void writeRam(System* system, int offset, unsigned char value);
+
 // extracts a decimal value from 1, 2, and 3 bytes respectively
 extern int getDecimalScore(int idx, const System* system);
 extern int getDecimalScore(int lo, int hi, const System* system);

--- a/src/games/RomUtils.hpp
+++ b/src/games/RomUtils.hpp
@@ -22,10 +22,6 @@ class System;
 // reads a byte at a memory location between 0 and 1023
 extern int readRam(const System* system, int offset);
 
-// writes a byte at a memory location between 0 and 128,
-// this method is required to allow one to set a game mode
-extern void writeRam(System* system, int offset, unsigned char value);
-
 // extracts a decimal value from 1, 2, and 3 bytes respectively
 extern int getDecimalScore(int idx, const System* system);
 extern int getDecimalScore(int lo, int hi, const System* system);


### PR DESCRIPTION
The last set of functionalities I need before actually implementing the mode and difficulty changes are the abilities to:
 - deal with other events supported in Stella but not previously supported in the ALE (Setting difficulty level and pressing select).
 - write to RAM so I can set the game mode.

I believe my next PR, after these two features, will finalize the implementation of the desired functionalities (stella_environment and RomSettings). Then it will be a matter of updating the code in all games.