### PR TITLE
Let ROMs set their default mode. 

### DIFF
--- a/src/environment/stella_environment.cpp
+++ b/src/environment/stella_environment.cpp
@@ -38,7 +38,10 @@ StellaEnvironment::StellaEnvironment(OSystem* osystem, RomSettings* settings):
   }
   m_num_reset_steps = 4;
   m_cartridge_md5 = m_osystem->console().properties().get(Cartridge_MD5);
-  
+ 
+  // Set current mode to the ROM's default mode
+  m_state.setCurrentMode(settings->getDefaultMode());
+
   m_max_num_frames_per_episode = m_osystem->settings().getInt("max_num_frames_per_episode");
   m_colour_averaging = m_osystem->settings().getBool("color_averaging");
 

--- a/src/games/RomSettings.cpp
+++ b/src/games/RomSettings.cpp
@@ -59,6 +59,18 @@ void RomSettings::setMode(game_mode_t m, System&, std::unique_ptr<StellaEnvironm
   }
 }
 
+
+game_mode_t RomSettings::getDefaultMode() {
+  // By default, return the first available mode, or 0 if none are listed
+  ModeVect available_modes = getAvailableModes();
+  if (available_modes.empty()) {
+    return 0;
+  } else {
+    return available_modes[0];
+  }
+}
+
+
 DifficultyVect RomSettings::getAvailableDifficulties() {
   return DifficultyVect(1, 0);
 };

--- a/src/games/RomSettings.hpp
+++ b/src/games/RomSettings.hpp
@@ -103,6 +103,9 @@ public:
     virtual void setMode(game_mode_t, System &system,
                          std::unique_ptr<StellaEnvironmentWrapper> environment);
 
+    // Return the default mode for the game
+    virtual game_mode_t getDefaultMode();
+
     // Returns a list of difficulties that the game can be played in.
     // By default, there is only one available difficulty.
     virtual DifficultyVect getAvailableDifficulties();

--- a/src/games/supported/AirRaid.cpp
+++ b/src/games/supported/AirRaid.cpp
@@ -116,10 +116,6 @@ ModeVect AirRaidSettings::getAvailableModes() {
 // the given mode must be one returned by the previous function
 void AirRaidSettings::setMode(game_mode_t m, System &system,
                               std::unique_ptr<StellaEnvironmentWrapper> environment) {
-
-    if(m == 0) {
-        m = 1; // the default mode is not valid in this game
-    }
     if(m >= 1 && m <= getNumModes()) {
         //open the mode selection panel
         environment->pressSelect(20);

--- a/src/games/supported/BattleZone.cpp
+++ b/src/games/supported/BattleZone.cpp
@@ -157,9 +157,6 @@ ModeVect BattleZoneSettings::getAvailableModes() {
 void BattleZoneSettings::setMode(game_mode_t m, System &system,
     std::unique_ptr<StellaEnvironmentWrapper> environment) {
 
-    if(m == 0) {
-        m = 1; // the default mode is not valid here
-    }
     if(m >= 1 && m <= 3) {
         // read the mode we are currently in
         unsigned char mode = readRam(&system, 0xA1);

--- a/src/games/supported/Berzerk.cpp
+++ b/src/games/supported/Berzerk.cpp
@@ -148,9 +148,6 @@ ModeVect BerzerkSettings::getAvailableModes() {
 void BerzerkSettings::setMode(game_mode_t m, System &system,
                               std::unique_ptr<StellaEnvironmentWrapper> environment) {
 
-    if(m == 0) {
-        m = 1; // The mode 0, which is the default, is not available in this game.
-    }
     if(m >= 1 && (m <= 9 || m == 0x10 || m == 0x11 || m == 0x12)) {
         // we wait that the game is ready to change mode
         for(unsigned int i = 0; i < 20; i++) {

--- a/src/games/supported/Centipede.cpp
+++ b/src/games/supported/Centipede.cpp
@@ -144,9 +144,6 @@ ModeVect CentipedeSettings::getAvailableModes() {
 // the given mode must be one returned by the previous function
 void CentipedeSettings::setMode(game_mode_t m, System &system,
                               std::unique_ptr<StellaEnvironmentWrapper> environment) {
-    if (m == 0) {
-        m = 0x16; // The default mode doesn't work here.
-    }
     if(m == 0x16 || m == 0x56) {
         // read the mode we are currently in
         unsigned char mode = readRam(&system, 0xA7);

--- a/src/games/supported/Defender.cpp
+++ b/src/games/supported/Defender.cpp
@@ -149,9 +149,6 @@ ModeVect DefenderSettings::getAvailableModes() {
 void DefenderSettings::setMode(game_mode_t m, System &system,
                               std::unique_ptr<StellaEnvironmentWrapper> environment) {
 
-    if(m == 0) {
-        m = 1; // The default mode (0) is not valid here.
-    }
     if(m >= 1 && (m <= 9 || m == 16)) {
         // read the mode we are currently in
         unsigned char mode = readRam(&system, 0x9B);

--- a/src/games/supported/DemonAttack.cpp
+++ b/src/games/supported/DemonAttack.cpp
@@ -135,9 +135,6 @@ ModeVect DemonAttackSettings::getAvailableModes() {
 void DemonAttackSettings::setMode(game_mode_t m, System &system,
                               std::unique_ptr<StellaEnvironmentWrapper> environment) {
 
-    if(m == 0) {
-	m = 1; // The default mode is not valid here
-    }
     if(m == 1 || m == 3 || m == 5 || m == 7) {
         // read the mode we are currently in
         unsigned char mode = readRam(&system, 0xEA);

--- a/src/games/supported/Galaxian.cpp
+++ b/src/games/supported/Galaxian.cpp
@@ -133,9 +133,6 @@ ModeVect GalaxianSettings::getAvailableModes() {
 void GalaxianSettings::setMode(game_mode_t mode, System &system,
                               std::unique_ptr<StellaEnvironmentWrapper> environment) {
 
-    if (mode == 0)
-        mode = 1;
-
     if (mode >= 1 && mode <= 9) {
         // press select until the correct mode is reached
         while (mode != static_cast<unsigned>(readRam(&system, 0xB3))) {

--- a/src/games/supported/Galaxian.cpp
+++ b/src/games/supported/Galaxian.cpp
@@ -122,3 +122,33 @@ void GalaxianSettings::loadState(Deserializer & ser) {
   m_lives = ser.getInt();
 }
 
+// returns a list of mode that the game can be played in
+ModeVect GalaxianSettings::getAvailableModes() {
+    ModeVect modes = { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+    return modes;
+}
+
+// set the mode of the game
+// the given mode must be one returned by the previous function
+void GalaxianSettings::setMode(game_mode_t mode, System &system,
+                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
+
+    if (mode == 0)
+        mode = 1;
+
+    if (mode >= 1 && mode <= 9) {
+        // press select until the correct mode is reached
+        while (mode != static_cast<unsigned>(readRam(&system, 0xB3))) {
+            environment->pressSelect();
+        }
+        //reset the environment to apply changes.
+        environment->softReset();
+    } else 
+    {
+        throw std::runtime_error("This mode doesn't currently exist for this game");
+    }
+}
+
+
+
+

--- a/src/games/supported/Galaxian.hpp
+++ b/src/games/supported/Galaxian.hpp
@@ -65,6 +65,22 @@ class GalaxianSettings : public RomSettings {
 
         virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
+        // get the available number of modes
+        unsigned int getNumModes() const { return 9; }
+
+        // returns a list of mode that the game can be played in
+        ModeVect getAvailableModes();
+
+        // set the mode of the game
+        // the given mode must be one returned by the previous function
+        void setMode(game_mode_t mode, System &system,
+                     std::unique_ptr<StellaEnvironmentWrapper> environment); 
+
+        // Returns a list of difficulties that the game can be played in.
+        // 2 difficulties: 0 is left B, 1 is left A
+        DifficultyVect getAvailableDifficulties() { return { 0, 1}; }
+
+
     private:
 
         bool m_terminal;

--- a/src/games/supported/NameThisGame.cpp
+++ b/src/games/supported/NameThisGame.cpp
@@ -126,9 +126,6 @@ ModeVect NameThisGameSettings::getAvailableModes() {
 void NameThisGameSettings::setMode(game_mode_t m, System &system,
                               std::unique_ptr<StellaEnvironmentWrapper> environment) {
 
-    if(m == 0) {
-      m = 0x08; // the default mode is not valid here
-    }
     if(m == 0x08 || m == 0x18 || m == 0x28) {
         // read the mode we are currently in
         unsigned char mode = readRam(&system, 0xDE);

--- a/src/games/supported/Pooyan.cpp
+++ b/src/games/supported/Pooyan.cpp
@@ -129,10 +129,6 @@ ModeVect PooyanSettings::getAvailableModes() {
 void PooyanSettings::setMode(game_mode_t m, System &system,
                               std::unique_ptr<StellaEnvironmentWrapper> environment) {
 
-
-    if (m == 0) {
-      m = 0x0A; // The default mode (0) is not valid here.
-    }
     if(m == 0x0A || m == 0x1E || m == 0x32 || m == 0x46) {
         environment->pressSelect(2);
         // read the mode we are currently in


### PR DESCRIPTION
The current code sets mode 0 by default even when this mode is not in the available list of modes supported by the ROM. This leads to games like centipede and battle zone to convert mode 0 to one of their supported modes and 2 separate modes mapping to the same game.

Even in the cases where the mode is supported, this isn't the real name of the mode, it is just a mapped name from its "real" number to 0, introducing an unnecessary level of semantic indirection.

This patch lets ROMs set their default mode. It also sets a default implementation which returns the first mode in the list of available modes. It also should lead to more meaningful use of mode numbers in the future.

I've checked every rom and this leads to a non-zero implementation in the following cases:

air_raid: 1
battle_zone: 1
berzerk: 1
centipede: 22
defender: 1
demon_attack: 1
name_this_game: 8
pooyan: 10

In all these cases, this is the mode that gets set when passed 0 in any case, so there are no changes in behaviour due to this patch.