### PR TITLE
Do not update screen or RAM state unless it's asked for

### DIFF
--- a/src/environment/stella_environment.hpp
+++ b/src/environment/stella_environment.hpp
@@ -90,8 +90,8 @@ class StellaEnvironment {
     const ALEState &getState() const;
 
     /** Returns the current screen after processing (e.g. colour averaging) */
-    const ALEScreen &getScreen() const { return m_screen; }
-    const ALERAM &getRAM() const { return m_ram; }
+    const ALEScreen &getScreen();
+    const ALERAM &getRAM();
 
     int getFrameNumber() const { return m_state.getFrameNumber(); }
     int getEpisodeFrameNumber() const { return m_state.getEpisodeFrameNumber(); }
@@ -126,6 +126,10 @@ class StellaEnvironment {
     ALEState m_state; // Current environment state    
     ALEScreen m_screen; // The current ALE screen (possibly colour-averaged)
     ALERAM m_ram; // The current ALE RAM
+
+    bool m_screen_updated; // Whether the current frame has been copied to m_screen
+    bool m_ram_updated; // Whether the current RAM state has been copied to m_ram
+
 
     bool m_use_paddles;  // Whether this game uses paddles
     


### PR DESCRIPTION
In the usual case where the client-side is doing "manual" frameskipping, due to the max-of-last-two-frames use (see https://github.com/openai/baselines or @spragunr code), only two out of every four frames need to be generated. This patch avoids generating this, and/or the RAM state, for those frames which are not being requested. When measured on a closed loop, this raises the frames per second about 2 percent (which is a bit disappointing, yes). It does save the computer from moving around about 600 MB/s, so maybe I can justify it on ecological reasons :) Or maybe it can become important if running tons of parallel environments and the computer becomes memory-bandwidth-bottlenecked at some point. In any case, it seems like the right thing to do, with very little complexity increase.

The patch also smuggles in a small fix so that the screen recorder doesn't record duplicate frames at the end of episodes when frameskip is bigger than 1 (and some potential sound issues) by only saving when an emulation step is performed.