### PR TITLE
Reverting name of examples about modes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,11 +184,11 @@ if(BUILD_EXAMPLES)
   target_link_libraries(fifoInterfaceExample ${LINK_LIBS})
   add_dependencies(fifoInterfaceExample ale-lib)
 
-  add_executable(ale-sharedLibraryExampleWithModes ${CMAKE_CURRENT_SOURCE_DIR}/doc/examples/sharedLibraryInterfaceWithModesExample.cpp)
-  set_target_properties(ale-sharedLibraryExampleWithModes PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/doc/examples)
-  target_link_libraries(ale-sharedLibraryExampleWithModes ale)
-  target_link_libraries(ale-sharedLibraryExampleWithModes ${LINK_LIBS})
-  add_dependencies(ale-sharedLibraryExampleWithModes ale-lib)
+  add_executable(ale-sharedLibraryInterfaceWithModesExample ${CMAKE_CURRENT_SOURCE_DIR}/doc/examples/sharedLibraryInterfaceWithModesExample.cpp)
+  set_target_properties(ale-sharedLibraryInterfaceWithModesExample PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/doc/examples)
+  target_link_libraries(ale-sharedLibraryInterfaceWithModesExample ale)
+  target_link_libraries(ale-sharedLibraryInterfaceWithModesExample ${LINK_LIBS})
+  add_dependencies(ale-sharedLibraryInterfaceWithModesExample ale-lib)
 
   # Example showing how to record an Atari 2600 video.
   if (USE_SDL)

--- a/doc/examples/Makefile.sharedLibraryWithModes
+++ b/doc/examples/Makefile.sharedLibraryWithModes
@@ -5,7 +5,7 @@ ALE := ../..
 
 FLAGS := -I$(ALE)/src -I$(ALE)/src/controllers -I$(ALE)/src/os_dependent -I$(ALE)/src/environment -I$(ALE)/src/external -L$(ALE)
 CXX := g++
-FILE := ale-sharedLibraryExampleWithModes
+FILE := ale-sharedLibraryInterfaceWithModesExample
 LDFLAGS := -lale -lz
 
 UNAME_S := $(shell uname -s)


### PR DESCRIPTION
The new name was not being ignored but git, because of its name. Also the clean rule wasn't updated correctly. Since there's no problem with the previous name, I'm just changing it back.