### PR TITLE
atari-py 1/3: Windows build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,9 +10,17 @@ option(BUILD_CPP_LIB "Build C++ Shared Library" ON)
 option(BUILD_CLI "Build ALE Command Line Interface" ON)
 option(BUILD_C_LIB "Build ALE C Library (needed for Python interface)" ON)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wunused -fPIC -O3 -fomit-frame-pointer -D__STDC_CONSTANT_MACROS")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fPIC -O3 -fomit-frame-pointer -D__STDC_CONSTANT_MACROS")
+
+if(CMAKE_COMPILER_IS_GNUCC)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wunused")
+endif()
+
 add_definitions(-DHAVE_INTTYPES)
-set(LINK_LIBS z)
+
+find_package(ZLIB REQUIRED)
+include_directories(${ZLIB_INCLUDE_DIRS})
+list(APPEND LINK_LIBS ${ZLIB_LIBRARIES})
 
 if(USE_RLGLUE)
   add_definitions(-D__USE_RLGLUE)
@@ -56,7 +64,8 @@ if(APPLE)
   set(CMAKE_SHARED_LIBRARY_SUFFIX ".so")
 endif()
 
-if(WINDOWS OR MINGW)
+if(WIN32 OR MINGW)
+  set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
   list(APPEND SOURCES ${SOURCE_DIR}/os_dependent/SettingsWin32.cxx ${SOURCE_DIR}/os_dependent/OSystemWin32.cxx ${SOURCE_DIR}/os_dependent/FSNodeWin32.cxx)
 else()
   list(APPEND SOURCES ${SOURCE_DIR}/os_dependent/SettingsUNIX.cxx ${SOURCE_DIR}/os_dependent/OSystemUNIX.cxx ${SOURCE_DIR}/os_dependent/FSNodePOSIX.cxx)

--- a/src/games/RomSettings.hpp
+++ b/src/games/RomSettings.hpp
@@ -33,6 +33,7 @@
 #ifndef __ROMSETTINGS_HPP__
 #define __ROMSETTINGS_HPP__
 
+#include <algorithm>
 #include <memory>
 #include <stdexcept>
 


### PR DESCRIPTION
This is the first PR in a set of PRs merging [openai/atari-py](https://github.com/openai/atari-py) into the ALE. This first PR adds the ability to build the ALE on Windows.

To get a proper build on Windows we had to:

1. Add zlib to the repository. This is how Stella now deals with zlib as well ([stella/src/zlib](https://github.com/stella-emu/stella/tree/master/src/zlib)).
2. CMake changes: Hide some flags under a GCC check, export all Windows symbols, and link zlib properly.

For all these PRs I'm hoping @christopherhesse will be able to review them before @mgbellemare takes a look.
