### PR TITLE
Mode and difficulty switch in 12 games

### DIFF
--- a/src/games/supported/Alien.cpp
+++ b/src/games/supported/Alien.cpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 65, 118, 134 and 142 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -142,3 +142,36 @@ void AlienSettings::loadState(Deserializer & ser) {
   m_lives = ser.getInt();
 }
 
+// returns a list of mode that the game can be played in
+ModeVect AlienSettings::getAvailableModes() {
+    ModeVect modes(getNumNodes());
+    for (unsigned int i = 0; i < modes.size(); i++) {
+        modes[i] = i;
+    }
+    return modes;
+}
+
+// set the mode of the game
+// the given mode must be one returned by the previous function
+void AlienSettings::setMode(game_mode_t m, System &system,
+                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
+
+    // read the mode we are currently in
+    unsigned char mode = readRam(&system, 0x81);
+    // press select until the correct mode is reached
+    while (mode != m) {
+        environment->pressSelect(1);
+        mode = readRam(&system, 0x81);
+    }
+    //update the number of lives
+    int byte = readRam(&system, 0xC0);
+    byte = byte & 15;
+    m_lives = byte;
+    //reset the environment to apply changes.
+    environment->softReset();
+ }
+
+DifficultyVect AlienSettings::getAvailableDifficulties() {
+    DifficultyVect diff = {0, 1, 2, 3};
+    return diff;
+}

--- a/src/games/supported/Alien.cpp
+++ b/src/games/supported/Alien.cpp
@@ -144,7 +144,7 @@ void AlienSettings::loadState(Deserializer & ser) {
 
 // returns a list of mode that the game can be played in
 ModeVect AlienSettings::getAvailableModes() {
-    ModeVect modes(getNumNodes());
+    ModeVect modes(getNumModes());
     for (unsigned int i = 0; i < modes.size(); i++) {
         modes[i] = i;
     }

--- a/src/games/supported/Alien.cpp
+++ b/src/games/supported/Alien.cpp
@@ -156,19 +156,24 @@ ModeVect AlienSettings::getAvailableModes() {
 void AlienSettings::setMode(game_mode_t m, System &system,
                               std::unique_ptr<StellaEnvironmentWrapper> environment) {
 
-    // read the mode we are currently in
-    unsigned char mode = readRam(&system, 0x81);
-    // press select until the correct mode is reached
-    while (mode != m) {
-        environment->pressSelect(1);
-        mode = readRam(&system, 0x81);
+    if(m < getNumModes()) {
+        // read the mode we are currently in
+        unsigned char mode = readRam(&system, 0x81);
+        // press select until the correct mode is reached
+        while (mode != m) {
+            environment->pressSelect(1);
+            mode = readRam(&system, 0x81);
+        }
+        //update the number of lives
+        int byte = readRam(&system, 0xC0);
+        byte = byte & 15;
+        m_lives = byte;
+        //reset the environment to apply changes.
+        environment->softReset();
     }
-    //update the number of lives
-    int byte = readRam(&system, 0xC0);
-    byte = byte & 15;
-    m_lives = byte;
-    //reset the environment to apply changes.
-    environment->softReset();
+    else {
+        throw std::runtime_error("This mode doesn't currently exist for this game");
+    }
  }
 
 DifficultyVect AlienSettings::getAvailableDifficulties() {

--- a/src/games/supported/Alien.cpp
+++ b/src/games/supported/Alien.cpp
@@ -161,7 +161,7 @@ void AlienSettings::setMode(game_mode_t m, System &system,
         unsigned char mode = readRam(&system, 0x81);
         // press select until the correct mode is reached
         while (mode != m) {
-            environment->pressSelect(1);
+            environment->pressSelect();
             mode = readRam(&system, 0x81);
         }
         //update the number of lives

--- a/src/games/supported/Alien.hpp
+++ b/src/games/supported/Alien.hpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 67 and 77 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -49,6 +49,9 @@ class AlienSettings : public RomSettings {
         // the rom-name
         const char* rom() const { return "alien"; }
 
+        // get the available number of modes
+        unsigned int getNumNodes() const { return 4; }
+
         // create a new instance of the rom
         RomSettings* clone() const;
 
@@ -65,6 +68,19 @@ class AlienSettings : public RomSettings {
         void loadState(Deserializer & ser);
 
         virtual int lives() { return m_lives; }
+
+        // list of modes that the game can be played in
+        // in this game, there are 4 available modes
+        ModeVect getAvailableModes();
+
+        // set the mode of the game
+        // the given mode must be one returned by the previous function
+        void setMode(game_mode_t, System &system,
+                     std::unique_ptr<StellaEnvironmentWrapper> environment);
+
+        // returns a list of difficulties that the game can be played in
+        // in this game, there are 4 available difficulties
+        DifficultyVect getAvailableDifficulties();
 
     private:
 

--- a/src/games/supported/Alien.hpp
+++ b/src/games/supported/Alien.hpp
@@ -50,7 +50,7 @@ class AlienSettings : public RomSettings {
         const char* rom() const { return "alien"; }
 
         // get the available number of modes
-        unsigned int getNumNodes() const { return 4; }
+        unsigned int getNumModes() const { return 4; }
 
         // create a new instance of the rom
         RomSettings* clone() const;

--- a/src/games/supported/Amidar.cpp
+++ b/src/games/supported/Amidar.cpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 46, 91, 100 and 108 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -121,5 +121,10 @@ void AmidarSettings::loadState(Deserializer & ser) {
   m_score = ser.getInt();
   m_terminal = ser.getBool();
   m_lives = ser.getInt();
+}
+
+DifficultyVect AmidarSettings::getAvailableDifficulties() {
+    DifficultyVect diff = {0, 3};
+    return diff;
 }
 

--- a/src/games/supported/Amidar.hpp
+++ b/src/games/supported/Amidar.hpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 67 and 74 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -65,6 +65,10 @@ class AmidarSettings : public RomSettings {
         void loadState(Deserializer & ser);
 
         virtual int lives() { return isTerminal() ? 0 : m_lives; }
+
+        // returns a list of difficulties that the game can be played in
+        // in this game, there are 2 available difficulties
+        DifficultyVect getAvailableDifficulties();
 
     private:
 

--- a/src/games/supported/BeamRider.cpp
+++ b/src/games/supported/BeamRider.cpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 54 - 63, 113, 122 and 130 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -134,5 +134,10 @@ ActionVect BeamRiderSettings::getStartingActions() {
     ActionVect startingActions;
     startingActions.push_back(PLAYER_A_RIGHT);
     return startingActions;
+}
+
+DifficultyVect BeamRiderSettings::getAvailableDifficulties() {
+    DifficultyVect diff = {0, 1};
+    return diff;
 }
 

--- a/src/games/supported/BeamRider.hpp
+++ b/src/games/supported/BeamRider.hpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 69 and 76 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -67,6 +67,12 @@ class BeamRiderSettings : public RomSettings {
         ActionVect getStartingActions();
 
         virtual int lives() { return isTerminal() ? 0 : m_lives; }
+
+        // returns a list of difficulties that the game can be played in
+        // in this game, there are 2 available difficulties. The game's
+        // manual says there are three modes but at least from my ROM
+        // I couldn't find them. I found two difficulties.
+        DifficultyVect getAvailableDifficulties();
 
     private:
 

--- a/src/games/supported/BeamRider.hpp
+++ b/src/games/supported/BeamRider.hpp
@@ -69,9 +69,7 @@ class BeamRiderSettings : public RomSettings {
         virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
         // returns a list of difficulties that the game can be played in
-        // in this game, there are 2 available difficulties. The game's
-        // manual says there are three modes but at least from my ROM
-        // I couldn't find them. I found two difficulties.
+        // in this game, there are 2 available difficulties.
         DifficultyVect getAvailableDifficulties();
 
     private:

--- a/src/games/supported/ChopperCommand.cpp
+++ b/src/games/supported/ChopperCommand.cpp
@@ -154,6 +154,9 @@ void ChopperCommandSettings::setMode(game_mode_t m, System &system,
         //reset the environment to apply changes.
         environment->softReset();
     }
+    else {
+        throw std::runtime_error("This mode doesn't currently exist for this game");
+    }
  }
 
 DifficultyVect ChopperCommandSettings::getAvailableDifficulties() {

--- a/src/games/supported/ChopperCommand.cpp
+++ b/src/games/supported/ChopperCommand.cpp
@@ -143,7 +143,7 @@ ModeVect ChopperCommandSettings::getAvailableModes() {
 void ChopperCommandSettings::setMode(game_mode_t m, System &system,
                               std::unique_ptr<StellaEnvironmentWrapper> environment) {
 
-    if(m == 0 || m == 2){
+    if(m == 0 || m == 2) {
         // read the mode we are currently in
         unsigned char mode = readRam(&system, 0xE0);
         // press select until the correct mode is reached

--- a/src/games/supported/ChopperCommand.cpp
+++ b/src/games/supported/ChopperCommand.cpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 42, 96, 106 and 114 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -56,13 +56,14 @@ void ChopperCommandSettings::step(const System& system) {
     // update terminal status
     m_lives = readRam(&system, 0xE4) & 0xF; 
     m_terminal = (m_lives == 0);
+    m_is_started = (readRam(&system, 0xC2) == 1);
 }
 
 
 /* is end of game */
 bool ChopperCommandSettings::isTerminal() const {
 
-    return m_terminal;
+    return (m_is_started && m_terminal);
 };
 
 
@@ -109,6 +110,7 @@ void ChopperCommandSettings::reset() {
     m_score    = 0;
     m_terminal = false;
     m_lives    = 3;
+    m_is_started = false;
 }
 
 
@@ -127,5 +129,35 @@ void ChopperCommandSettings::loadState(Deserializer & ser) {
   m_score = ser.getInt();
   m_terminal = ser.getBool();
   m_lives = ser.getInt();
+}
+
+
+// returns a list of mode that the game can be played in
+ModeVect ChopperCommandSettings::getAvailableModes() {
+    ModeVect modes = {0, 2};
+    return modes;
+}
+
+// set the mode of the game
+// the given mode must be one returned by the previous function
+void ChopperCommandSettings::setMode(game_mode_t m, System &system,
+                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
+
+    if(m == 0 || m == 2){
+        // read the mode we are currently in
+        unsigned char mode = readRam(&system, 0xE0);
+        // press select until the correct mode is reached
+        while (mode != m) {
+            environment->pressSelect(2);
+            mode = readRam(&system, 0xE0);
+        }
+        //reset the environment to apply changes.
+        environment->softReset();
+    }
+ }
+
+DifficultyVect ChopperCommandSettings::getAvailableDifficulties() {
+    DifficultyVect diff = {0, 1};
+    return diff;
 }
 

--- a/src/games/supported/ChopperCommand.hpp
+++ b/src/games/supported/ChopperCommand.hpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 67 and 74 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -49,6 +49,9 @@ class ChopperCommandSettings : public RomSettings {
         // the rom-name
         const char* rom() const { return "chopper_command"; }
 
+        // get the available number of modes
+        unsigned int getNumModes() const { return 2; }
+
         // create a new instance of the rom
         RomSettings* clone() const;
 
@@ -66,8 +69,22 @@ class ChopperCommandSettings : public RomSettings {
 
         virtual int lives() { return m_lives; }
 
+        // returns a list of mode that the game can be played in
+        // in this game, there are 2 available modes
+        ModeVect getAvailableModes();
+
+        // set the mode of the game
+        // the given mode must be one returned by the previous function
+        void setMode(game_mode_t, System &system,
+                     std::unique_ptr<StellaEnvironmentWrapper> environment); 
+
+        // returns a list of difficulties that the game can be played in
+        // in this game, there are 2 available difficulties
+        DifficultyVect getAvailableDifficulties();
+
     private:
 
+        bool m_is_started;
         bool m_terminal;
         reward_t m_reward;
         reward_t m_score;

--- a/src/games/supported/DemonAttack.cpp
+++ b/src/games/supported/DemonAttack.cpp
@@ -139,7 +139,6 @@ void DemonAttackSettings::setMode(game_mode_t m, System &system,
         unsigned char mode = readRam(&system, 0xEA);
         // press select until the correct mode is reached
         while (mode != m) {
-            m_level_change = true;
             environment->pressSelect(1);
             mode = readRam(&system, 0xEA);
         }

--- a/src/games/supported/DemonAttack.cpp
+++ b/src/games/supported/DemonAttack.cpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 48, 89, 98 and 106 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -59,8 +59,10 @@ void DemonAttackSettings::step(const System& system) {
     // update terminal status
     int lives_displayed = readRam(&system, 0xF2);
     int display_flag = readRam(&system, 0xF1);
-    m_terminal = (lives_displayed == 0) && display_flag == 0xBD;
+    // for terminal checking, we must make sure that we do not detect incorrectly a level change as a game-over
+    m_terminal = (lives_displayed == 0) && display_flag == 0xBD && !m_level_change;
     m_lives = lives_displayed + 1; // Once we reach terminal, lives() will correctly return 0
+    m_level_change = false;
 }
 
 
@@ -102,6 +104,7 @@ void DemonAttackSettings::reset() {
     m_score    = 0;
     m_terminal = false;
     m_lives    = 4;
+    m_level_change = false;
 }
 
         
@@ -120,4 +123,35 @@ void DemonAttackSettings::loadState(Deserializer & ser) {
   m_terminal = ser.getBool();
   m_lives = ser.getInt();
 }
+
+// returns a list of mode that the game can be played in
+ModeVect DemonAttackSettings::getAvailableModes() {
+    ModeVect modes = {1, 3, 5, 7};
+    return modes;
+}
+
+// set the mode of the game
+// the given mode must be one returned by the previous function
+void DemonAttackSettings::setMode(game_mode_t m, System &system,
+                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
+    if(m == 1 || m == 3 || m == 5 || m == 7) {
+        // read the mode we are currently in
+        unsigned char mode = readRam(&system, 0xEA);
+        // press select until the correct mode is reached
+        while (mode != m) {
+            m_level_change = true;
+            environment->pressSelect(1);
+            mode = readRam(&system, 0xEA);
+        }
+        m_level_change = true;
+        //reset the environment to apply changes.
+        environment->softReset();
+    }
+ }
+
+DifficultyVect DemonAttackSettings::getAvailableDifficulties() {
+    DifficultyVect diff = {0, 1};
+    return diff;
+}
+
 

--- a/src/games/supported/DemonAttack.cpp
+++ b/src/games/supported/DemonAttack.cpp
@@ -147,6 +147,9 @@ void DemonAttackSettings::setMode(game_mode_t m, System &system,
         //reset the environment to apply changes.
         environment->softReset();
     }
+    else {
+        throw std::runtime_error("This mode doesn't currently exist for this game");
+    }
  }
 
 DifficultyVect DemonAttackSettings::getAvailableDifficulties() {

--- a/src/games/supported/DemonAttack.hpp
+++ b/src/games/supported/DemonAttack.hpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 67 and 74 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -49,6 +49,9 @@ class DemonAttackSettings : public RomSettings {
         // the rom-name
         const char* rom() const { return "demon_attack"; }
 
+        // get the available number of modes
+        unsigned int getNumModes() const { return 8; }
+
         // create a new instance of the rom
         RomSettings* clone() const;
 
@@ -66,12 +69,26 @@ class DemonAttackSettings : public RomSettings {
 
         virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
+        // returns a list of mode that the game can be played in
+        // in this game, there are 8 available modes
+        ModeVect getAvailableModes();
+
+        // set the mode of the game
+        // the given mode must be one returned by the previous function
+        void setMode(game_mode_t, System &system,
+                     std::unique_ptr<StellaEnvironmentWrapper> environment); 
+
+        // returns a list of difficulties that the game can be played in
+        // in this game, there are 2 available difficulties
+        DifficultyVect getAvailableDifficulties();
+
     private:
 
         bool m_terminal;
         reward_t m_reward;
         reward_t m_score;
         int m_lives;
+        bool m_level_change;
 };
 
 #endif // __DEMONATTACK_HPP__

--- a/src/games/supported/Freeway.cpp
+++ b/src/games/supported/Freeway.cpp
@@ -1,4 +1,6 @@
 /* *****************************************************************************
+ * The method lives() is based on Xitari's code, from Google Inc.
+ *
  * A.L.E (Arcade Learning Environment)
  * Copyright (c) 2009-2013 by Yavar Naddaf, Joel Veness, Marc G. Bellemare and 
  *   the Reinforcement Learning and Artificial Intelligence Laboratory

--- a/src/games/supported/Freeway.cpp
+++ b/src/games/supported/Freeway.cpp
@@ -100,7 +100,7 @@ void FreewaySettings::loadState(Deserializer & ser) {
 
 // returns a list of mode that the game can be played in
 ModeVect FreewaySettings::getAvailableModes() {
-    ModeVect modes(getNumNodes());
+    ModeVect modes(getNumModes());
     for (unsigned int i = 0; i < modes.size(); i++) {
         modes[i] = i;
     }

--- a/src/games/supported/Freeway.cpp
+++ b/src/games/supported/Freeway.cpp
@@ -117,7 +117,7 @@ void FreewaySettings::setMode(game_mode_t m, System &system,
         unsigned char mode = readRam(&system, 0x80);
         // press select until the correct mode is reached
         while (mode != m) {
-            environment->pressSelect(1);
+            environment->pressSelect();
             mode = readRam(&system, 0x80);
         }
         //reset the environment to apply changes.

--- a/src/games/supported/Freeway.cpp
+++ b/src/games/supported/Freeway.cpp
@@ -112,15 +112,20 @@ ModeVect FreewaySettings::getAvailableModes() {
 void FreewaySettings::setMode(game_mode_t m, System &system,
                               std::unique_ptr<StellaEnvironmentWrapper> environment) {
 
-    // read the mode we are currently in
-    unsigned char mode = readRam(&system, 0x80);
-    // press select until the correct mode is reached
-    while (mode != m) {
-        environment->pressSelect(1);
-        mode = readRam(&system, 0x80);
+    if(m < getNumModes()) {
+        // read the mode we are currently in
+        unsigned char mode = readRam(&system, 0x80);
+        // press select until the correct mode is reached
+        while (mode != m) {
+            environment->pressSelect(1);
+            mode = readRam(&system, 0x80);
+        }
+        //reset the environment to apply changes.
+        environment->softReset();
     }
-    //reset the environment to apply changes.
-    environment->softReset();
+    else {
+        throw std::runtime_error("This mode doesn't currently exist for this game");
+    }
  }
 
 DifficultyVect FreewaySettings::getAvailableDifficulties() {

--- a/src/games/supported/Freeway.hpp
+++ b/src/games/supported/Freeway.hpp
@@ -51,7 +51,7 @@ class FreewaySettings : public RomSettings {
         const char* rom() const { return "freeway"; }
 
         // get the available number of modes
-        unsigned int getNumNodes() const { return 8; }
+        unsigned int getNumModes() const { return 8; }
 
         // create a new instance of the rom
         RomSettings* clone() const;

--- a/src/games/supported/Freeway.hpp
+++ b/src/games/supported/Freeway.hpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The line 67 is based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2

--- a/src/games/supported/Frostbite.cpp
+++ b/src/games/supported/Frostbite.cpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 61, 115, 123 and 131 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -132,4 +132,26 @@ void FrostbiteSettings::loadState(Deserializer & ser) {
   m_terminal = ser.getBool();
   m_lives = ser.getInt();
 }
+
+// returns a list of mode that the game can be played in
+ModeVect FrostbiteSettings::getAvailableModes() {
+    ModeVect modes = {0, 2};
+    return modes;
+}
+
+// set the mode of the game
+// the given mode must be one returned by the previous function
+void FrostbiteSettings::setMode(game_mode_t m, System &system,
+                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
+
+    // read the mode we are currently in
+    unsigned char mode = readRam(&system, 0x80);
+    // press select until the correct mode is reached
+    while (mode != m) {
+        environment->pressSelect(1);
+        mode = readRam(&system, 0x80);
+    }
+    //reset the environment to apply changes.
+    environment->softReset();
+ }
 

--- a/src/games/supported/Frostbite.cpp
+++ b/src/games/supported/Frostbite.cpp
@@ -144,14 +144,19 @@ ModeVect FrostbiteSettings::getAvailableModes() {
 void FrostbiteSettings::setMode(game_mode_t m, System &system,
                               std::unique_ptr<StellaEnvironmentWrapper> environment) {
 
-    // read the mode we are currently in
-    unsigned char mode = readRam(&system, 0x80);
-    // press select until the correct mode is reached
-    while (mode != m) {
-        environment->pressSelect(1);
-        mode = readRam(&system, 0x80);
+    if(m == 0 || m == 2) {
+        // read the mode we are currently in
+        unsigned char mode = readRam(&system, 0x80);
+        // press select until the correct mode is reached
+        while (mode != m) {
+            environment->pressSelect(1);
+            mode = readRam(&system, 0x80);
+        }
+        //reset the environment to apply changes.
+        environment->softReset();
     }
-    //reset the environment to apply changes.
-    environment->softReset();
+    else {
+        throw std::runtime_error("This mode doesn't currently exist for this game");
+    }
  }
 

--- a/src/games/supported/Frostbite.hpp
+++ b/src/games/supported/Frostbite.hpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 67 and 74 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -49,6 +49,9 @@ class FrostbiteSettings : public RomSettings {
         // the rom-name
         const char* rom() const { return "frostbite"; }
 
+        // get the available number of modes
+        unsigned int getNumModes() const { return 2; }
+
         // create a new instance of the rom
         RomSettings* clone() const;
 
@@ -65,6 +68,16 @@ class FrostbiteSettings : public RomSettings {
         void loadState(Deserializer & ser);
 
         virtual int lives() { return isTerminal() ? 0 : m_lives; }
+
+        // returns a list of mode that the game can be played in
+        // in this game, there are 2 available modes
+        ModeVect getAvailableModes();
+
+        // set the mode of the game
+        // the given mode must be one returned by the previous function
+        void setMode(game_mode_t, System &system,
+                     std::unique_ptr<StellaEnvironmentWrapper> environment); 
+
 
     private:
 

--- a/src/games/supported/JamesBond.cpp
+++ b/src/games/supported/JamesBond.cpp
@@ -153,7 +153,7 @@ void JamesBondSettings::setMode(game_mode_t m, System &system,
         // read the mode we are currently in
         unsigned char mode = readRam(&system, 0x8C);
         // press select until the correct mode is reached
-        //in the welcome screen, the value of the mode is increased by 0x48
+        // in the welcome screen, the value of the mode is increased by 0x48
         while (mode != m && mode != m + 0x48) {
             environment->pressSelect(20);
             mode = readRam(&system, 0x8C);

--- a/src/games/supported/JamesBond.cpp
+++ b/src/games/supported/JamesBond.cpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 63, 64, 117, 126 and 134 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -134,3 +134,29 @@ void JamesBondSettings::loadState(Deserializer & ser) {
   m_lives = ser.getInt();
 }
 
+
+// returns a list of mode that the game can be played in
+ModeVect JamesBondSettings::getAvailableModes() {
+    ModeVect modes(getNumModes());
+    for (unsigned int i = 0; i < modes.size(); i++) {
+        modes[i] = i;
+    }
+    return modes;
+}
+
+// set the mode of the game
+// the given mode must be one returned by the previous function
+void JamesBondSettings::setMode(game_mode_t m, System &system,
+                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
+
+    // read the mode we are currently in
+    unsigned char mode = readRam(&system, 0x8C);
+    // press select until the correct mode is reached
+    //in the welcome screen, the value of the mode is increased by 0x48
+    while (mode != m && mode != m + 0x48) {
+        environment->pressSelect(20);
+        mode = readRam(&system, 0x8C);
+    }
+    //reset the environment to apply changes.
+    environment->softReset();
+ }

--- a/src/games/supported/JamesBond.cpp
+++ b/src/games/supported/JamesBond.cpp
@@ -149,14 +149,19 @@ ModeVect JamesBondSettings::getAvailableModes() {
 void JamesBondSettings::setMode(game_mode_t m, System &system,
                               std::unique_ptr<StellaEnvironmentWrapper> environment) {
 
-    // read the mode we are currently in
-    unsigned char mode = readRam(&system, 0x8C);
-    // press select until the correct mode is reached
-    //in the welcome screen, the value of the mode is increased by 0x48
-    while (mode != m && mode != m + 0x48) {
-        environment->pressSelect(20);
-        mode = readRam(&system, 0x8C);
+    if(m == 0 || m == 1) {
+        // read the mode we are currently in
+        unsigned char mode = readRam(&system, 0x8C);
+        // press select until the correct mode is reached
+        //in the welcome screen, the value of the mode is increased by 0x48
+        while (mode != m && mode != m + 0x48) {
+            environment->pressSelect(20);
+            mode = readRam(&system, 0x8C);
+        }
+        //reset the environment to apply changes.
+        environment->softReset();
     }
-    //reset the environment to apply changes.
-    environment->softReset();
+    else {
+        throw std::runtime_error("This mode doesn't currently exist for this game");
+    }
  }

--- a/src/games/supported/JamesBond.hpp
+++ b/src/games/supported/JamesBond.hpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 67 and 74 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -49,6 +49,9 @@ class JamesBondSettings : public RomSettings {
         // the rom-name
         const char* rom() const { return "jamesbond"; }
 
+        // get the available number of modes
+        unsigned int getNumModes() const { return 2; }
+
         // create a new instance of the rom
         RomSettings* clone() const;
 
@@ -65,6 +68,15 @@ class JamesBondSettings : public RomSettings {
         void loadState(Deserializer & ser);
 
         virtual int lives() { return isTerminal() ? 0 : m_lives; }
+
+        // returns a list of mode that the game can be played in
+        // in this game, there are 2 available modes
+        ModeVect getAvailableModes();
+
+        // set the mode of the game
+        // the given mode must be one returned by the previous function
+        void setMode(game_mode_t, System &system,
+                     std::unique_ptr<StellaEnvironmentWrapper> environment); 
 
     private:
 

--- a/src/games/supported/JourneyEscape.cpp
+++ b/src/games/supported/JourneyEscape.cpp
@@ -1,4 +1,6 @@
 /* *****************************************************************************
+ * The method lives() is based on Xitari's code, from Google Inc.
+ *
  * A.L.E (Arcade Learning Environment)
  * Copyright (c) 2009-2013 by Yavar Naddaf, Joel Veness, Marc G. Bellemare and 
  *   the Reinforcement Learning and Artificial Intelligence Laboratory
@@ -116,4 +118,8 @@ ActionVect JourneyEscapeSettings::getStartingActions() {
     return startingActions;
 }
 
+DifficultyVect JourneyEscapeSettings::getAvailableDifficulties() {
+    DifficultyVect diff = {0, 1};
+    return diff;
+}
 

--- a/src/games/supported/JourneyEscape.hpp
+++ b/src/games/supported/JourneyEscape.hpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The line 70 is based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -68,6 +68,10 @@ class JourneyEscapeSettings : public RomSettings {
         ActionVect getStartingActions();
 
         virtual int lives() { return 0; }
+
+        // returns a list of difficulties that the game can be played in
+        // in this game, there are 2 available difficulties
+        DifficultyVect getAvailableDifficulties();
 
     private:
 

--- a/src/games/supported/QBert.cpp
+++ b/src/games/supported/QBert.cpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 57, 59, 115, 124 and 133 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -131,5 +131,10 @@ void QBertSettings::loadState(Deserializer & ser) {
   m_terminal = ser.getBool();
   m_last_lives = ser.getInt();
   m_lives = ser.getInt();
+}
+
+DifficultyVect QBertSettings::getAvailableDifficulties() {
+    DifficultyVect diff = {0, 1};
+    return diff;
 }
 

--- a/src/games/supported/QBert.hpp
+++ b/src/games/supported/QBert.hpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 67 and 75 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -65,6 +65,10 @@ class QBertSettings : public RomSettings {
         void loadState(Deserializer & ser);
 
         virtual int lives() { return isTerminal() ? 0 : m_lives; } 
+
+        // returns a list of difficulties that the game can be played in
+        // in this game, there are 2 available difficulties
+        DifficultyVect getAvailableDifficulties();
 
     private:
 

--- a/src/games/supported/RiverRaid.cpp
+++ b/src/games/supported/RiverRaid.cpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 84 - 91 and 143 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -159,3 +159,9 @@ void RiverRaidSettings::loadState(Deserializer & ser) {
   m_terminal = ser.getBool();
   m_lives_byte = ser.getInt();
 }
+
+DifficultyVect RiverRaidSettings::getAvailableDifficulties() {
+    DifficultyVect diff = {0, 1};
+    return diff;
+}
+

--- a/src/games/supported/RiverRaid.hpp
+++ b/src/games/supported/RiverRaid.hpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 68, 73 and 79 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -66,6 +66,10 @@ class RiverRaidSettings : public RomSettings {
         void loadState(Deserializer & ser);
 
         virtual int lives() { return isTerminal() ? 0 : numericLives(); } 
+
+        // returns a list of difficulties that the game can be played in
+        // in this game, there are 2 available difficulties
+        DifficultyVect getAvailableDifficulties();
 
     private:
 

--- a/src/games/supported/Seaquest.cpp
+++ b/src/games/supported/Seaquest.cpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 57, 110, 119 and 127 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -127,3 +127,7 @@ void SeaquestSettings::loadState(Deserializer & ser) {
   m_lives = ser.getInt();
 }
 
+DifficultyVect SeaquestSettings::getAvailableDifficulties() {
+    DifficultyVect diff = {0, 1};
+    return diff;
+}

--- a/src/games/supported/Seaquest.hpp
+++ b/src/games/supported/Seaquest.hpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 67 and 74 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -65,6 +65,10 @@ class SeaquestSettings : public RomSettings {
         void loadState(Deserializer & ser);
 
         virtual int lives() { return isTerminal() ? 0 : m_lives; }
+
+        // returns a list of difficulties that the game can be played in
+        // in this game, there are 2 available difficulties
+        DifficultyVect getAvailableDifficulties();
 
     private:
 

--- a/src/games/supported/Zaxxon.cpp
+++ b/src/games/supported/Zaxxon.cpp
@@ -147,6 +147,7 @@ void ZaxxonSettings::setMode(game_mode_t m, System &system,
     unsigned char mode = readRam(&system, 0x82);
     // press select until the correct mode is reached
     while (mode != m) {
+        // hold select button for 10 frames
         environment->pressSelect(10);
         mode = readRam(&system, 0x82);
     }

--- a/src/games/supported/Zaxxon.cpp
+++ b/src/games/supported/Zaxxon.cpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 61, 63, 116, 124 and 132 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -131,4 +131,26 @@ void ZaxxonSettings::loadState(Deserializer & ser) {
   m_terminal = ser.getBool();
   m_lives = ser.getInt();
 }
+
+// returns a list of mode that the game can be played in
+ModeVect ZaxxonSettings::getAvailableModes() {
+    ModeVect modes = {0, 8, 16, 24};
+    return modes;
+}
+
+// set the mode of the game
+// the given mode must be one returned by the previous function
+void ZaxxonSettings::setMode(game_mode_t m, System &system,
+                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
+
+    // read the mode we are currently in
+    unsigned char mode = readRam(&system, 0x82);
+    // press select until the correct mode is reached
+    while (mode != m) {
+        environment->pressSelect(10);
+        mode = readRam(&system, 0x82);
+    }
+    //reset the environment to apply changes.
+    environment->softReset();
+ }
 

--- a/src/games/supported/Zaxxon.hpp
+++ b/src/games/supported/Zaxxon.hpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 67 and 74 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -49,6 +49,9 @@ class ZaxxonSettings : public RomSettings {
         // the rom-name
         const char* rom() const { return "zaxxon"; }
 
+        // get the available number of modes
+        unsigned int getNumModes() const { return 4; }
+
         // create a new instance of the rom
         RomSettings* clone() const;
 
@@ -65,6 +68,16 @@ class ZaxxonSettings : public RomSettings {
         void loadState(Deserializer & ser);
 
         virtual int lives() { return isTerminal() ? 0 : m_lives; }
+
+        // returns a list of mode that the game can be played in
+        // in this game, there are 4 available modes
+        ModeVect getAvailableModes();
+
+        // set the mode of the game
+        // the given mode must be one returned by the previous function
+        void setMode(game_mode_t, System &system,
+                     std::unique_ptr<StellaEnvironmentWrapper> environment); 
+
 
     private:
 


### PR DESCRIPTION
In order to submit small PRs I'm changing just 12 games for now. I'll keep working on the others. A summary of the current status is below. I won't deal with 2-player modes.

- **Games in which mode and difficulty switch are already implemented:**
`Alien`, `Amidar`, `BeamRider`, `ChopperCommand`, `DemonAttack`, `Freeway`, `Frostbite`, `Jamesbond`, `JourneyEscape`, `QBert`, `RiverRaid`, `Seaquest`.

- **Games in which mode and difficulty switch are not implemented yet:**
`Adventure`, `AirRaid`, `Asteroids`, `Atlantis`, `BankHeist`, `BattleZone`, `Berzerk`, `Bowling`, `Boxing`, `Breakout`, `Centipede`, `CrazyClimber`, `Defender`, `DoubleDunk`, `FishingDerby`, `Frogger`, `Galaxian`, `Gopher`, `Gravitar`, `Hero`, `IceHockey`, `Kaboom`, `Kangaroo`, `KingKong`, `Koolaid`, `LostLuggage`, `MrDo`, `MsPacMan`, `NameThisGame`, `Pong`, `Pooyan`, `PrivateEye`, `SirLancelot`, `SpaceInvaders`, `StarGunner`, `Tennis`, `TimePilot`, `Trondead`, `Turmoil`, `Tutankham`, `UpNDown`, `Venture`, `VideoPinball`, `WizardOfWor`, `YarsRevenge`.

- **Games that have only one one-player mode and difficulty:**
`Assault`, `Asterix`, `Carnival`, `ElevatorAction`, `Enduro`, `KungFuMaster`, `MontezumaRevenge`, `Phoenix`, `Pitfall`, `RoadRunner`, `Robotank`, `DonkeyKong`, `KeystoneKapers`, `LaserGates`, `Solaris`, `Tetris`.

- **Games that the only modes I'm not currently supporting are two-player modes**:
`Asterix`, `BeamRider`, `Carnival`, `ChopperCommand`, `DemonAttack`, `Frostbite`, `JourneyEscape`, `KungFuMaster`, `RiverRaid`, `RoadRunner`, `Seaquest`, `WizardOfWor`, `Zaxxon`.