### PR TITLE
workaround for SDL header not found problem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,8 +28,9 @@ if(USE_SDL)
     list(APPEND LINK_LIBS ${SDL_LIBRARY} ${SDL_MAIN_LIBRARY})
   else()
     MESSAGE("SDL 1.2 not found: You may need to manually edit CMakeLists.txt or run \"cmake -i\" to specify your SDL path.")
-    # Uncomment below to specify the path to your SDL library. Run "locate libSDL" if unsure.
+    # Uncomment below to specify the path to your SDL library and header file. Run "locate libSDL" and "locate SDL.h" if unsure.
     # link_directories(path_to_your_SDL)
+    # include_directories(path_to_your_SDL_header)
     if(APPLE)
       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -framework Cocoa")
       list(APPEND LINK_LIBS sdl sdlmain)


### PR DESCRIPTION
If SDL 1.2 is not found automatically, you may also fail to find SDL header file.
In my case, macOS High Sierra, this problem is solved by explicitly naming include directory.

![image](https://user-images.githubusercontent.com/38775262/48459386-1dfae180-e80d-11e8-8ef8-04dac29214b1.png)

I just modify comments to suggest this workaround. 
I think #244 would be solved by this way.