### PR TITLE
Mode and difficulty switch in 34 games

### DIFF
--- a/doc/examples/python_example_with_modes.py
+++ b/doc/examples/python_example_with_modes.py
@@ -49,8 +49,8 @@ legal_actions = ale.getLegalActionSet()
 for mode in avail_modes:
   for diff in avail_diff:
 
-    ale.setMode(mode)
     ale.setDifficulty(diff)
+    ale.setMode(mode)
     print 'Mode {0} difficulty {1}:'.format(mode, diff)
 
     total_reward = 0

--- a/doc/examples/sharedLibraryInterfaceWithModesExample.cpp
+++ b/doc/examples/sharedLibraryInterfaceWithModesExample.cpp
@@ -60,8 +60,8 @@ int main(int argc, char** argv) {
     for (int i = 0; i < modes.size(); i++){
         for (int j = 0; j < difficulties.size(); j++){
             
-            ale.setMode(modes[i]);
             ale.setDifficulty(difficulties[j]);
+            ale.setMode(modes[i]);
             cout << "Mode " << modes[i] << ", difficulty " << difficulties[j] << ":" << endl;
 
             float totalReward = 0;

--- a/src/games/supported/AirRaid.cpp
+++ b/src/games/supported/AirRaid.cpp
@@ -122,8 +122,7 @@ void AirRaidSettings::setMode(game_mode_t m, System &system,
     }
     if(m >= 1 && m <= getNumModes()) {
         //open the mode selection panel
-        environment->pressSelect(10);
-        environment->pressSelect(10);
+        environment->pressSelect(20);
         // read the mode we are currently in
         unsigned char mode = readRam(&system, 0xAA);
         // press select until the correct mode is reached

--- a/src/games/supported/AirRaid.cpp
+++ b/src/games/supported/AirRaid.cpp
@@ -101,3 +101,41 @@ ActionVect AirRaidSettings::getStartingActions() {
     startingActions.push_back(PLAYER_A_FIRE);
     return startingActions;
 }
+
+
+// returns a list of mode that the game can be played in
+ModeVect AirRaidSettings::getAvailableModes() {
+    ModeVect modes(getNumModes());
+    for (unsigned int i = 0; i < modes.size(); i++) {
+        modes[i] = i + 1;
+    }
+    return modes;
+}
+
+// set the mode of the game
+// the given mode must be one returned by the previous function
+void AirRaidSettings::setMode(game_mode_t m, System &system,
+                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
+
+    if(m == 0) {
+        m = 1; // the default mode is not valid in this game
+    }
+    if(m >= 1 && m <= getNumModes()) {
+        //open the mode selection panel
+        environment->pressSelect(10);
+        environment->pressSelect(10);
+        // read the mode we are currently in
+        unsigned char mode = readRam(&system, 0xAA);
+        // press select until the correct mode is reached
+        while (mode != m) {
+            // hold select button for 10 frames
+            environment->pressSelect(10);
+            mode = readRam(&system, 0xAA);
+        }
+        //reset the environment to apply changes.
+        environment->softReset();
+    }
+    else {
+        throw std::runtime_error("This mode doesn't currently exist for this game");
+    }
+ }

--- a/src/games/supported/AirRaid.hpp
+++ b/src/games/supported/AirRaid.hpp
@@ -34,6 +34,9 @@ class AirRaidSettings : public RomSettings {
         // the rom-name
         const char* rom() const { return "air_raid"; }
 
+        // get the available number of modes
+        unsigned int getNumModes() const { return 8; }
+
         // create a new instance of the rom
         RomSettings* clone() const;
 
@@ -49,7 +52,17 @@ class AirRaidSettings : public RomSettings {
         // loads the state of the rom settings
         void loadState(Deserializer & ser);
 
-        ActionVect getStartingActions();    
+        ActionVect getStartingActions();
+
+        
+        // returns a list of mode that the game can be played in
+        // in this game, there are 8 available modes
+        ModeVect getAvailableModes();
+
+        // set the mode of the game
+        // the given mode must be one returned by the previous function
+        void setMode(game_mode_t, System &system,
+                     std::unique_ptr<StellaEnvironmentWrapper> environment); 
 
      private:
 

--- a/src/games/supported/Asteroids.cpp
+++ b/src/games/supported/Asteroids.cpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 42 - 44, 92, 102 and 110 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -129,5 +129,41 @@ void AsteroidsSettings::loadState(Deserializer & ser) {
   m_score = ser.getInt();
   m_terminal = ser.getBool();
   m_lives = ser.getInt();
+}
+
+// returns a list of mode that the game can be played in
+ModeVect AsteroidsSettings::getAvailableModes() {
+    ModeVect modes(getNumModes() - 1);
+    for (unsigned int i = 0; i < modes.size(); i++) {
+        modes[i] = i;
+    }
+    modes.push_back(0x80); //this is the "kids" mode
+    return modes;
+}
+
+// set the mode of the game
+// the given mode must be one returned by the previous function
+void AsteroidsSettings::setMode(game_mode_t m, System &system,
+                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
+
+    if(m < 32 || m == 0x80) {
+        // read the mode we are currently in
+        unsigned char mode = readRam(&system, 0x80);
+        // press select until the correct mode is reached
+        while (mode != m) {
+            environment->pressSelect(2);
+            mode = readRam(&system, 0x80);
+        }
+        //reset the environment to apply changes.
+        environment->softReset();
+    }
+    else {
+        throw std::runtime_error("This mode doesn't currently exist for this game");
+    }
+ }
+
+DifficultyVect AsteroidsSettings::getAvailableDifficulties() {
+    DifficultyVect diff = {0, 3};
+    return diff;
 }
 

--- a/src/games/supported/Asteroids.hpp
+++ b/src/games/supported/Asteroids.hpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 67 and 74 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -49,6 +49,9 @@ class AsteroidsSettings : public RomSettings {
         // the rom-name
         const char* rom() const { return "asteroids"; }
 
+        // get the available number of modes
+        unsigned int getNumModes() const { return 33; }
+
         // create a new instance of the rom
         RomSettings* clone() const;
 
@@ -65,6 +68,19 @@ class AsteroidsSettings : public RomSettings {
         void loadState(Deserializer & ser);
 
         virtual int lives()  { return isTerminal() ? 0 : m_lives; }
+
+        // returns a list of mode that the game can be played in
+        // in this game, there are 33 available modes
+        ModeVect getAvailableModes();
+
+        // set the mode of the game
+        // the given mode must be one returned by the previous function
+        void setMode(game_mode_t, System &system,
+                     std::unique_ptr<StellaEnvironmentWrapper> environment); 
+
+        // returns a list of difficulties that the game can be played in
+        // in this game, there are 2 available difficulties
+        DifficultyVect getAvailableDifficulties();
 
     private:
 

--- a/src/games/supported/Atlantis.cpp
+++ b/src/games/supported/Atlantis.cpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 100, 110 and 118 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -127,4 +127,34 @@ void AtlantisSettings::loadState(Deserializer & ser) {
   m_terminal = ser.getBool();
   m_lives = ser.getInt();
 }
+
+// returns a list of mode that the game can be played in
+ModeVect AtlantisSettings::getAvailableModes() {
+    ModeVect modes(getNumModes());
+    for (unsigned int i = 0; i < modes.size(); i++) {
+        modes[i] = i;
+    }
+    return modes;
+}
+
+// set the mode of the game
+// the given mode must be one returned by the previous function
+void AtlantisSettings::setMode(game_mode_t m, System &system,
+                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
+
+    if(m < getNumModes()) {
+        // read the mode we are currently in
+        unsigned char mode = readRam(&system, 0x8D);
+        // press select until the correct mode is reached
+        while (mode != m) {
+            environment->pressSelect(2);
+            mode = readRam(&system, 0x8D);
+        }
+        //reset the environment to apply changes.
+        environment->softReset();
+    }
+    else {
+        throw std::runtime_error("This mode doesn't currently exist for this game");
+    }
+ }
 

--- a/src/games/supported/Atlantis.hpp
+++ b/src/games/supported/Atlantis.hpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 67 and 74 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -49,6 +49,9 @@ class AtlantisSettings : public RomSettings {
         // the rom-name
         const char* rom() const { return "atlantis"; }
 
+        // get the available number of modes
+        unsigned int getNumModes() const { return 4; }
+
         // create a new instance of the rom
         RomSettings* clone() const;
 
@@ -65,6 +68,15 @@ class AtlantisSettings : public RomSettings {
         void loadState(Deserializer & ser);
 
         virtual int lives() { return isTerminal() ? 0 : m_lives; }
+
+        // returns a list of mode that the game can be played in
+        // in this game, there are 8 available modes
+        ModeVect getAvailableModes();
+
+        // set the mode of the game
+        // the given mode must be one returned by the previous function
+        void setMode(game_mode_t, System &system,
+                     std::unique_ptr<StellaEnvironmentWrapper> environment);
 
     private:
 

--- a/src/games/supported/BankHeist.cpp
+++ b/src/games/supported/BankHeist.cpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 97, 107 and 115 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -130,3 +130,38 @@ void BankHeistSettings::loadState(Deserializer & ser) {
   m_lives = ser.getInt();
 }
 
+// returns a list of mode that the game can be played in
+ModeVect BankHeistSettings::getAvailableModes() {
+    ModeVect modes(getNumModes());
+    for (unsigned int i = 0; i < modes.size(); i++) {
+        modes[i] = i * 4;
+    }
+    return modes;
+}
+
+// set the mode of the game
+// the given mode must be one returned by the previous function
+void BankHeistSettings::setMode(game_mode_t m, System &system,
+                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
+
+    if(m <= 28 && m % 4==0) {
+        // read the mode we are currently in
+        unsigned char mode = readRam(&system, 0x80);
+        // press select until the correct mode is reached
+        while (mode != m) {
+            // hold select button for 10 frames
+            environment->pressSelect();
+            mode = readRam(&system, 0x80);
+        }
+        //reset the environment to apply changes.
+        environment->softReset();
+    }
+    else {
+        throw std::runtime_error("This mode doesn't currently exist for this game");
+    }
+ }
+
+DifficultyVect BankHeistSettings::getAvailableDifficulties() {
+    DifficultyVect diff = {0, 1, 2, 3};
+    return diff;
+}

--- a/src/games/supported/BankHeist.cpp
+++ b/src/games/supported/BankHeist.cpp
@@ -144,7 +144,7 @@ ModeVect BankHeistSettings::getAvailableModes() {
 void BankHeistSettings::setMode(game_mode_t m, System &system,
                               std::unique_ptr<StellaEnvironmentWrapper> environment) {
 
-    if(m <= 28 && m % 4==0) {
+    if(m <= 28 && m % 4 == 0) {
         // read the mode we are currently in
         unsigned char mode = readRam(&system, 0x80);
         // press select until the correct mode is reached

--- a/src/games/supported/BankHeist.hpp
+++ b/src/games/supported/BankHeist.hpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 67 and 74 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -49,6 +49,9 @@ class BankHeistSettings : public RomSettings {
         // the rom-name
         const char* rom() const { return "bank_heist"; }
 
+        // get the available number of modes
+        unsigned int getNumModes() const { return 8; }
+
         // create a new instance of the rom
         RomSettings* clone() const;
 
@@ -64,7 +67,20 @@ class BankHeistSettings : public RomSettings {
         // loads the state of the rom settings
         void loadState(Deserializer & ser);
 
-        virtual int lives() { return isTerminal() ? 0 : m_lives; }        
+        virtual int lives() { return isTerminal() ? 0 : m_lives; }
+
+        // returns a list of mode that the game can be played in
+        // in this game, there are 8 available modes
+        ModeVect getAvailableModes();
+
+        // set the mode of the game
+        // the given mode must be one returned by the previous function
+        void setMode(game_mode_t, System &system,
+                     std::unique_ptr<StellaEnvironmentWrapper> environment); 
+
+        // returns a list of difficulties that the game can be played in
+        // in this game, there are 2 available difficulties
+        DifficultyVect getAvailableDifficulties();
 
     private:
 

--- a/src/games/supported/BattleZone.cpp
+++ b/src/games/supported/BattleZone.cpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 125, 135 and 143 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -142,4 +142,37 @@ void BattleZoneSettings::loadState(Deserializer & ser) {
   m_terminal = ser.getBool();
   m_lives = ser.getInt();
 }
+
+// returns a list of mode that the game can be played in
+ModeVect BattleZoneSettings::getAvailableModes() {
+    ModeVect modes(getNumModes());
+    for (unsigned int i = 0; i < modes.size(); i++) {
+        modes[i] = i + 1;
+    }
+    return modes;
+}
+
+// set the mode of the game
+// the given mode must be one returned by the previous function
+void BattleZoneSettings::setMode(game_mode_t m, System &system,
+    std::unique_ptr<StellaEnvironmentWrapper> environment) {
+
+    if(m == 0) {
+        m = 1; // the default mode is not valid here
+    }
+    if(m >= 1 && m <= 3) {
+        // read the mode we are currently in
+        unsigned char mode = readRam(&system, 0xA1);
+        // press select until the correct mode is reached
+        while (mode != m) {
+            environment->pressSelect(2);
+            mode = readRam(&system, 0xA1);
+        }
+        //reset the environment to apply changes.
+        environment->softReset();
+    }
+    else {
+        throw std::runtime_error("This mode doesn't currently exist for this game");
+    }
+ }
 

--- a/src/games/supported/BattleZone.hpp
+++ b/src/games/supported/BattleZone.hpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 67 and 74 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -49,6 +49,9 @@ class BattleZoneSettings : public RomSettings {
         // the rom-name
         const char* rom() const { return "battle_zone"; }
 
+        // get the available number of modes
+        unsigned int getNumModes() const { return 3; }
+
         // create a new instance of the rom
         RomSettings* clone() const;
 
@@ -65,6 +68,15 @@ class BattleZoneSettings : public RomSettings {
         void loadState(Deserializer & ser);
 
         virtual int lives() { return isTerminal() ? 0 : m_lives; }
+
+        // returns a list of mode that the game can be played in
+        // in this game, there are 3 available modes
+        ModeVect getAvailableModes();
+
+        // set the mode of the game
+        // the given mode must be one returned by the previous function
+        void setMode(game_mode_t, System &system,
+                     std::unique_ptr<StellaEnvironmentWrapper> environment); 
 
     private:
 

--- a/src/games/supported/Berzerk.cpp
+++ b/src/games/supported/Berzerk.cpp
@@ -151,7 +151,7 @@ void BerzerkSettings::setMode(game_mode_t m, System &system,
     if(m == 0) {
         m = 1; // The mode 0, which is the default, is not available in this game.
     }
-    if(m >= 1 && (m <= 9 || m == 16 || m == 17 || m == 18)) {
+    if(m >= 1 && (m <= 9 || m == 0x10 || m == 0x11 || m == 0x12)) {
         // we wait that the game is ready to change mode
         for(unsigned int i = 0; i < 20; i++) {
             environment->act(PLAYER_A_NOOP, PLAYER_B_NOOP);

--- a/src/games/supported/Berzerk.cpp
+++ b/src/games/supported/Berzerk.cpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 44, 97, 107 and 115 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -129,4 +129,46 @@ void BerzerkSettings::loadState(Deserializer & ser) {
   m_terminal = ser.getBool();
   m_lives = ser.getInt();
 }
+
+// returns a list of mode that the game can be played in
+ModeVect BerzerkSettings::getAvailableModes() {
+    ModeVect modes(getNumModes() - 3);
+    for (unsigned int i = 0; i < modes.size(); i++) {
+        //this is 1-12 in Atari-decimal (0x01 ... 0x09 0x10 0x11 0x12)
+        modes[i] = i + 1;
+    }
+    modes.push_back(0x10);
+    modes.push_back(0x11);
+    modes.push_back(0x12);
+    return modes;
+}
+
+// set the mode of the game
+// the given mode must be one returned by the previous function
+void BerzerkSettings::setMode(game_mode_t m, System &system,
+                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
+
+    if(m == 0) {
+        m = 1; // The mode 0, which is the default, is not available in this game.
+    }
+    if(m >= 1 && (m <= 9 || m == 16 || m == 17 || m == 18)) {
+        // we wait that the game is ready to change mode
+        for(unsigned int i = 0; i < 20; i++) {
+            environment->act(PLAYER_A_NOOP, PLAYER_B_NOOP);
+        }
+        // read the mode we are currently in
+        unsigned char mode = readRam(&system, 0x80);
+        // press select until the correct mode is reached
+        while (mode != m) {
+            environment->pressSelect(2);
+            mode = readRam(&system, 0x80);
+        }
+        //reset the environment to apply changes.
+        environment->softReset();
+    }
+    else {
+        throw std::runtime_error("This mode doesn't currently exist for this game");
+    }
+ }
+
 

--- a/src/games/supported/Berzerk.hpp
+++ b/src/games/supported/Berzerk.hpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 67 and 74 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -49,6 +49,9 @@ class BerzerkSettings : public RomSettings {
         // the rom-name
         const char* rom() const { return "berzerk"; }
 
+        // get the available number of modes
+        unsigned int getNumModes() const { return 12; }
+
         // create a new instance of the rom
         RomSettings* clone() const;
 
@@ -65,6 +68,16 @@ class BerzerkSettings : public RomSettings {
         void loadState(Deserializer & ser);
 
         virtual int lives() { return isTerminal() ? 0 : m_lives; }
+
+        // returns a list of mode that the game can be played in
+        // in this game, there are 12 available modes
+        ModeVect getAvailableModes();
+
+        // set the mode of the game
+        // the given mode must be one returned by the previous function
+        void setMode(game_mode_t, System &system,
+                     std::unique_ptr<StellaEnvironmentWrapper> environment); 
+
 
     private:
 

--- a/src/games/supported/Bowling.cpp
+++ b/src/games/supported/Bowling.cpp
@@ -98,3 +98,35 @@ void BowlingSettings::loadState(Deserializer & ser) {
   m_terminal = ser.getBool();
 }
 
+// returns a list of mode that the game can be played in
+ModeVect BowlingSettings::getAvailableModes() {
+    ModeVect modes = {0, 2, 4};
+    return modes;
+}
+
+// set the mode of the game
+// the given mode must be one returned by the previous function
+void BowlingSettings::setMode(game_mode_t m, System &system,
+                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
+
+    if(m == 0 || m == 2 || m == 4) {
+        // read the mode we are currently in
+        unsigned char mode = readRam(&system, 2);
+        // press select until the correct mode is reached
+        while (mode != m) {
+            environment->pressSelect(2);
+            mode = readRam(&system, 2);
+        }
+        //reset the environment to apply changes.
+        environment->softReset();
+    }
+    else {
+        throw std::runtime_error("This mode doesn't currently exist for this game");
+    }
+ }
+
+DifficultyVect BowlingSettings::getAvailableDifficulties() {
+    DifficultyVect diff = {0, 1};
+    return diff;
+}
+

--- a/src/games/supported/Bowling.hpp
+++ b/src/games/supported/Bowling.hpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The line 67 is based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -49,6 +49,9 @@ class BowlingSettings : public RomSettings {
         // the rom-name
         const char* rom() const { return "bowling"; }
 
+        // get the available number of modes
+        unsigned int getNumModes() const { return 3; }
+
         // create a new instance of the rom
         RomSettings* clone() const;
 
@@ -66,6 +69,19 @@ class BowlingSettings : public RomSettings {
 
         // No lives in bowling!
         virtual int lives() { return 0; }
+
+        // returns a list of mode that the game can be played in
+        // in this game, there are 3 available modes
+        ModeVect getAvailableModes();
+
+        // set the mode of the game
+        // the given mode must be one returned by the previous function
+        void setMode(game_mode_t, System &system,
+                     std::unique_ptr<StellaEnvironmentWrapper> environment); 
+
+        // returns a list of difficulties that the game can be played in
+        // in this game, there are 2 available difficulties
+        DifficultyVect getAvailableDifficulties();
 
     private:
 

--- a/src/games/supported/Boxing.cpp
+++ b/src/games/supported/Boxing.cpp
@@ -123,3 +123,7 @@ void BoxingSettings::loadState(Deserializer & ser) {
   m_terminal = ser.getBool();
 }
 
+DifficultyVect BoxingSettings::getAvailableDifficulties() {
+    DifficultyVect diff = {0, 1, 2, 3};
+    return diff;
+}

--- a/src/games/supported/Boxing.hpp
+++ b/src/games/supported/Boxing.hpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The line 67 is based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -65,6 +65,10 @@ class BoxingSettings : public RomSettings {
         void loadState(Deserializer & ser);
 
         virtual int lives() { return 0; }
+
+        // returns a list of difficulties that the game can be played in
+        // in this game, there are 4 available difficulties
+        DifficultyVect getAvailableDifficulties();
 
     private:
 

--- a/src/games/supported/Breakout.cpp
+++ b/src/games/supported/Breakout.cpp
@@ -124,7 +124,7 @@ void BreakoutSettings::loadState(Deserializer & ser) {
 ModeVect BreakoutSettings::getAvailableModes() {
     ModeVect modes(getNumModes());
     for (unsigned int i = 0; i < modes.size(); i++) {
-        modes[i] = i*4;
+        modes[i] = i * 4;
     }
     return modes;
 }

--- a/src/games/supported/Breakout.cpp
+++ b/src/games/supported/Breakout.cpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 61, 101, 113 and 122 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -118,5 +118,41 @@ void BreakoutSettings::loadState(Deserializer & ser) {
   m_terminal = ser.getBool();
   m_started = ser.getBool();
   m_lives = ser.getInt();
+}
+
+// returns a list of mode that the game can be played in
+ModeVect BreakoutSettings::getAvailableModes() {
+    ModeVect modes(getNumModes());
+    for (unsigned int i = 0; i < modes.size(); i++) {
+        modes[i] = i*4;
+    }
+    return modes;
+}
+
+// set the mode of the game
+// the given mode must be one returned by the previous function
+void BreakoutSettings::setMode(game_mode_t m, System &system,
+                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
+
+    if(m < getNumModes() * 4 && m % 4 == 0) {
+        // read the mode we are currently in
+        unsigned char mode = readRam(&system, 0xB2);
+        // press select until the correct mode is reached
+        while (mode != m) {
+            environment->pressSelect();
+            mode = readRam(&system, 0xB2);
+        }
+        //reset the environment to apply changes.
+        environment->softReset();
+    }
+    else {
+        throw std::runtime_error("This mode doesn't currently exist for this game");
+    }
+ }
+
+
+DifficultyVect BreakoutSettings::getAvailableDifficulties() {
+    DifficultyVect diff = {0, 1};
+    return diff;
 }
 

--- a/src/games/supported/Breakout.hpp
+++ b/src/games/supported/Breakout.hpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 68 and 76 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -49,6 +49,9 @@ class BreakoutSettings : public RomSettings {
         // the rom-name
         const char* rom() const { return "breakout"; }
 
+        // get the available number of modes
+        unsigned int getNumModes() const { return 12; }
+
         // create a new instance of the rom
         RomSettings* clone() const;
 
@@ -66,6 +69,19 @@ class BreakoutSettings : public RomSettings {
 
         // remaining lives
         int lives() { return isTerminal() ? 0 : m_lives; }
+
+        // returns a list of mode that the game can be played in
+        // in this game, there are 8 available modes
+        ModeVect getAvailableModes();
+
+        // set the mode of the game
+        // the given mode must be one returned by the previous function
+        void setMode(game_mode_t, System &system,
+                     std::unique_ptr<StellaEnvironmentWrapper> environment); 
+
+        // returns a list of difficulties that the game can be played in
+        // in this game, there are 2 available difficulties
+        DifficultyVect getAvailableDifficulties();
 
     private:
 

--- a/src/games/supported/Centipede.cpp
+++ b/src/games/supported/Centipede.cpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 59, 116, 126 and 134 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -133,4 +133,33 @@ void CentipedeSettings::loadState(Deserializer & ser) {
   m_terminal = ser.getBool();
   m_lives = ser.getInt();
 }
+
+// returns a list of mode that the game can be played in
+ModeVect CentipedeSettings::getAvailableModes() {
+    ModeVect modes = {0x16, 0x56};
+    return modes;
+}
+
+// set the mode of the game
+// the given mode must be one returned by the previous function
+void CentipedeSettings::setMode(game_mode_t m, System &system,
+                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
+    if (m == 0) {
+        m = 0x16; // The default mode doesn't work here.
+    }
+    if(m == 0x16 || m == 0x56) {
+        // read the mode we are currently in
+        unsigned char mode = readRam(&system, 0xA7);
+        // press select until the correct mode is reached
+        while (mode != m) {
+            environment->pressSelect(2);
+            mode = readRam(&system, 0xA7);
+        }
+        //reset the environment to apply changes.
+        environment->softReset();
+    }
+    else {
+        throw std::runtime_error("This mode doesn't currently exist for this game");
+    }
+ }
 

--- a/src/games/supported/Centipede.hpp
+++ b/src/games/supported/Centipede.hpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 67 and 74 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -49,6 +49,9 @@ class CentipedeSettings : public RomSettings {
         // the rom-name
         const char* rom() const { return "centipede"; }
 
+        // get the available number of modes
+        unsigned int getNumModes() const { return 2; }
+
         // create a new instance of the rom
         RomSettings* clone() const;
 
@@ -65,6 +68,15 @@ class CentipedeSettings : public RomSettings {
         void loadState(Deserializer & ser);
 
         virtual int lives() { return isTerminal() ? 0 : m_lives; }
+
+        // returns a list of mode that the game can be played in
+        // in this game, there are 8 available modes
+        ModeVect getAvailableModes();
+
+        // set the mode of the game
+        // the given mode must be one returned by the previous function
+        void setMode(game_mode_t, System &system,
+                     std::unique_ptr<StellaEnvironmentWrapper> environment); 
 
     private:
 

--- a/src/games/supported/CrazyClimber.cpp
+++ b/src/games/supported/CrazyClimber.cpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 117, 126 and 124 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -122,5 +122,40 @@ void CrazyClimberSettings::loadState(Deserializer & ser) {
   m_score = ser.getInt();
   m_terminal = ser.getBool();
   m_lives = ser.getInt();
+}
+
+// returns a list of mode that the game can be played in
+ModeVect CrazyClimberSettings::getAvailableModes() {
+    ModeVect modes(getNumModes());
+    for (unsigned int i = 0; i < modes.size(); i++) {
+        modes[i] = i;
+    }
+    return modes;
+}
+
+// set the mode of the game
+// the given mode must be one returned by the previous function
+void CrazyClimberSettings::setMode(game_mode_t m, System &system,
+    std::unique_ptr<StellaEnvironmentWrapper> environment) {
+
+    if(m < getNumModes()) {
+        // read the mode we are currently in
+        unsigned char mode = readRam(&system, 0x80);
+        // press select until the correct mode is reached
+        while (mode != m) {
+            environment->pressSelect(2);
+            mode = readRam(&system, 0x80);
+        }
+        //reset the environment to apply changes.
+        environment->softReset();
+    }
+    else {
+        throw std::runtime_error("This mode doesn't currently exist for this game");
+    }
+ }
+
+DifficultyVect CrazyClimberSettings::getAvailableDifficulties() {
+    DifficultyVect diff = {0, 1};
+    return diff;
 }
 

--- a/src/games/supported/CrazyClimber.hpp
+++ b/src/games/supported/CrazyClimber.hpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 67 and 74 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -49,6 +49,9 @@ class CrazyClimberSettings : public RomSettings {
         // the rom-name
         const char* rom() const { return "crazy_climber"; }
 
+        // get the available number of modes
+        unsigned int getNumModes() const { return 4; }
+
         // create a new instance of the rom
         RomSettings* clone() const;
 
@@ -65,6 +68,19 @@ class CrazyClimberSettings : public RomSettings {
         void loadState(Deserializer & ser);
 
         virtual int lives() { return isTerminal() ? 0 : m_lives; }
+
+        // returns a list of mode that the game can be played in
+        // in this game, there are 4 available modes
+        ModeVect getAvailableModes();
+
+        // set the mode of the game
+        // the given mode must be one returned by the previous function
+        void setMode(game_mode_t, System &system,
+                     std::unique_ptr<StellaEnvironmentWrapper> environment); 
+
+        // returns a list of difficulties that the game can be played in
+        // in this game, there are 2 available difficulties
+        DifficultyVect getAvailableDifficulties();
 
     private:
 

--- a/src/games/supported/Defender.cpp
+++ b/src/games/supported/Defender.cpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 117, 126 and 134 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -133,4 +133,44 @@ void DefenderSettings::loadState(Deserializer & ser) {
   m_terminal = ser.getBool();
   m_lives = ser.getInt();
 }
+
+// returns a list of mode that the game can be played in
+ModeVect DefenderSettings::getAvailableModes() {
+    ModeVect modes(getNumModes() - 1);
+    for (unsigned int i = 0; i < modes.size(); i++) {
+        modes[i] = i + 1;
+    }
+    modes.push_back(16); //easy mode
+    return modes;
+}
+
+// set the mode of the game
+// the given mode must be one returned by the previous function
+void DefenderSettings::setMode(game_mode_t m, System &system,
+                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
+
+    if(m == 0) {
+        m = 1; // The default mode (0) is not valid here.
+    }
+    if(m >= 1 && (m <= 9 || m == 16)) {
+        // read the mode we are currently in
+        unsigned char mode = readRam(&system, 0x9B);
+        // press select until the correct mode is reached
+        while (mode != m) {
+            environment->pressSelect(2);
+            mode = readRam(&system, 0x9B);
+        }
+        //reset the environment to apply changes.
+        environment->softReset();
+    }
+    else {
+        throw std::runtime_error("This mode doesn't currently exist for this game");
+    }
+ }
+
+DifficultyVect DefenderSettings::getAvailableDifficulties() {
+    DifficultyVect diff = {0, 1};
+    return diff;
+}
+
 

--- a/src/games/supported/Defender.hpp
+++ b/src/games/supported/Defender.hpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 67 and 74 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -49,6 +49,9 @@ class DefenderSettings : public RomSettings {
         // the rom-name
         const char* rom() const { return "defender"; }
 
+        // get the available number of modes
+        unsigned int getNumModes() const { return 10; }
+
         // create a new instance of the rom
         RomSettings* clone() const;
 
@@ -65,6 +68,19 @@ class DefenderSettings : public RomSettings {
         void loadState(Deserializer & ser);
 
         virtual int lives() { return isTerminal() ? 0 : m_lives; }
+
+        // returns a list of mode that the game can be played in
+        // in this game, there are 10 available modes
+        ModeVect getAvailableModes();
+
+        // set the mode of the game
+        // the given mode must be one returned by the previous function
+        void setMode(game_mode_t, System &system,
+                     std::unique_ptr<StellaEnvironmentWrapper> environment); 
+
+        // returns a list of difficulties that the game can be played in
+        // in this game, there are 2 available difficulties
+        DifficultyVect getAvailableDifficulties();
 
     private:
 

--- a/src/games/supported/DoubleDunk.cpp
+++ b/src/games/supported/DoubleDunk.cpp
@@ -116,3 +116,50 @@ ActionVect DoubleDunkSettings::getStartingActions() {
     startingActions.push_back(PLAYER_A_UPFIRE);
     return startingActions;
 }
+
+// returns a list of mode that the game can be played in
+ModeVect DoubleDunkSettings::getAvailableModes() {
+    // this game has a menu that allows to define various yes/no options
+    // setting these options define in a way a different mode
+    // there are 4 relevant options, which makes 2^4=16 available modes
+    ModeVect modes(getNumModes());
+    for (unsigned int i = 0; i < modes.size(); i++) {
+        modes[i] = i;
+    }
+    return modes;
+}
+
+// set the mode of the game
+// the given mode must be one returned by the previous function
+void DoubleDunkSettings::setMode(game_mode_t m, System &system,
+                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
+
+    if(m < getNumModes()) {
+        environment->pressSelect();
+        //discard the first two entries (irrelevant)
+        environment->act(PLAYER_A_DOWN, PLAYER_B_NOOP);
+        environment->act(PLAYER_A_NOOP, PLAYER_B_NOOP);
+        environment->act(PLAYER_A_DOWN, PLAYER_B_NOOP);
+        environment->act(PLAYER_A_NOOP, PLAYER_B_NOOP);
+        for(unsigned i = 0; i < 4; i++) {
+            if((m & (1 << i)) != 0) { //test if the ith bit is set
+                environment->act(PLAYER_A_RIGHT, PLAYER_B_NOOP);
+            } else {
+                environment->act(PLAYER_A_LEFT, PLAYER_B_NOOP);
+            }
+            environment->act(PLAYER_A_NOOP, PLAYER_B_NOOP);
+            environment->act(PLAYER_A_DOWN, PLAYER_B_NOOP);
+            environment->act(PLAYER_A_NOOP, PLAYER_B_NOOP);
+        }
+        //reset the environment to apply changes.
+        environment->softReset();
+        //apply starting action
+        environment->act(PLAYER_A_UPFIRE, PLAYER_B_NOOP);
+        environment->act(PLAYER_A_NOOP, PLAYER_B_NOOP);
+    }
+    else {
+        throw std::runtime_error("This mode doesn't currently exist for this game");
+    }
+ }
+
+

--- a/src/games/supported/DoubleDunk.hpp
+++ b/src/games/supported/DoubleDunk.hpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The line 69 is based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -49,6 +49,9 @@ class DoubleDunkSettings : public RomSettings {
         // the rom-name
         const char* rom() const { return "double_dunk"; }
 
+        // get the available number of modes
+        unsigned int getNumModes() const { return 16; }
+
         // create a new instance of the rom
         RomSettings* clone() const;
 
@@ -67,6 +70,16 @@ class DoubleDunkSettings : public RomSettings {
         ActionVect getStartingActions();
 
         virtual int lives() { return 0; }
+
+        // returns a list of mode that the game can be played in
+        // in this game, there are 16 available modes
+        ModeVect getAvailableModes();
+
+        // set the mode of the game
+        // the given mode must be one returned by the previous function
+        void setMode(game_mode_t, System &system,
+                     std::unique_ptr<StellaEnvironmentWrapper> environment); 
+
 
     private:
 

--- a/src/games/supported/FishingDerby.cpp
+++ b/src/games/supported/FishingDerby.cpp
@@ -114,3 +114,9 @@ void FishingDerbySettings::loadState(Deserializer & ser) {
   m_terminal = ser.getBool();
 }
 
+DifficultyVect FishingDerbySettings::getAvailableDifficulties() {
+    DifficultyVect diff = {0, 1, 2, 3};
+    return diff;
+}
+
+

--- a/src/games/supported/FishingDerby.hpp
+++ b/src/games/supported/FishingDerby.hpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The line 67 is based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -65,6 +65,10 @@ class FishingDerbySettings : public RomSettings {
         void loadState(Deserializer & ser);
 
         virtual int lives() { return 0; }
+
+        // returns a list of difficulties that the game can be played in
+        // in this game, there are 4 available difficulties
+        DifficultyVect getAvailableDifficulties();
 
     private:
 

--- a/src/games/supported/Gopher.cpp
+++ b/src/games/supported/Gopher.cpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 61, 62, 105, 114 and 122 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -126,4 +126,37 @@ ActionVect GopherSettings::getStartingActions() {
     ActionVect startingActions;
     startingActions.push_back(PLAYER_A_FIRE);
     return startingActions;
+}
+
+// returns a list of mode that the game can be played in
+ModeVect GopherSettings::getAvailableModes() {
+    ModeVect modes = {0, 2};
+    return modes;
+}
+
+// set the mode of the game
+// the given mode must be one returned by the previous function
+void GopherSettings::setMode(game_mode_t m, System &system,
+                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
+
+    if(m == 0 || m == 2) {
+        environment->softReset();
+        // read the mode we are currently in
+        unsigned char mode = readRam(&system, 0xD3);
+        // press select until the correct mode is reached
+        while (mode != m) {
+            environment->pressSelect(5);
+            mode = readRam(&system, 0xD3);
+        }
+        //reset the environment to apply changes.
+        environment->softReset();
+    }
+    else {
+        throw std::runtime_error("This mode doesn't currently exist for this game");
+    }
+ }
+
+DifficultyVect GopherSettings::getAvailableDifficulties() {
+    DifficultyVect diff = {0, 1};
+    return diff;
 }

--- a/src/games/supported/Gopher.hpp
+++ b/src/games/supported/Gopher.hpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 70 and 77 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -49,6 +49,9 @@ class GopherSettings : public RomSettings {
         // the rom-name
         const char* rom() const { return "gopher"; }
 
+        // get the available number of modes
+        unsigned int getNumModes() const { return 2; }
+
         // create a new instance of the rom
         RomSettings* clone() const;
 
@@ -68,6 +71,19 @@ class GopherSettings : public RomSettings {
         ActionVect getStartingActions();
 
         virtual int lives() { return isTerminal() ? 0 : m_lives; }
+
+        // returns a list of mode that the game can be played in
+        // in this game, there are 8 available modes
+        ModeVect getAvailableModes();
+
+        // set the mode of the game
+        // the given mode must be one returned by the previous function
+        void setMode(game_mode_t, System &system,
+                     std::unique_ptr<StellaEnvironmentWrapper> environment); 
+
+        // returns a list of difficulties that the game can be played in
+        // in this game, there are 2 available difficulties
+        DifficultyVect getAvailableDifficulties();
 
     private:
 

--- a/src/games/supported/Gravitar.hpp
+++ b/src/games/supported/Gravitar.hpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 70 and 77 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -49,6 +49,9 @@ class GravitarSettings : public RomSettings {
         // the rom-name
         const char* rom() const { return "gravitar"; }
 
+        // get the available number of modes
+        unsigned int getNumModes() const { return 5; }
+
         // create a new instance of the rom
         RomSettings* clone() const;
 
@@ -68,6 +71,15 @@ class GravitarSettings : public RomSettings {
         ActionVect getStartingActions();
 
         virtual int lives() { return isTerminal() ? 0 : m_lives; }
+
+        // returns a list of mode that the game can be played in
+        // in this game, there are 5 available modes
+        ModeVect getAvailableModes();
+
+        // set the mode of the game
+        // the given mode must be one returned by the previous function
+        void setMode(game_mode_t, System &system,
+                     std::unique_ptr<StellaEnvironmentWrapper> environment); 
 
     private:
 

--- a/src/games/supported/Hero.cpp
+++ b/src/games/supported/Hero.cpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 96, 106 and 114 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -129,3 +129,32 @@ void HeroSettings::loadState(Deserializer & ser) {
   m_lives = ser.getInt();
 }
 
+// returns a list of mode that the game can be played in
+ModeVect HeroSettings::getAvailableModes() {
+    ModeVect modes(getNumModes());
+    for (unsigned int i = 0; i < modes.size(); i++) {
+        modes[i] = i;
+    }
+    return modes;
+}
+
+// set the mode of the game
+// the given mode must be one returned by the previous function
+void HeroSettings::setMode(game_mode_t m, System &system,
+                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
+
+    if(m < getNumModes()) {
+        // read the mode we are currently in
+        unsigned char mode = readRam(&system, 0x80);
+        // press select until the correct mode is reached
+        while (mode != m) {
+            environment->pressSelect();
+            mode = readRam(&system, 0x80);
+        }
+        //reset the environment to apply changes.
+        environment->softReset();
+    }
+    else {
+        throw std::runtime_error("This mode doesn't currently exist for this game");
+    }
+ }

--- a/src/games/supported/Hero.hpp
+++ b/src/games/supported/Hero.hpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 67 and 74 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -49,6 +49,9 @@ class HeroSettings : public RomSettings {
         // the rom-name
         const char* rom() const { return "hero"; }
 
+        // get the available number of modes
+        unsigned int getNumModes() const { return 5; }
+
         // create a new instance of the rom
         RomSettings* clone() const;
 
@@ -65,6 +68,15 @@ class HeroSettings : public RomSettings {
         void loadState(Deserializer & ser);
 
         virtual int lives() { return isTerminal() ? 0 : m_lives; }
+
+        // returns a list of mode that the game can be played in
+        // in this game, there are 8 available modes
+        ModeVect getAvailableModes();
+
+        // set the mode of the game
+        // the given mode must be one returned by the previous function
+        void setMode(game_mode_t, System &system,
+                     std::unique_ptr<StellaEnvironmentWrapper> environment); 
 
     private:
 

--- a/src/games/supported/IceHockey.cpp
+++ b/src/games/supported/IceHockey.cpp
@@ -115,3 +115,35 @@ void IceHockeySettings::loadState(Deserializer & ser) {
   m_terminal = ser.getBool();
 }
 
+// returns a list of mode that the game can be played in
+ModeVect IceHockeySettings::getAvailableModes() {
+    ModeVect modes = {0, 2};
+    return modes;
+}
+
+// set the mode of the game
+// the given mode must be one returned by the previous function
+void IceHockeySettings::setMode(game_mode_t m, System &system,
+                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
+
+    if(m == 0 || m == 2) {
+        // read the mode we are currently in
+        unsigned char mode = readRam(&system, 0x80);
+        // press select until the correct mode is reached
+        while (mode != m) {
+            environment->pressSelect(2);
+            mode = readRam(&system, 0x80);
+        }
+        //reset the environment to apply changes.
+        environment->softReset();
+    }
+    else {
+        throw std::runtime_error("This mode doesn't currently exist for this game");
+    }
+ }
+
+DifficultyVect IceHockeySettings::getAvailableDifficulties() {
+    DifficultyVect diff = {0, 1, 2, 3};
+    return diff;
+}
+

--- a/src/games/supported/IceHockey.hpp
+++ b/src/games/supported/IceHockey.hpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The line 67 is based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -49,6 +49,9 @@ class IceHockeySettings : public RomSettings {
         // the rom-name
         const char* rom() const { return "ice_hockey"; }
 
+        // get the available number of modes
+        unsigned int getNumModes() const { return 2; }
+
         // create a new instance of the rom
         RomSettings* clone() const;
 
@@ -65,6 +68,19 @@ class IceHockeySettings : public RomSettings {
         void loadState(Deserializer & ser);
 
         virtual int lives() { return 0; }
+
+        // returns a list of mode that the game can be played in
+        // in this game, there are 2 available modes
+        ModeVect getAvailableModes();
+
+        // set the mode of the game
+        // the given mode must be one returned by the previous function
+        void setMode(game_mode_t, System &system,
+                     std::unique_ptr<StellaEnvironmentWrapper> environment); 
+
+        // returns a list of difficulties that the game can be played in
+        // in this game, there are 4 available difficulties
+        DifficultyVect getAvailableDifficulties();
 
     private:
 

--- a/src/games/supported/Kangaroo.cpp
+++ b/src/games/supported/Kangaroo.cpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 60, 113, 123 and 131 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -130,4 +130,32 @@ void KangarooSettings::loadState(Deserializer & ser) {
   m_terminal = ser.getBool();
   m_lives = ser.getInt();
 }
+
+// returns a list of mode that the game can be played in
+ModeVect KangarooSettings::getAvailableModes() {
+    ModeVect modes = {0, 1};
+    return modes;
+}
+
+// set the mode of the game
+// the given mode must be one returned by the previous function
+void KangarooSettings::setMode(game_mode_t m, System &system,
+                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
+
+    if( m == 0 || m == 1){
+        // read the mode we are currently in
+        unsigned char mode = readRam(&system, 0xBA);
+        // press select until the correct mode is reached
+        //in the welcome screen, the value of the mode is increased by 0x80
+        while(mode != m && mode != m + 0x80) {
+            environment->pressSelect(2);
+            mode = readRam(&system, 0xBA);
+        }
+        //reset the environment to apply changes.
+        environment->softReset();
+    }
+    else {
+        throw std::runtime_error("This mode doesn't currently exist for this game");
+    }
+ }
 

--- a/src/games/supported/Kangaroo.hpp
+++ b/src/games/supported/Kangaroo.hpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 67 and 74 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -49,6 +49,9 @@ class KangarooSettings : public RomSettings {
         // the rom-name
         const char* rom() const { return "kangaroo"; }
 
+        // get the available number of modes
+        unsigned int getNumModes() const { return 2; }
+
         // create a new instance of the rom
         RomSettings* clone() const;
 
@@ -65,6 +68,15 @@ class KangarooSettings : public RomSettings {
         void loadState(Deserializer & ser);
 
         virtual int lives() { return isTerminal() ? 0 : m_lives; }
+
+        // returns a list of mode that the game can be played in
+        // in this game, there are 8 available modes
+        ModeVect getAvailableModes();
+
+        // set the mode of the game
+        // the given mode must be one returned by the previous function
+        void setMode(game_mode_t, System &system,
+                     std::unique_ptr<StellaEnvironmentWrapper> environment); 
 
     private:
 

--- a/src/games/supported/MsPacman.hpp
+++ b/src/games/supported/MsPacman.hpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 67 and 74 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -49,6 +49,9 @@ class MsPacmanSettings : public RomSettings {
         // the rom-name
         const char* rom() const { return "ms_pacman"; }
 
+        // get the available number of modes
+        unsigned int getNumModes() const { return 4; }
+
         // create a new instance of the rom
         RomSettings* clone() const;
 
@@ -65,6 +68,15 @@ class MsPacmanSettings : public RomSettings {
         void loadState(Deserializer & ser);
 
         virtual int lives() { return isTerminal() ? 0 : m_lives; }
+
+        // returns a list of mode that the game can be played in
+        // in this game, there are 8 available modes
+        ModeVect getAvailableModes();
+
+        // set the mode of the game
+        // the given mode must be one returned by the previous function
+        void setMode(game_mode_t, System &system,
+                     std::unique_ptr<StellaEnvironmentWrapper> environment); 
 
     private:
 

--- a/src/games/supported/NameThisGame.cpp
+++ b/src/games/supported/NameThisGame.cpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 57, 99, 107 and 115 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -113,5 +113,40 @@ void NameThisGameSettings::loadState(Deserializer & ser) {
   m_score = ser.getInt();
   m_terminal = ser.getBool();
   m_lives = ser.getInt();
+}
+
+// returns a list of mode that the game can be played in
+ModeVect NameThisGameSettings::getAvailableModes() {
+    ModeVect modes = {0x08, 0x18, 0x28};
+    return modes;
+}
+
+// set the mode of the game
+// the given mode must be one returned by the previous function
+void NameThisGameSettings::setMode(game_mode_t m, System &system,
+                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
+
+    if(m == 0) {
+      m = 0x08; // the default mode is not valid here
+    }
+    if(m == 0x08 || m == 0x18 || m == 0x28) {
+        // read the mode we are currently in
+        unsigned char mode = readRam(&system, 0xDE);
+        // press select until the correct mode is reached
+        while (mode != m) {
+            environment->pressSelect(2);
+            mode = readRam(&system, 0xDE);
+        }
+        //reset the environment to apply changes.
+        environment->softReset();
+    }
+    else {
+        throw std::runtime_error("This mode doesn't currently exist for this game");
+    }
+ }
+
+DifficultyVect NameThisGameSettings::getAvailableDifficulties() {
+    DifficultyVect diff = {0, 1};
+    return diff;
 }
 

--- a/src/games/supported/NameThisGame.hpp
+++ b/src/games/supported/NameThisGame.hpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 67 and 74 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -49,6 +49,9 @@ class NameThisGameSettings : public RomSettings {
         // the rom-name
         const char* rom() const { return "name_this_game"; }
 
+        // get the available number of modes
+        unsigned int getNumModes() const { return 3; }
+
         // create a new instance of the rom
         RomSettings* clone() const;
 
@@ -65,6 +68,19 @@ class NameThisGameSettings : public RomSettings {
         void loadState(Deserializer & ser);
 
         virtual int lives() { return isTerminal() ? 0 : m_lives; }
+
+        // returns a list of mode that the game can be played in
+        // in this game, there are 3 available modes
+        ModeVect getAvailableModes();
+
+        // set the mode of the game
+        // the given mode must be one returned by the previous function
+        void setMode(game_mode_t, System &system,
+                     std::unique_ptr<StellaEnvironmentWrapper> environment); 
+
+        // returns a list of difficulties that the game can be played in
+        // in this game, there are 2 available difficulties
+        DifficultyVect getAvailableDifficulties();
 
     private:
 

--- a/src/games/supported/Pong.cpp
+++ b/src/games/supported/Pong.cpp
@@ -99,3 +99,38 @@ void PongSettings::loadState(Deserializer & ser) {
   m_terminal = ser.getBool();
 }
 
+// returns a list of mode that the game can be played in
+ModeVect PongSettings::getAvailableModes() {
+    ModeVect modes(getNumModes());
+    for (unsigned int i = 0; i < modes.size(); i++) {
+        modes[i] = i;
+    }
+    return modes;
+}
+
+// set the mode of the game
+// the given mode must be one returned by the previous function
+void PongSettings::setMode(game_mode_t m, System &system,
+                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
+
+    if(m < getNumModes()) {
+        // read the mode we are currently in
+        unsigned char mode = readRam(&system, 0x96);
+        // press select until the correct mode is reached
+        while (mode != m) {
+            environment->pressSelect(2);
+            mode = readRam(&system, 0x96);
+        }
+        //reset the environment to apply changes.
+        environment->softReset();
+    }
+    else {
+        throw std::runtime_error("This mode doesn't currently exist for this game");
+    }
+ }
+
+DifficultyVect PongSettings::getAvailableDifficulties() {
+    DifficultyVect diff = {0, 1};
+    return diff;
+}
+

--- a/src/games/supported/Pong.hpp
+++ b/src/games/supported/Pong.hpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The line 67 is based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -49,6 +49,9 @@ class PongSettings : public RomSettings {
         // the rom-name
         const char* rom() const { return "pong"; }
 
+        // get the available number of modes
+        unsigned int getNumModes() const { return 2; }
+
         // create a new instance of the rom
         RomSettings* clone() const;
 
@@ -65,6 +68,19 @@ class PongSettings : public RomSettings {
         void loadState(Deserializer & ser);
 
         virtual int lives() { return 0; }
+
+        // returns a list of difficulties that the game can be played in
+        // in this game, there are 2 available difficulties
+        DifficultyVect getAvailableDifficulties();
+
+        // returns a list of mode that the game can be played in
+        // in this game, there are 2 available modes
+        ModeVect getAvailableModes();
+
+        // set the mode of the game
+        // the given mode must be one returned by the previous function
+        void setMode(game_mode_t, System &system,
+                     std::unique_ptr<StellaEnvironmentWrapper> environment); 
 
     private:
 

--- a/src/games/supported/Pooyan.cpp
+++ b/src/games/supported/Pooyan.cpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 61, 102, 110 and 118 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -117,4 +117,36 @@ void PooyanSettings::loadState(Deserializer & ser) {
   m_terminal = ser.getBool();
   m_lives = ser.getInt();
 }
+
+// returns a list of mode that the game can be played in
+ModeVect PooyanSettings::getAvailableModes() {
+    ModeVect modes = {0x0A, 0x1E, 0x32, 0x46};
+    return modes;
+}
+
+// set the mode of the game
+// the given mode must be one returned by the previous function
+void PooyanSettings::setMode(game_mode_t m, System &system,
+                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
+
+
+    if (m == 0) {
+      m = 0x0A; // The default mode (0) is not valid here.
+    }
+    if(m == 0x0A || m == 0x1E || m == 0x32 || m == 0x46) {
+        environment->pressSelect(2);
+        // read the mode we are currently in
+        unsigned char mode = readRam(&system, 0xBD);
+        // press select until the correct mode is reached
+        while (mode != m) {
+            environment->pressSelect(2);
+            mode = readRam(&system, 0xBD);
+        }
+        //reset the environment to apply changes.
+        environment->softReset();
+    }
+    else {
+        throw std::runtime_error("This mode doesn't currently exist for this game");
+    }
+ }
 

--- a/src/games/supported/Pooyan.hpp
+++ b/src/games/supported/Pooyan.hpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 67 and 74 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -49,6 +49,9 @@ class PooyanSettings : public RomSettings {
         // the rom-name
         const char* rom() const { return "pooyan"; }
 
+        // get the available number of modes
+        unsigned int getNumModes() const { return 4; }
+
         // create a new instance of the rom
         RomSettings* clone() const;
 
@@ -65,6 +68,15 @@ class PooyanSettings : public RomSettings {
         void loadState(Deserializer & ser);
 
         virtual int lives() { return isTerminal() ? 0 : m_lives; }
+
+        // returns a list of mode that the game can be played in
+        // in this game, there are 4 available modes
+        ModeVect getAvailableModes();
+
+        // set the mode of the game
+        // the given mode must be one returned by the previous function
+        void setMode(game_mode_t, System &system,
+                     std::unique_ptr<StellaEnvironmentWrapper> environment); 
 
     private:
 

--- a/src/games/supported/PrivateEye.cpp
+++ b/src/games/supported/PrivateEye.cpp
@@ -115,3 +115,40 @@ ActionVect PrivateEyeSettings::getStartingActions() {
     startingActions.push_back(PLAYER_A_UP);
     return startingActions;
 }
+
+// returns a list of mode that the game can be played in
+ModeVect PrivateEyeSettings::getAvailableModes() {
+    ModeVect modes(getNumModes());
+    for (unsigned int i = 0; i < modes.size(); i++) {
+        modes[i] = i;
+    }
+    return modes;
+}
+
+// set the mode of the game
+// the given mode must be one returned by the previous function
+void PrivateEyeSettings::setMode(game_mode_t m, System &system,
+                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
+
+    if(m < getNumModes()) {
+        // read the mode we are currently in
+        unsigned char mode = readRam(&system, 0x80);
+        // press select until the correct mode is reached
+        while (mode != m) {
+            environment->pressSelect(2);
+            mode = readRam(&system, 0x80);
+        }
+        //reset the environment to apply changes.
+        environment->softReset();
+    }
+    else {
+        throw std::runtime_error("This mode doesn't currently exist for this game");
+    }
+ }
+
+
+DifficultyVect PrivateEyeSettings::getAvailableDifficulties() {
+    DifficultyVect diff = {0, 1, 2, 3};
+    return diff;
+}
+

--- a/src/games/supported/PrivateEye.hpp
+++ b/src/games/supported/PrivateEye.hpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The line 69 is based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -49,6 +49,9 @@ class PrivateEyeSettings : public RomSettings {
         // the rom-name
         const char* rom() const { return "private_eye"; }
 
+        // get the available number of modes
+        unsigned int getNumModes() const { return 5; }
+
         // create a new instance of the rom
         RomSettings* clone() const;
 
@@ -67,6 +70,19 @@ class PrivateEyeSettings : public RomSettings {
         ActionVect getStartingActions();
 
         virtual int lives() { return 0; }
+
+        // returns a list of mode that the game can be played in
+        // in this game, there are 5 available modes
+        ModeVect getAvailableModes();
+
+        // set the mode of the game
+        // the given mode must be one returned by the previous function
+        void setMode(game_mode_t, System &system,
+                     std::unique_ptr<StellaEnvironmentWrapper> environment);
+
+        // returns a list of difficulties that the game can be played in
+        // in this game, there are 4 available difficulties
+        DifficultyVect getAvailableDifficulties();
 
     private:
 

--- a/src/games/supported/SpaceInvaders.cpp
+++ b/src/games/supported/SpaceInvaders.cpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 54 - 59, 100, 109 and 117 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -124,3 +124,37 @@ void SpaceInvadersSettings::loadState(Deserializer & ser) {
   m_lives = ser.getInt();
 }
 
+// returns a list of mode that the game can be played in
+ModeVect SpaceInvadersSettings::getAvailableModes() {
+    ModeVect modes(getNumModes());
+    for (unsigned int i = 0; i < modes.size(); i++) {
+        modes[i] = i;
+    }
+    return modes;
+}
+
+// set the mode of the game
+// the given mode must be one returned by the previous function
+void SpaceInvadersSettings::setMode(game_mode_t m, System &system,
+                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
+
+    if(m < getNumModes()) {
+        // read the mode we are currently in
+        unsigned char mode = readRam(&system, 0xDC);
+        // press select until the correct mode is reached
+        while (mode != m) {
+            environment->pressSelect(2);
+            mode = readRam(&system, 0xDC);
+        }
+        //reset the environment to apply changes.
+        environment->softReset();
+    }
+    else {
+        throw std::runtime_error("This mode doesn't currently exist for this game");
+    }
+ }
+
+DifficultyVect SpaceInvadersSettings::getAvailableDifficulties() {
+    DifficultyVect diff = {0, 1};
+    return diff;
+}

--- a/src/games/supported/SpaceInvaders.hpp
+++ b/src/games/supported/SpaceInvaders.hpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 67 and 74 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -49,6 +49,9 @@ class SpaceInvadersSettings : public RomSettings {
         // the rom-name
         const char* rom() const { return "space_invaders"; }
 
+        // get the available number of modes
+        unsigned int getNumModes() const { return 16; }
+
         // create a new instance of the rom
         RomSettings* clone() const;
 
@@ -65,6 +68,20 @@ class SpaceInvadersSettings : public RomSettings {
         void loadState(Deserializer & ser);
 
         virtual int lives() { return isTerminal() ? 0 : m_lives; }
+
+        // returns a list of mode that the game can be played in
+        // in this game, there are 16 available modes
+        ModeVect getAvailableModes();
+
+        // set the mode of the game
+        // the given mode must be one returned by the previous function
+        void setMode(game_mode_t, System &system,
+                     std::unique_ptr<StellaEnvironmentWrapper> environment); 
+
+        // returns a list of difficulties that the game can be played in
+        // in this game, there are 2 available difficulties
+        DifficultyVect getAvailableDifficulties();
+
 
     private:
 

--- a/src/games/supported/StarGunner.cpp
+++ b/src/games/supported/StarGunner.cpp
@@ -1,6 +1,5 @@
 /* *****************************************************************************
- * The lines 71, 73, 126, 127, 135, 136, 144 and 145 are based on Xitari's code, 
- * from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -146,3 +145,32 @@ void StarGunnerSettings::loadState(Deserializer & ser) {
   m_game_started = ser.getBool();  
 }
 
+// returns a list of mode that the game can be played in
+ModeVect StarGunnerSettings::getAvailableModes() {
+    ModeVect modes(getNumModes());
+    for (unsigned int i = 0; i < modes.size(); i++) {
+        modes[i] = i;
+    }
+    return modes;
+}
+
+// set the mode of the game
+// the given mode must be one returned by the previous function
+void StarGunnerSettings::setMode(game_mode_t m, System &system,
+    std::unique_ptr<StellaEnvironmentWrapper> environment) {
+
+    if(m < getNumModes()) {
+        // read the mode we are currently in
+        unsigned char mode = readRam(&system, 0xF4);
+        // press select until the correct mode is reached
+        while (mode != m) {
+            environment->pressSelect(15);
+            mode = readRam(&system, 0xF4);
+        }
+        //reset the environment to apply changes.
+        environment->softReset();
+    }
+    else {
+        throw std::runtime_error("This mode doesn't currently exist for this game");
+    }
+ }

--- a/src/games/supported/StarGunner.hpp
+++ b/src/games/supported/StarGunner.hpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 67, 74 and 75 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -49,6 +49,9 @@ class StarGunnerSettings : public RomSettings {
         // the rom-name
         const char* rom() const { return "star_gunner"; }
 
+        // get the available number of modes
+        unsigned int getNumModes() const { return 4; }
+
         // create a new instance of the rom
         RomSettings* clone() const;
 
@@ -65,6 +68,15 @@ class StarGunnerSettings : public RomSettings {
         void loadState(Deserializer & ser);
 
         virtual int lives() { return isTerminal() ? 0 : m_lives; }
+
+        // returns a list of mode that the game can be played in
+        // in this game, there are 4 available modes
+        ModeVect getAvailableModes();
+
+        // set the mode of the game
+        // the given mode must be one returned by the previous function
+        void setMode(game_mode_t, System &system,
+                     std::unique_ptr<StellaEnvironmentWrapper> environment); 
 
     private:
 

--- a/src/games/supported/Tennis.cpp
+++ b/src/games/supported/Tennis.cpp
@@ -129,3 +129,35 @@ void TennisSettings::loadState(Deserializer & ser) {
   m_prev_delta_score = ser.getInt();
 }
 
+// returns a list of mode that the game can be played in
+ModeVect TennisSettings::getAvailableModes() {
+    ModeVect modes = {0, 2};
+    return modes;
+}
+
+// set the mode of the game
+// the given mode must be one returned by the previous function
+void TennisSettings::setMode(game_mode_t m, System &system,
+                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
+
+    if(m == 0 || m == 2) {
+        // read the mode we are currently in
+        unsigned char mode = readRam(&system, 0x80);
+        // press select until the correct mode is reached
+        while (mode != m) {
+            environment->pressSelect(2);
+            mode = readRam(&system, 0x80);
+        }
+        //reset the environment to apply changes.
+        environment->softReset();
+    }
+    else {
+        throw std::runtime_error("This mode doesn't currently exist for this game");
+    }
+ }
+
+DifficultyVect TennisSettings::getAvailableDifficulties() {
+    DifficultyVect diff = {0, 1, 2, 3};
+    return diff;
+}
+

--- a/src/games/supported/Tennis.hpp
+++ b/src/games/supported/Tennis.hpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The line 67 is based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -49,6 +49,9 @@ class TennisSettings : public RomSettings {
         // the rom-name
         const char* rom() const { return "tennis"; }
 
+        // get the available number of modes
+        unsigned int getNumModes() const { return 2; }
+
         // create a new instance of the rom
         RomSettings* clone() const;
 
@@ -65,6 +68,19 @@ class TennisSettings : public RomSettings {
         void loadState(Deserializer & ser);
 
         virtual int lives() { return 0; }
+
+        // returns a list of mode that the game can be played in
+        // in this game, there are 2 available modes
+        ModeVect getAvailableModes();
+
+        // set the mode of the game
+        // the given mode must be one returned by the previous function
+        void setMode(game_mode_t, System &system,
+                     std::unique_ptr<StellaEnvironmentWrapper> environment); 
+
+        // returns a list of difficulties that the game can be played in
+        // in this game, there are 4 available difficulties
+        DifficultyVect getAvailableDifficulties();
     
     private:
 

--- a/src/games/supported/TimePilot.cpp
+++ b/src/games/supported/TimePilot.cpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 64, 109, 117 and 125 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -125,3 +125,8 @@ void TimePilotSettings::loadState(Deserializer & ser) {
   m_lives = ser.getInt();
 }
 
+
+DifficultyVect TimePilotSettings::getAvailableDifficulties() {
+    DifficultyVect diff = {0, 1, 2};
+    return diff;
+}

--- a/src/games/supported/TimePilot.hpp
+++ b/src/games/supported/TimePilot.hpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 67 and 74 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -65,6 +65,10 @@ class TimePilotSettings : public RomSettings {
         void loadState(Deserializer & ser);
 
         virtual int lives() { return isTerminal() ? 0 : m_lives; }
+
+        // returns a list of difficulties that the game can be played in
+        // in this game, there are 3 available difficulties
+        DifficultyVect getAvailableDifficulties();
 
     private:
 

--- a/src/games/supported/Tutankham.cpp
+++ b/src/games/supported/Tutankham.cpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 63, 106, 114 and 122 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -122,3 +122,29 @@ void TutankhamSettings::loadState(Deserializer & ser) {
   m_lives = ser.getInt();
 }
 
+// returns a list of mode that the game can be played in
+ModeVect TutankhamSettings::getAvailableModes() {
+    ModeVect modes = {0, 4, 8, 12};
+    return modes;
+}
+
+// set the mode of the game
+// the given mode must be one returned by the previous function
+void TutankhamSettings::setMode(game_mode_t m, System &system,
+                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
+
+    if(m == 0 || m == 4 || m == 8 || m == 12) {
+        // read the mode we are currently in
+        unsigned char mode = readRam(&system, 0xAB);
+        // press select until the correct mode is reached
+        while (mode != m) {
+            environment->pressSelect(2);
+            mode = readRam(&system, 0xAB);
+        }
+        //reset the environment to apply changes.
+        environment->softReset();
+    }
+    else {
+        throw std::runtime_error("This mode doesn't currently exist for this game");
+    }
+ }

--- a/src/games/supported/Tutankham.hpp
+++ b/src/games/supported/Tutankham.hpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 67 and 74 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -49,6 +49,9 @@ class TutankhamSettings : public RomSettings {
         // the rom-name
         const char* rom() const { return "tutankham"; }
 
+        // get the available number of modes
+        unsigned int getNumModes() const { return 4; }
+
         // create a new instance of the rom
         RomSettings* clone() const;
 
@@ -65,6 +68,15 @@ class TutankhamSettings : public RomSettings {
         void loadState(Deserializer & ser);
 
         virtual int lives() { return isTerminal()? 0 : m_lives; }
+
+        // returns a list of mode that the game can be played in
+        // in this game, there are 4 available modes
+        ModeVect getAvailableModes();
+
+        // set the mode of the game
+        // the given mode must be one returned by the previous function
+        void setMode(game_mode_t, System &system,
+                     std::unique_ptr<StellaEnvironmentWrapper> environment); 
 
     private:
 

--- a/src/games/supported/UpNDown.cpp
+++ b/src/games/supported/UpNDown.cpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 61, 102, 110 and 118 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -124,4 +124,8 @@ ActionVect UpNDownSettings::getStartingActions() {
     return startingActions;
 }
 
+DifficultyVect UpNDownSettings::getAvailableDifficulties() {
+    DifficultyVect diff = {0, 1, 2, 3};
+    return diff;
+}
 

--- a/src/games/supported/UpNDown.hpp
+++ b/src/games/supported/UpNDown.hpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 70 and 77 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -68,6 +68,10 @@ class UpNDownSettings : public RomSettings {
         ActionVect getStartingActions();
 
         virtual int lives() { return isTerminal() ? 0 : m_lives; }
+
+        // returns a list of difficulties that the game can be played in
+        // in this game, there are 4 available difficulties
+        DifficultyVect getAvailableDifficulties();
 
     private:
 

--- a/src/games/supported/Venture.cpp
+++ b/src/games/supported/Venture.cpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 63, 116, 124 and 132 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -130,5 +130,11 @@ void VentureSettings::loadState(Deserializer & ser) {
   m_score = ser.getInt();
   m_terminal = ser.getBool();
   m_lives = ser.getInt();
+}
+
+
+DifficultyVect VentureSettings::getAvailableDifficulties() {
+    DifficultyVect diff = {0, 1, 2, 3};
+    return diff;
 }
 

--- a/src/games/supported/Venture.hpp
+++ b/src/games/supported/Venture.hpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 67 and 74 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -65,6 +65,10 @@ class VentureSettings : public RomSettings {
         void loadState(Deserializer & ser);
 
         virtual int lives() { return isTerminal() ? 0 : m_lives; }
+
+        // returns a list of difficulties that the game can be played in
+        // in this game, there are 2 available difficulties
+        DifficultyVect getAvailableDifficulties();
 
     private:
 

--- a/src/games/supported/VideoPinball.cpp
+++ b/src/games/supported/VideoPinball.cpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 60 - 65, 109, 117 and 125 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -125,3 +125,34 @@ void VideoPinballSettings::loadState(Deserializer & ser) {
   m_lives = ser.getInt();
 }
 
+// returns a list of mode that the game can be played in
+ModeVect VideoPinballSettings::getAvailableModes() {
+    ModeVect modes = {0, 2};
+    return modes;
+}
+
+// set the mode of the game
+// the given mode must be one returned by the previous function
+void VideoPinballSettings::setMode(game_mode_t m, System &system,
+    std::unique_ptr<StellaEnvironmentWrapper> environment) {
+
+    if(m == 0 || m == 2) {
+        // read the mode we are currently in
+        unsigned char mode = readRam(&system, 0xC1);
+        // press select until the correct mode is reached
+        while (mode != m) {
+            environment->pressSelect(2);
+            mode = readRam(&system, 0xC1);
+        }
+        //reset the environment to apply changes.
+        environment->softReset();
+    }
+    else {
+        throw std::runtime_error("This mode doesn't currently exist for this game");
+    }
+ }
+
+DifficultyVect VideoPinballSettings::getAvailableDifficulties() {
+    DifficultyVect diff = {0, 1};
+    return diff;
+}

--- a/src/games/supported/VideoPinball.hpp
+++ b/src/games/supported/VideoPinball.hpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 67 and 74 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -49,6 +49,9 @@ class VideoPinballSettings : public RomSettings {
         // the rom-name
         const char* rom() const { return "video_pinball"; }
 
+        // get the available number of modes
+        unsigned int getNumModes() const { return 2; }
+
         // create a new instance of the rom
         RomSettings* clone() const;
 
@@ -65,6 +68,19 @@ class VideoPinballSettings : public RomSettings {
         void loadState(Deserializer & ser);
 
         virtual int lives() { return isTerminal() ? 0 : m_lives; }
+
+        // returns a list of mode that the game can be played in
+        // in this game, there are 2 available modes
+        ModeVect getAvailableModes();
+
+        // set the mode of the game
+        // the given mode must be one returned by the previous function
+        void setMode(game_mode_t, System &system,
+                     std::unique_ptr<StellaEnvironmentWrapper> environment); 
+
+        // returns a list of difficulties that the game can be played in
+        // in this game, there are 2 available difficulties
+        DifficultyVect getAvailableDifficulties();
 
     private:
 

--- a/src/games/supported/WizardOfWor.cpp
+++ b/src/games/supported/WizardOfWor.cpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 61, 63, 67, 112, 121 and 129 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -127,5 +127,10 @@ void WizardOfWorSettings::loadState(Deserializer & ser) {
   m_score = ser.getInt();
   m_terminal = ser.getBool();
   m_lives = ser.getInt();
+}
+
+DifficultyVect WizardOfWorSettings::getAvailableDifficulties() {
+    DifficultyVect diff = {0, 1};
+    return diff;
 }
 

--- a/src/games/supported/WizardOfWor.hpp
+++ b/src/games/supported/WizardOfWor.hpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 67 and 74 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -65,6 +65,10 @@ class WizardOfWorSettings : public RomSettings {
         void loadState(Deserializer & ser);
 
         virtual int lives() { return isTerminal() ? 0 : m_lives; }
+
+        // returns a list of difficulties that the game can be played in
+        // in this game, there are 2 available difficulties
+        DifficultyVect getAvailableDifficulties();
 
     private:
 

--- a/src/games/supported/YarsRevenge.cpp
+++ b/src/games/supported/YarsRevenge.cpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 57, 58, 60, 113, 121 and 129 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -133,4 +133,38 @@ ActionVect YarsRevengeSettings::getStartingActions() {
     ActionVect startingActions;
     startingActions.push_back(PLAYER_A_FIRE);
     return startingActions;
+}
+
+// returns a list of mode that the game can be played in
+ModeVect YarsRevengeSettings::getAvailableModes() {
+    ModeVect modes = {0, 0x20, 0x40, 0x60};
+    return modes;
+}
+
+// set the mode of the game
+// the given mode must be one returned by the previous function
+void YarsRevengeSettings::setMode(game_mode_t m, System &system,
+                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
+
+    if(m == 0 || m == 0x20 || m == 0x40 || m == 0x60) {
+        // enter in mode selection screen
+        environment->pressSelect(2);
+        // read the mode we are currently in
+        unsigned char mode = readRam(&system, 0xE3);
+        // press select until the correct mode is reached
+        while (mode != m) {
+            environment->pressSelect();
+            mode = readRam(&system, 0xE3);
+        }
+        //reset the environment to apply changes.
+        environment->softReset();
+    }
+    else {
+        throw std::runtime_error("This mode doesn't currently exist for this game");
+    }
+ }
+
+DifficultyVect YarsRevengeSettings::getAvailableDifficulties() {
+    DifficultyVect diff = {0, 1};
+    return diff;
 }

--- a/src/games/supported/YarsRevenge.hpp
+++ b/src/games/supported/YarsRevenge.hpp
@@ -1,5 +1,5 @@
 /* *****************************************************************************
- * The lines 70 and 77 are based on Xitari's code, from Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -49,6 +49,9 @@ class YarsRevengeSettings : public RomSettings {
         // the rom-name
         const char* rom() const { return "yars_revenge"; }
 
+        // get the available number of modes
+        unsigned int getNumModes() const { return 4; }
+
         // create a new instance of the rom
         RomSettings* clone() const;
 
@@ -68,6 +71,19 @@ class YarsRevengeSettings : public RomSettings {
         ActionVect getStartingActions();
 
         virtual int lives() { return isTerminal() ? 0 : m_lives; }
+
+        // returns a list of mode that the game can be played in
+        // in this game, there are 4 available modes
+        ModeVect getAvailableModes();
+
+        // set the mode of the game
+        // the given mode must be one returned by the previous function
+        void setMode(game_mode_t, System &system,
+                     std::unique_ptr<StellaEnvironmentWrapper> environment); 
+
+        // returns a list of difficulties that the game can be played in
+        // in this game, there are 2 available difficulties
+        DifficultyVect getAvailableDifficulties();
 
     private:
 


### PR DESCRIPTION
In order to submit small PRs I'm changing just 34 games for now. I'll keep working on the others. A summary of the current status is below. I won't deal with 2-player modes.

- **Games in which mode and difficulty switch are already implemented:**
**`AirRaid`**, `Alien`, `Amidar`, **`Asteroids`**, **`Atlantis`**, **`BankHeist`**, **`BattleZone`**, `BeamRider`, **`Berzerk`**, **`Bowling`**, **`Boxing`**, **`Breakout`**, **`Centipede`**, `ChopperCommand`, **`CrazyClimber`**, **`Defender`**, `DemonAttack`, **`DoubleDunk`**, **`FishingDerby`**, `Freeway`, `Frostbite`, **`Gopher`**, **`Gravitar`**, **`Hero`**, **`IceHockey`**, `Jamesbond`, `JourneyEscape`, **`Kangaroo`**, **`MsPacMan`**, **`NameThisGame`**, **`Pong`**, **`Pooyan`**, **`PrivateEye`**, `QBert`, `RiverRaid`, `Seaquest`, **`SpaceInvaders`**, **`StarGunner`**,  **`Tennis`**, **`TimePilot`**, **`Tutankham`**, **`UpNDown`**, **`Venture`**, **`VideoPinball`**, **`YarsRevenge`**, **`WizardOfWor`**.

- **Games I won't implement the mode and difficulty switch:**
`Adventure`,  `Frogger`, `Galaxian`, `Kaboom`, `KingKong`, `Koolaid`, `LostLuggage`, `MrDo`, `SirLancelot`, `Trondead`, `Turmoil`.

- **Games that have only one one-player mode and difficulty:**
`Assault`, `Asterix`, `Carnival`, `ElevatorAction`, `Enduro`, `KungFuMaster`, `MontezumaRevenge`, `Phoenix`, `Pitfall`, `RoadRunner`, `Robotank`, `DonkeyKong`, `KeystoneKapers`, `LaserGates`, `Solaris`, `Tetris`.

- **Games that the only modes I'm not currently supporting are two-player modes**:
`Asterix`, `Asteroids`, `Atlantis`, `BeamRider`, `Bowling`, `Boxing`, `Breakout`, `Carnival`, `ChopperCommand`, `CrazyClimber`, `Defender`, `DemonAttack`, `FishingDerby`, `Frostbite`, `IceHockey`, `JourneyEscape`, `Kangaroo`, `KungFuMaster`, `NameThisGame`, `Pong`, `Pooyan`, `RiverRaid`, `RoadRunner`, `Seaquest`, `SpaceInvaders`, `StarGunner`, `Tennis`, `TimePilot`, `Tutankham`, `UpNDown`, `VideoPinball`, `YarsRevenge`, `WizardOfWor`, `Zaxxon`.