### PR TITLE
Reset actions on reset

### DIFF
--- a/src/environment/stella_environment.cpp
+++ b/src/environment/stella_environment.cpp
@@ -176,6 +176,10 @@ reward_t StellaEnvironment::act(Action player_a_action, Action player_b_action) 
 /** This functions emulates a push on the reset button of the console */
 void StellaEnvironment::softReset() {
   emulate(RESET, PLAYER_B_NOOP, m_num_reset_steps);
+
+  // Reset previous actions to NOOP for correct action repeating
+  m_player_a_action = PLAYER_A_NOOP;
+  m_player_b_action = PLAYER_B_NOOP;
 }
 
 /** Applies the given actions (e.g. updating paddle positions when the paddle is used)


### PR DESCRIPTION
Fixes the following bug:

When `repeat_action_prob > 0`, `StellaEnvironment::act` will repeat the last played actions. These are not reset when the environment is reset, so the first action on a new episode may be a repeat of the last action of the previous episode.

This is patched by resetting the last actions to be NOOPs whenever the environment is reset (when the episode ends), consistent with the constructor.