### PR TITLE
Reformat non-games ALE files

### DIFF
--- a/ale_python_interface/ale_c_wrapper.cpp
+++ b/ale_python_interface/ale_c_wrapper.cpp
@@ -4,22 +4,22 @@
 #include <string>
 #include <stdexcept>
 
-void encodeState(ALEState *state, char *buf, int buf_len) {
-	std::string str = state->serialize();
+void encodeState(ALEState* state, char* buf, int buf_len) {
+  std::string str = state->serialize();
 
-	if (buf_len < int(str.length())) {
-		throw new std::runtime_error("Buffer is not big enough to hold serialized ALEState. Please use encodeStateLen to determine the correct buffer size");
-	}
+  if (buf_len < int(str.length())) {
+    throw new std::runtime_error(
+        "Buffer is not big enough to hold serialized ALEState. Please use "
+        "encodeStateLen to determine the correct buffer size");
+  }
 
-	memcpy(buf, str.data(), str.length());
+  memcpy(buf, str.data(), str.length());
 }
 
-int encodeStateLen(ALEState *state) {
-	return state->serialize().length();
-}
+int encodeStateLen(ALEState* state) { return state->serialize().length(); }
 
-ALEState *decodeState(const char *serialized, int len) {
-	std::string str(serialized, len);
+ALEState* decodeState(const char* serialized, int len) {
+  std::string str(serialized, len);
 
-	return new ALEState(str);
+  return new ALEState(str);
 }

--- a/doc/examples/sharedLibraryInterfaceExample.cpp
+++ b/doc/examples/sharedLibraryInterfaceExample.cpp
@@ -18,48 +18,49 @@
 #include <ale_interface.hpp>
 
 #ifdef __USE_SDL
-  #include <SDL.h>
+#include <SDL.h>
 #endif
 
 using namespace std;
 
 int main(int argc, char** argv) {
-    if (argc < 2) {
-        std::cerr << "Usage: " << argv[0] << " rom_file" << std::endl;
-        return 1;
-    }
+  if (argc < 2) {
+    std::cerr << "Usage: " << argv[0] << " rom_file" << std::endl;
+    return 1;
+  }
 
-    ALEInterface ale;
+  ALEInterface ale;
 
-    // Get & Set the desired settings
-    ale.setInt("random_seed", 123);
-    //The default is already 0.25, this is just an example
-    ale.setFloat("repeat_action_probability", 0.25);
+  // Get & Set the desired settings
+  ale.setInt("random_seed", 123);
+  //The default is already 0.25, this is just an example
+  ale.setFloat("repeat_action_probability", 0.25);
 
 #ifdef __USE_SDL
-    ale.setBool("display_screen", true);
-    ale.setBool("sound", true);
+  ale.setBool("display_screen", true);
+  ale.setBool("sound", true);
 #endif
 
-    // Load the ROM file. (Also resets the system for new settings to
-    // take effect.)
-    ale.loadROM(argv[1]);
+  // Load the ROM file. (Also resets the system for new settings to
+  // take effect.)
+  ale.loadROM(argv[1]);
 
-    // Get the vector of legal actions
-    ActionVect legal_actions = ale.getLegalActionSet();
+  // Get the vector of legal actions
+  ActionVect legal_actions = ale.getLegalActionSet();
 
-    // Play 10 episodes
-    for (int episode=0; episode<10; episode++) {
-        float totalReward = 0;
-        while (!ale.game_over()) {
-            Action a = legal_actions[rand() % legal_actions.size()];
-            // Apply the action and get the resulting reward
-            float reward = ale.act(a);
-            totalReward += reward;
-        }
-        cout << "Episode " << episode << " ended with score: " << totalReward << endl;
-        ale.reset_game();
+  // Play 10 episodes
+  for (int episode = 0; episode < 10; episode++) {
+    float totalReward = 0;
+    while (!ale.game_over()) {
+      Action a = legal_actions[rand() % legal_actions.size()];
+      // Apply the action and get the resulting reward
+      float reward = ale.act(a);
+      totalReward += reward;
     }
+    cout << "Episode " << episode << " ended with score: " << totalReward
+         << endl;
+    ale.reset_game();
+  }
 
-    return 0;
+  return 0;
 }

--- a/doc/examples/sharedLibraryInterfaceWithModesExample.cpp
+++ b/doc/examples/sharedLibraryInterfaceWithModesExample.cpp
@@ -19,64 +19,64 @@
 #include <ale_interface.hpp>
 
 #ifdef __USE_SDL
-  #include <SDL.h>
+#include <SDL.h>
 #endif
 
 using namespace std;
 
 int main(int argc, char** argv) {
-    if (argc < 2) {
-        std::cerr << "Usage: " << argv[0] << " rom_file" << std::endl;
-        return 1;
-    }
+  if (argc < 2) {
+    std::cerr << "Usage: " << argv[0] << " rom_file" << std::endl;
+    return 1;
+  }
 
-    ALEInterface ale;
+  ALEInterface ale;
 
-    // Get & Set the desired settings
-    ale.setInt("random_seed", 123);
-    //The default is already 0.25, this is just an example
-    ale.setFloat("repeat_action_probability", 0.25);
+  // Get & Set the desired settings
+  ale.setInt("random_seed", 123);
+  //The default is already 0.25, this is just an example
+  ale.setFloat("repeat_action_probability", 0.25);
 
 #ifdef __USE_SDL
-    ale.setBool("display_screen", true);
-    ale.setBool("sound", true);
+  ale.setBool("display_screen", true);
+  ale.setBool("sound", true);
 #endif
 
-    // Load the ROM file. (Also resets the system for new settings to
-    // take effect.)
-    ale.loadROM(argv[1]);
+  // Load the ROM file. (Also resets the system for new settings to
+  // take effect.)
+  ale.loadROM(argv[1]);
 
-    // Get the vectors of available modes and difficulties
-    ModeVect modes = ale.getAvailableModes();
-    DifficultyVect difficulties = ale.getAvailableDifficulties();
+  // Get the vectors of available modes and difficulties
+  ModeVect modes = ale.getAvailableModes();
+  DifficultyVect difficulties = ale.getAvailableDifficulties();
 
-    cout << "Number of available modes: " << modes.size() << endl;
-    cout << "Number of available difficulties: " << difficulties.size() << endl;
+  cout << "Number of available modes: " << modes.size() << endl;
+  cout << "Number of available difficulties: " << difficulties.size() << endl;
 
-    // Get the vector of legal actions
-    ActionVect legal_actions = ale.getLegalActionSet();
+  // Get the vector of legal actions
+  ActionVect legal_actions = ale.getLegalActionSet();
 
-    // Play one episode in each mode and in each difficulty
-    for (int i = 0; i < modes.size(); i++){
-        for (int j = 0; j < difficulties.size(); j++){
+  // Play one episode in each mode and in each difficulty
+  for (int i = 0; i < modes.size(); i++) {
+    for (int j = 0; j < difficulties.size(); j++) {
+      ale.setDifficulty(difficulties[j]);
+      ale.setMode(modes[i]);
+      // Reset after choosing difficulty and mode.
+      ale.reset_game();
+      cout << "Mode " << modes[i] << ", difficulty " << difficulties[j] << ":"
+           << endl;
 
-            ale.setDifficulty(difficulties[j]);
-            ale.setMode(modes[i]);
-            // Reset after choosing difficulty and mode.
-            ale.reset_game();
-            cout << "Mode " << modes[i] << ", difficulty " << difficulties[j] << ":" << endl;
-
-            float totalReward = 0;
-            while (!ale.game_over()) {
-                Action a = legal_actions[rand() % legal_actions.size()];
-                // Apply the action and get the resulting reward
-                float reward = ale.act(a);
-                totalReward += reward;
-            }
-            cout << "Episode ended with score: " << totalReward << endl;
-            ale.reset_game();
-        }
+      float totalReward = 0;
+      while (!ale.game_over()) {
+        Action a = legal_actions[rand() % legal_actions.size()];
+        // Apply the action and get the resulting reward
+        float reward = ale.act(a);
+        totalReward += reward;
+      }
+      cout << "Episode ended with score: " << totalReward << endl;
+      ale.reset_game();
     }
+  }
 
-    return 0;
+  return 0;
 }

--- a/doc/examples/videoRecordingExample.cpp
+++ b/doc/examples/videoRecordingExample.cpp
@@ -28,54 +28,55 @@
 using namespace std;
 
 int main(int argc, char** argv) {
-    if (argc < 2) {
-        std::cout << "Usage: " << argv[0] << " rom_file" << std::endl;
-        return 1;
-    }
+  if (argc < 2) {
+    std::cout << "Usage: " << argv[0] << " rom_file" << std::endl;
+    return 1;
+  }
 
-    ALEInterface ale;
+  ALEInterface ale;
 
-    // Get & Set the desired settings
-    ale.setInt("random_seed", 123);
+  // Get & Set the desired settings
+  ale.setInt("random_seed", 123);
 
-    // We enable both screen and sound, which we will need for recording.
-    ale.setBool("display_screen", true);
-    // You may leave sound disabled (by setting this flag to false) if so desired.
-    ale.setBool("sound", true);
+  // We enable both screen and sound, which we will need for recording.
+  ale.setBool("display_screen", true);
+  // You may leave sound disabled (by setting this flag to false) if so desired.
+  ale.setBool("sound", true);
 
-    std::string recordPath = "record";
-    std::cout << std::endl;
+  std::string recordPath = "record";
+  std::cout << std::endl;
 
-    // Set record flags
-    ale.setString("record_screen_dir", recordPath.c_str());
-    ale.setString("record_sound_filename", (recordPath + "/sound.wav").c_str());
-    // We set fragsize to 64 to ensure proper sound sync
-    ale.setInt("fragsize", 64);
+  // Set record flags
+  ale.setString("record_screen_dir", recordPath.c_str());
+  ale.setString("record_sound_filename", (recordPath + "/sound.wav").c_str());
+  // We set fragsize to 64 to ensure proper sound sync
+  ale.setInt("fragsize", 64);
 
-    // Not completely portable, but will work in most cases
-    std::string cmd = "mkdir ";
-    cmd += recordPath;
-    system(cmd.c_str());
+  // Not completely portable, but will work in most cases
+  std::string cmd = "mkdir ";
+  cmd += recordPath;
+  system(cmd.c_str());
 
-    // Load the ROM file. (Also resets the system for new settings to
-    // take effect.)
-    ale.loadROM(argv[1]);
+  // Load the ROM file. (Also resets the system for new settings to
+  // take effect.)
+  ale.loadROM(argv[1]);
 
-    // Get the vector of legal actions
-    ActionVect legal_actions = ale.getLegalActionSet();
+  // Get the vector of legal actions
+  ActionVect legal_actions = ale.getLegalActionSet();
 
-    // Play a single episode, which we record.
-    while (!ale.game_over()) {
+  // Play a single episode, which we record.
+  while (!ale.game_over()) {
+    Action a = legal_actions[rand() % legal_actions.size()];
+    // Apply the action (discard the resulting reward)
+    ale.act(a);
+  }
 
-        Action a = legal_actions[rand() % legal_actions.size()];
-        // Apply the action (discard the resulting reward)
-        ale.act(a);
-    }
+  std::cout << std::endl;
+  std::cout << "Recording complete. To create a video, you may want to run \n"
+               "  doc/scripts/videoRecordingExampleJoinXXX.sh. See manual for "
+               "details.."
+            << std::endl;
 
-    std::cout << std::endl;
-    std::cout << "Recording complete. To create a video, you may want to run \n"
-        "  doc/scripts/videoRecordingExampleJoinXXX.sh. See manual for details.." << std::endl;
-
-    return 0;
+  return 0;
 }
-#endif // __USE_SDL
+#endif  // __USE_SDL

--- a/src/ale_interface.cpp
+++ b/src/ale_interface.cpp
@@ -55,7 +55,8 @@ using namespace ale;
 std::string ALEInterface::welcomeMessage() {
   std::ostringstream oss;
   oss << "A.L.E: Arcade Learning Environment (version " << Version << ")\n"
-      << "[Powered by Stella]\n" << "Use -help for help screen.";
+      << "[Powered by Stella]\n"
+      << "Use -help for help screen.";
   return oss.str();
 }
 
@@ -68,8 +69,8 @@ void ALEInterface::disableBufferedIO() {
   std::cout.sync_with_stdio();
 }
 
-void ALEInterface::createOSystem(std::unique_ptr<OSystem> &theOSystem,
-                          std::unique_ptr<Settings> &theSettings) {
+void ALEInterface::createOSystem(std::unique_ptr<OSystem>& theOSystem,
+                                 std::unique_ptr<Settings>& theSettings) {
 #if (defined(WIN32) || defined(__MINGW32__))
   theOSystem.reset(new OSystemWin32());
   theSettings.reset(new SettingsWin32(theOSystem.get()));
@@ -81,7 +82,8 @@ void ALEInterface::createOSystem(std::unique_ptr<OSystem> &theOSystem,
   theOSystem->settings().loadConfig();
 }
 
-void ALEInterface::checkForUnsupportedRom(std::unique_ptr<OSystem>& theOSystem) {
+void ALEInterface::checkForUnsupportedRom(
+    std::unique_ptr<OSystem>& theOSystem) {
   const Properties properties = theOSystem->console().properties();
   const std::string md5 = properties.get(Cartridge_MD5);
   bool found = false;
@@ -96,7 +98,8 @@ void ALEInterface::checkForUnsupportedRom(std::unique_ptr<OSystem>& theOSystem) 
   if (!found) {
     // If the md5 doesn't match our master list, warn the user.
     Logger::Warning << std::endl;
-    Logger::Warning << "WARNING: Possibly unsupported ROM: mismatched MD5." << std::endl;
+    Logger::Warning << "WARNING: Possibly unsupported ROM: mismatched MD5."
+                    << std::endl;
     Logger::Warning << "Cartridge_MD5: " << md5 << std::endl;
     const std::string name = properties.get(Cartridge_Name);
     Logger::Warning << "Cartridge_name: " << name << std::endl;
@@ -105,7 +108,7 @@ void ALEInterface::checkForUnsupportedRom(std::unique_ptr<OSystem>& theOSystem) 
 }
 
 void ALEInterface::loadSettings(const std::string& romfile,
-                                std::unique_ptr<OSystem> &theOSystem) {
+                                std::unique_ptr<OSystem>& theOSystem) {
   // Load the configuration from a config file (passed on the command
   //  line), if provided
   std::string configFile = theOSystem->settings().getString("config", false);
@@ -124,7 +127,7 @@ void ALEInterface::loadSettings(const std::string& romfile,
   } else if (!FilesystemNode::fileExists(romfile)) {
     Logger::Error << "ROM file " << romfile << " not found." << std::endl;
     exit(1);
-  } else if (theOSystem->createConsole(romfile))  {
+  } else if (theOSystem->createConsole(romfile)) {
     checkForUnsupportedRom(theOSystem);
     Logger::Info << "Running ROM file..." << std::endl;
     theOSystem->settings().setString("rom_file", romfile);
@@ -133,10 +136,10 @@ void ALEInterface::loadSettings(const std::string& romfile,
     exit(1);
   }
 
-// Must force the resetting of the OSystem's random seed, which is set before we change
-// choose our random seed.
+  // Must force the resetting of the OSystem's random seed, which is set before we change
+  // choose our random seed.
   Logger::Info << "Random seed is "
-      << theOSystem->settings().getInt("random_seed") << std::endl;
+               << theOSystem->settings().getInt("random_seed") << std::endl;
   theOSystem->resetRNGSeed();
 
   std::string currentDisplayFormat = theOSystem->console().getFormat();
@@ -156,8 +159,7 @@ ALEInterface::ALEInterface(bool display_screen) {
   this->setBool("display_screen", display_screen);
 }
 
-ALEInterface::~ALEInterface() {
-}
+ALEInterface::~ALEInterface() {}
 
 // Loads and initializes a game. After this call the game should be
 // ready to play. Resets the OSystem/Console/Environment/etc. This is
@@ -176,12 +178,13 @@ void ALEInterface::loadROM(std::string rom_file = "") {
 #ifndef __USE_SDL
   if (theOSystem->p_display_screen != NULL) {
     Logger::Error
-        << "Screen display requires directive __USE_SDL to be defined." << std::endl;
+        << "Screen display requires directive __USE_SDL to be defined."
+        << std::endl;
     Logger::Error << "Please recompile this code with flag '-D__USE_SDL'."
-        << std::endl;
-    Logger::Error
-        << "Also ensure ALE has been compiled with USE_SDL active (see ALE makefile)."
-        << std::endl;
+                  << std::endl;
+    Logger::Error << "Also ensure ALE has been compiled with USE_SDL active "
+                     "(see ALE makefile)."
+                  << std::endl;
     exit(1);
   }
 #endif
@@ -232,14 +235,10 @@ void ALEInterface::setFloat(const std::string& key, const float value) {
 }
 
 // Resets the game, but not the full system.
-void ALEInterface::reset_game() {
-  environment->reset();
-}
+void ALEInterface::reset_game() { environment->reset(); }
 
 // Indicates if the game has ended.
-bool ALEInterface::game_over() const {
-  return environment->isTerminal();
-}
+bool ALEInterface::game_over() const { return environment->isTerminal(); }
 
 // The remaining number of lives.
 int ALEInterface::lives() {
@@ -278,7 +277,7 @@ ModeVect ALEInterface::getAvailableModes() {
 void ALEInterface::setMode(game_mode_t m) {
   //We first need to make sure m is an available mode
   ModeVect available = romSettings->getAvailableModes();
-  if(find(available.begin(), available.end(), m) != available.end()) {
+  if (find(available.begin(), available.end(), m) != available.end()) {
     environment->setMode(m);
   } else {
     throw std::runtime_error("Invalid game mode requested");
@@ -296,7 +295,7 @@ DifficultyVect ALEInterface::getAvailableDifficulties() {
 // This should be called only after the rom is loaded.
 void ALEInterface::setDifficulty(difficulty_t m) {
   DifficultyVect available = romSettings->getAvailableDifficulties();
-  if(find(available.begin(), available.end(), m) != available.end()) {
+  if (find(available.begin(), available.end(), m) != available.end()) {
     environment->setDifficulty(m);
   } else {
     throw std::runtime_error("Invalid difficulty requested");
@@ -322,9 +321,7 @@ ActionVect ALEInterface::getMinimalActionSet() {
 }
 
 // Returns the frame number since the loading of the ROM
-int ALEInterface::getFrameNumber() {
-  return environment->getFrameNumber();
-}
+int ALEInterface::getFrameNumber() { return environment->getFrameNumber(); }
 
 // Returns the frame number since the start of the current episode
 int ALEInterface::getEpisodeFrameNumber() const {
@@ -332,9 +329,7 @@ int ALEInterface::getEpisodeFrameNumber() const {
 }
 
 // Returns the current game screen
-const ALEScreen& ALEInterface::getScreen() {
-  return environment->getScreen();
-}
+const ALEScreen& ALEInterface::getScreen() { return environment->getScreen(); }
 
 //This method should receive an empty vector to fill it with
 //the grayscale colours
@@ -344,9 +339,9 @@ void ALEInterface::getScreenGrayscale(
   size_t h = environment->getScreen().height();
   size_t screen_size = w * h;
 
-  pixel_t *ale_screen_data = environment->getScreen().getArray();
-  theOSystem->colourPalette().applyPaletteGrayscale(grayscale_output_buffer,
-      ale_screen_data, screen_size);
+  pixel_t* ale_screen_data = environment->getScreen().getArray();
+  theOSystem->colourPalette().applyPaletteGrayscale(
+      grayscale_output_buffer, ale_screen_data, screen_size);
 }
 
 //This method should receive a vector to fill it with
@@ -357,29 +352,22 @@ void ALEInterface::getScreenRGB(std::vector<unsigned char>& output_rgb_buffer) {
   size_t h = environment->getScreen().height();
   size_t screen_size = w * h;
 
-  pixel_t *ale_screen_data = environment->getScreen().getArray();
+  pixel_t* ale_screen_data = environment->getScreen().getArray();
 
-  theOSystem->colourPalette().applyPaletteRGB(output_rgb_buffer, ale_screen_data, screen_size);
+  theOSystem->colourPalette().applyPaletteRGB(output_rgb_buffer,
+                                              ale_screen_data, screen_size);
 }
 
 // Returns the current RAM content
-const ALERAM& ALEInterface::getRAM() {
-  return environment->getRAM();
-}
+const ALERAM& ALEInterface::getRAM() { return environment->getRAM(); }
 
 // Saves the state of the system
-void ALEInterface::saveState() {
-  environment->save();
-}
+void ALEInterface::saveState() { environment->save(); }
 
 // Loads the state of the system
-void ALEInterface::loadState() {
-  environment->load();
-}
+void ALEInterface::loadState() { environment->load(); }
 
-ALEState ALEInterface::cloneState() {
-  return environment->cloneState();
-}
+ALEState ALEInterface::cloneState() { return environment->cloneState(); }
 
 void ALEInterface::restoreState(const ALEState& state) {
   return environment->restoreState(state);
@@ -398,7 +386,7 @@ void ALEInterface::saveScreenPNG(const std::string& filename) {
   exporter.save(environment->getScreen(), filename);
 }
 
-ScreenExporter *ALEInterface::createScreenExporter(
-    const std::string &filename) const {
+ScreenExporter*
+ALEInterface::createScreenExporter(const std::string& filename) const {
   return new ScreenExporter(theOSystem->colourPalette(), filename);
 }

--- a/src/ale_interface.hpp
+++ b/src/ale_interface.hpp
@@ -51,7 +51,7 @@ static const std::string Version = "0.6.0";
    This class interfaces ALE with external code for controlling agents.
  */
 class ALEInterface {
-public:
+ public:
   ALEInterface();
   ~ALEInterface();
   // Legacy constructor
@@ -132,7 +132,7 @@ public:
   int getEpisodeFrameNumber() const;
 
   // Returns the current game screen
-  const ALEScreen &getScreen();
+  const ALEScreen& getScreen();
 
   //This method should receive an empty vector to fill it with
   //the grayscale colours
@@ -144,7 +144,7 @@ public:
   void getScreenRGB(std::vector<unsigned char>& output_rgb_buffer);
 
   // Returns the current RAM content
-  const ALERAM &getRAM();
+  const ALERAM& getRAM();
 
   // Saves the state of the system
   void saveState();
@@ -174,7 +174,7 @@ public:
   // Creates a ScreenExporter object which can be used to save a sequence of frames. Ownership
   // said object is passed to the caller. Frames are saved in the directory 'path', which needs
   // to exists.
-  ScreenExporter *createScreenExporter(const std::string &path) const;
+  ScreenExporter* createScreenExporter(const std::string& path) const;
 
  public:
   std::unique_ptr<OSystem> theOSystem;
@@ -187,10 +187,10 @@ public:
   // Display ALE welcome message
   static std::string welcomeMessage();
   static void disableBufferedIO();
-  static void createOSystem(std::unique_ptr<OSystem> &theOSystem,
-                            std::unique_ptr<Settings> &theSettings);
+  static void createOSystem(std::unique_ptr<OSystem>& theOSystem,
+                            std::unique_ptr<Settings>& theSettings);
   static void loadSettings(const std::string& romfile,
-                           std::unique_ptr<OSystem> &theOSystem);
+                           std::unique_ptr<OSystem>& theOSystem);
 
  private:
   static void checkForUnsupportedRom(std::unique_ptr<OSystem>& theOSystem);

--- a/src/common/ColourPalette.cpp
+++ b/src/common/ColourPalette.cpp
@@ -23,192 +23,182 @@
 
 using namespace std;
 
-inline uInt32 packRGB(uInt8 r, uInt8 g, uInt8 b)
-{
-    return ((uInt32)r << 16) + ((uInt32)g << 8) + (uInt32)b;
+inline uInt32 packRGB(uInt8 r, uInt8 g, uInt8 b) {
+  return ((uInt32)r << 16) + ((uInt32)g << 8) + (uInt32)b;
 }
 
-inline uInt32 convertGrayscale(uInt32 packedRGBValue)
-{
-    double r = (packedRGBValue >> 16) & 0xff;
-    double g = (packedRGBValue >> 8)  & 0xff;
-    double b = (packedRGBValue >> 0)  & 0xff;
+inline uInt32 convertGrayscale(uInt32 packedRGBValue) {
+  double r = (packedRGBValue >> 16) & 0xff;
+  double g = (packedRGBValue >> 8) & 0xff;
+  double b = (packedRGBValue >> 0) & 0xff;
 
-    uInt8 lum = (uInt8) round(r * 0.2989 + g * 0.5870 + b * 0.1140);
+  uInt8 lum = (uInt8)round(r * 0.2989 + g * 0.5870 + b * 0.1140);
 
-    return packRGB(lum, lum, lum);
+  return packRGB(lum, lum, lum);
 }
 
-ColourPalette::ColourPalette(): m_palette(NULL) {
+ColourPalette::ColourPalette() : m_palette(NULL) {}
+
+void ColourPalette::getRGB(int val, int& r, int& g, int& b) const {
+  assert(m_palette != NULL);
+  assert(val >= 0 && val <= 0xFF);
+  // Make sure we are reading from RGB, not grayscale.
+  assert((val & 0x01) == 0);
+
+  // Set the RGB components accordingly
+  r = (m_palette[val] >> 16) & 0xFF;
+  g = (m_palette[val] >> 8) & 0xFF;
+  b = (m_palette[val] >> 0) & 0xFF;
 }
 
+uInt8 ColourPalette::getGrayscale(int val) const {
+  assert(m_palette != NULL);
+  assert(val >= 0 && val < 0xFF);
+  assert((val & 0x01) == 1);
 
-void ColourPalette::getRGB(int val, int &r, int &g, int &b) const
-{
-    assert(m_palette != NULL);
-    assert(val >= 0 && val <= 0xFF);
-    // Make sure we are reading from RGB, not grayscale.
-    assert((val & 0x01) == 0);
-
-    // Set the RGB components accordingly
-    r = (m_palette[val] >> 16) & 0xFF;
-    g = (m_palette[val] >>  8) & 0xFF;
-    b = (m_palette[val] >>  0) & 0xFF;
+  // Set the RGB components accordingly
+  return (m_palette[val + 1] >> 0) & 0xFF;
 }
 
-uInt8 ColourPalette::getGrayscale(int val) const
-{
-    assert(m_palette != NULL);
-    assert(val >= 0 && val < 0xFF);
-    assert((val & 0x01) == 1);
+uInt32 ColourPalette::getRGB(int val) const { return m_palette[val]; }
 
-    // Set the RGB components accordingly
-    return (m_palette[val+1] >> 0) & 0xFF;
+void ColourPalette::applyPaletteRGB(uInt8* dst_buffer, uInt8* src_buffer,
+                                    size_t src_size) {
+  uInt8* p = src_buffer;
+  uInt8* q = dst_buffer;
+
+  for (size_t i = 0; i < src_size; i++, p++) {
+    int rgb = m_palette[*p];
+    *q = (unsigned char)((rgb >> 16)); q++;  // r
+    *q = (unsigned char)((rgb >>  8)); q++;  // g
+    *q = (unsigned char)((rgb >>  0)); q++;  // b
+  }
 }
 
-uInt32 ColourPalette::getRGB(int val) const
-{
-    return m_palette[val];
+void ColourPalette::applyPaletteRGB(std::vector<unsigned char>& dst_buffer,
+                                    uInt8* src_buffer, size_t src_size) {
+  dst_buffer.resize(3 * src_size);
+  assert(dst_buffer.size() == 3 * src_size);
+
+  uInt8* p = src_buffer;
+
+  for (size_t i = 0; i < src_size * 3; i += 3, p++) {
+    int rgb = m_palette[*p];
+    dst_buffer[i + 0] = (unsigned char)((rgb >> 16));  // r
+    dst_buffer[i + 1] = (unsigned char)((rgb >>  8));  // g
+    dst_buffer[i + 2] = (unsigned char)((rgb >>  0));  // b
+  }
 }
 
-void ColourPalette::applyPaletteRGB(uInt8* dst_buffer, uInt8 *src_buffer, size_t src_size)
-{
-    uInt8 *p = src_buffer;
-    uInt8 *q = dst_buffer;
+void ColourPalette::applyPaletteGrayscale(uInt8* dst_buffer, uInt8* src_buffer,
+                                          size_t src_size) {
+  uInt8* p = src_buffer;
+  uInt8* q = dst_buffer;
 
-    for(size_t i = 0; i < src_size; i++, p++){
-        int rgb = m_palette[*p];
-        *q = (unsigned char) ((rgb >> 16));  q++;    // r
-        *q = (unsigned char) ((rgb >>  8));  q++;    // g
-        *q = (unsigned char) ((rgb >>  0));  q++;    // b
-    }
+  for (size_t i = 0; i < src_size; i++, p++, q++) {
+    *q = (unsigned char)(m_palette[*p + 1] & 0xFF);
+  }
 }
 
-void ColourPalette::applyPaletteRGB(std::vector<unsigned char>& dst_buffer, uInt8 *src_buffer, size_t src_size)
-{
-    dst_buffer.resize(3 * src_size);
-    assert(dst_buffer.size() == 3 * src_size);
+void ColourPalette::applyPaletteGrayscale(
+    std::vector<unsigned char>& dst_buffer, uInt8* src_buffer,
+    size_t src_size) {
+  dst_buffer.resize(src_size);
+  assert(dst_buffer.size() == src_size);
 
-    uInt8 *p = src_buffer;
+  uInt8* p = src_buffer;
 
-    for(size_t i = 0; i < src_size * 3; i += 3, p++){
-        int rgb = m_palette[*p];
-        dst_buffer[i+0] = (unsigned char) ((rgb >> 16));    // r
-        dst_buffer[i+1] = (unsigned char) ((rgb >>  8));    // g
-        dst_buffer[i+2] = (unsigned char) ((rgb >>  0));    // b
-    }
-}
-
-void ColourPalette::applyPaletteGrayscale(uInt8* dst_buffer, uInt8 *src_buffer, size_t src_size)
-{
-    uInt8 *p = src_buffer;
-    uInt8 *q = dst_buffer;
-
-    for(size_t i = 0; i < src_size; i++, p++, q++){
-        *q = (unsigned char) (m_palette[*p+1] & 0xFF);
-    }
-}
-
-void ColourPalette::applyPaletteGrayscale(std::vector<unsigned char>& dst_buffer, uInt8 *src_buffer, size_t src_size)
-{
-    dst_buffer.resize(src_size);
-    assert(dst_buffer.size() == src_size);
-
-    uInt8 *p = src_buffer;
-
-    for(size_t i = 0; i < src_size; i++, p++){
-        dst_buffer[i] = (unsigned char) (m_palette[*p+1] & 0xFF);
-    }
+  for (size_t i = 0; i < src_size; i++, p++) {
+    dst_buffer[i] = (unsigned char)(m_palette[*p + 1] & 0xFF);
+  }
 }
 
 void ColourPalette::setPalette(const string& type,
-                               const string& displayFormat)
-{
-    // See which format we should be using
-    int paletteNum = 0;
-    if(type == "standard")
-        paletteNum = 0;
-    else if(type == "z26")
-        paletteNum = 1;
-    else if(type == "user" && myUserPaletteDefined)
-        paletteNum = 2;
+                               const string& displayFormat) {
+  // See which format we should be using
+  int paletteNum = 0;
+  if (type == "standard")
+    paletteNum = 0;
+  else if (type == "z26")
+    paletteNum = 1;
+  else if (type == "user" && myUserPaletteDefined)
+    paletteNum = 2;
 
-    int paletteFormat = 0;
-    if (displayFormat.compare(0, 3, "PAL") == 0)
-        paletteFormat = 1;
-    else if (displayFormat.compare(0, 5, "SECAM") == 0)
-        paletteFormat = 2;
+  int paletteFormat = 0;
+  if (displayFormat.compare(0, 3, "PAL") == 0)
+    paletteFormat = 1;
+  else if (displayFormat.compare(0, 5, "SECAM") == 0)
+    paletteFormat = 2;
 
-    uInt32* paletteMapping[3][3] = {
-        {NTSCPalette,       PALPalette,     SECAMPalette},
-        {NTSCPaletteZ26,    PALPaletteZ26,  SECAMPaletteZ26},
-        {m_userNTSCPalette, m_userPALPalette, m_userSECAMPalette}
-    };
+  uInt32* paletteMapping[3][3] = {
+      {NTSCPalette, PALPalette, SECAMPalette},
+      {NTSCPaletteZ26, PALPaletteZ26, SECAMPaletteZ26},
+      {m_userNTSCPalette, m_userPALPalette, m_userSECAMPalette}};
 
-    m_palette  = paletteMapping[paletteNum][paletteFormat];
+  m_palette = paletteMapping[paletteNum][paletteFormat];
 }
 
-void ColourPalette::loadUserPalette(const string& paletteFile)
-{
-    const int bytesPerColor = 3;
-    const int NTSCPaletteSize = 128;
-    const int PALPaletteSize = 128;
-    const int SECAMPaletteSize = 8;
+void ColourPalette::loadUserPalette(const string& paletteFile) {
+  const int bytesPerColor = 3;
+  const int NTSCPaletteSize = 128;
+  const int PALPaletteSize = 128;
+  const int SECAMPaletteSize = 8;
 
-    int expectedFileSize =  NTSCPaletteSize * bytesPerColor +
-                            PALPaletteSize * bytesPerColor +
-                            SECAMPaletteSize * bytesPerColor;
+  int expectedFileSize = NTSCPaletteSize * bytesPerColor +
+                         PALPaletteSize * bytesPerColor +
+                         SECAMPaletteSize * bytesPerColor;
 
-    ifstream paletteStream(paletteFile.c_str(), ios::binary);
-    if(!paletteStream)
-        return;
+  ifstream paletteStream(paletteFile.c_str(), ios::binary);
+  if (!paletteStream)
+    return;
 
-    // Make sure the contains enough data for the NTSC, PAL and SECAM palettes
-    // This means 128 colours each for NTSC and PAL, at 3 bytes per pixel
-    // and 8 colours for SECAM at 3 bytes per pixel
-    paletteStream.seekg(0, ios::end);
-    streampos length = paletteStream.tellg();
-    paletteStream.seekg(0, ios::beg);
+  // Make sure the contains enough data for the NTSC, PAL and SECAM palettes
+  // This means 128 colours each for NTSC and PAL, at 3 bytes per pixel
+  // and 8 colours for SECAM at 3 bytes per pixel
+  paletteStream.seekg(0, ios::end);
+  streampos length = paletteStream.tellg();
+  paletteStream.seekg(0, ios::beg);
 
-    if(length < expectedFileSize)
-    {
-        paletteStream.close();
-        cerr << "ERROR: invalid palette file " << paletteFile << endl;
-        return;
-    }
-
-    // Now that we have valid data, create the user-defined palettes
-    uInt8 pixbuf[bytesPerColor];  // Temporary buffer for one 24-bit pixel
-
-    for(int i = 0; i < NTSCPaletteSize; i++)  // NTSC palette
-    {
-        paletteStream.read((char*)pixbuf, bytesPerColor);
-        m_userNTSCPalette[(i<<1)] = packRGB(pixbuf[0], pixbuf[1], pixbuf[2]);
-        m_userNTSCPalette[(i<<1)+1] = convertGrayscale(m_userNTSCPalette[(i<<1)]);
-    }
-    for(int i = 0; i < PALPaletteSize; i++)  // PAL palette
-    {
-        paletteStream.read((char*)pixbuf, bytesPerColor);
-        m_userPALPalette[(i<<1)] = packRGB(pixbuf[0], pixbuf[1], pixbuf[2]);
-        m_userPALPalette[(i<<1)+1] = convertGrayscale(m_userPALPalette[(i<<1)]);
-    }
-
-    uInt32 tmpSecam[SECAMPaletteSize*2];         // All 8 24-bit pixels, plus 8 colorloss pixels
-    for(int i = 0; i < SECAMPaletteSize; i++)    // SECAM palette
-    {
-        paletteStream.read((char*)pixbuf, bytesPerColor);
-        tmpSecam[(i<<1)]   = packRGB(pixbuf[0], pixbuf[1], pixbuf[2]);
-        tmpSecam[(i<<1)+1] = convertGrayscale(tmpSecam[(i<<1)]);
-    }
-
-    uInt32*tmpSECAMPalettePtr = m_userSECAMPalette;
-    for(int i = 0; i < 16; ++i)
-    {
-        memcpy(tmpSECAMPalettePtr, tmpSecam, SECAMPaletteSize*2);
-        tmpSECAMPalettePtr += SECAMPaletteSize*2;
-    }
-
+  if (length < expectedFileSize) {
     paletteStream.close();
+    cerr << "ERROR: invalid palette file " << paletteFile << endl;
+    return;
+  }
 
-    myUserPaletteDefined = true;
+  // Now that we have valid data, create the user-defined palettes
+  uInt8 pixbuf[bytesPerColor]; // Temporary buffer for one 24-bit pixel
+
+  for (int i = 0; i < NTSCPaletteSize; i++) // NTSC palette
+  {
+    paletteStream.read((char*)pixbuf, bytesPerColor);
+    m_userNTSCPalette[(i << 1)] = packRGB(pixbuf[0], pixbuf[1], pixbuf[2]);
+    m_userNTSCPalette[(i << 1) + 1] =
+        convertGrayscale(m_userNTSCPalette[(i << 1)]);
+  }
+  for (int i = 0; i < PALPaletteSize; i++) // PAL palette
+  {
+    paletteStream.read((char*)pixbuf, bytesPerColor);
+    m_userPALPalette[(i << 1)] = packRGB(pixbuf[0], pixbuf[1], pixbuf[2]);
+    m_userPALPalette[(i << 1) + 1] =
+        convertGrayscale(m_userPALPalette[(i << 1)]);
+  }
+
+  uInt32 tmpSecam[SECAMPaletteSize *
+                  2]; // All 8 24-bit pixels, plus 8 colorloss pixels
+  for (int i = 0; i < SECAMPaletteSize; i++) // SECAM palette
+  {
+    paletteStream.read((char*)pixbuf, bytesPerColor);
+    tmpSecam[(i << 1)] = packRGB(pixbuf[0], pixbuf[1], pixbuf[2]);
+    tmpSecam[(i << 1) + 1] = convertGrayscale(tmpSecam[(i << 1)]);
+  }
+
+  uInt32* tmpSECAMPalettePtr = m_userSECAMPalette;
+  for (int i = 0; i < 16; ++i) {
+    memcpy(tmpSECAMPalettePtr, tmpSecam, SECAMPaletteSize * 2);
+    tmpSECAMPalettePtr += SECAMPaletteSize * 2;
+  }
+
+  paletteStream.close();
+
+  myUserPaletteDefined = true;
 }

--- a/src/common/ColourPalette.hpp
+++ b/src/common/ColourPalette.hpp
@@ -22,37 +22,38 @@
 #include "../emucore/m6502/src/bspf/src/bspf.hxx"
 
 class ColourPalette {
+ public:
+  ColourPalette();
 
-    public:
+  /** Converts a given palette value in range [0, 255] into its RGB components. */
+  void getRGB(int val, int& r, int& g, int& b) const;
 
-        ColourPalette();
+  /** Converts a given palette value into packed RGB (format 0x00RRGGBB). */
+  uInt32 getRGB(int val) const;
 
-        /** Converts a given palette value in range [0, 255] into its RGB components. */
-        void getRGB(int val, int &r, int &g, int &b) const;
+  /** Returns the byte-sized grayscale value for this palette index. */
+  uInt8 getGrayscale(int val) const;
 
-        /** Converts a given palette value into packed RGB (format 0x00RRGGBB). */
-        uInt32 getRGB(int val) const;
-
-        /** Returns the byte-sized grayscale value for this palette index. */
-        uInt8 getGrayscale(int val) const;
-
-        /**
+  /**
             Applies the current RGB palette to the src_buffer and returns the results in dst_buffer
             For each byte in src_buffer, three bytes are returned in dst_buffer
             8 bits => 24 bits
          */
-        void applyPaletteRGB(uInt8* dst_buffer, uInt8 *src_buffer, size_t src_size);
-        void applyPaletteRGB(std::vector<unsigned char>& dst_buffer, uInt8 *src_buffer, size_t src_size);
+  void applyPaletteRGB(uInt8* dst_buffer, uInt8* src_buffer, size_t src_size);
+  void applyPaletteRGB(std::vector<unsigned char>& dst_buffer,
+                       uInt8* src_buffer, size_t src_size);
 
-        /**
+  /**
             Applies the current grayscale palette to the src_buffer and returns the results in dst_buffer
             For each byte in src_buffer, a single byte is returned in dst_buffer
             8 bits => 8 bits
          */
-        void applyPaletteGrayscale(uInt8* dst_buffer, uInt8 *src_buffer, size_t src_size);
-        void applyPaletteGrayscale(std::vector<unsigned char>& dst_buffer, uInt8 *src_buffer, size_t src_size);
+  void applyPaletteGrayscale(uInt8* dst_buffer, uInt8* src_buffer,
+                             size_t src_size);
+  void applyPaletteGrayscale(std::vector<unsigned char>& dst_buffer,
+                             uInt8* src_buffer, size_t src_size);
 
-        /**
+  /**
           Loads all defined palettes with PAL color-loss data depending
           on 'state'.
           Sets the palette according to the given palette name.
@@ -60,24 +61,23 @@ class ColourPalette {
           @param type  The palette type = {standard, z26, user}
           @param displayFormat The display format = { NTSC, PAL, SECAM }
         */
-        void setPalette(const std::string& type,
-                        const std::string& displayFormat);
+  void setPalette(const std::string& type, const std::string& displayFormat);
 
-        /**
+  /**
             Loads a user-defined palette file (from OSystem::paletteFile), filling the
             appropriate user-defined palette arrays.
         */
-        void loadUserPalette(const std::string& paletteFile);
+  void loadUserPalette(const std::string& paletteFile);
 
-private:
-        uInt32 *m_palette;
+ private:
+  uInt32* m_palette;
 
-        bool myUserPaletteDefined;
+  bool myUserPaletteDefined;
 
-        // Table of RGB values for NTSC, PAL and SECAM - user-defined
-        uInt32 m_userNTSCPalette[256];
-        uInt32 m_userPALPalette[256];
-        uInt32 m_userSECAMPalette[256];
+  // Table of RGB values for NTSC, PAL and SECAM - user-defined
+  uInt32 m_userNTSCPalette[256];
+  uInt32 m_userPALPalette[256];
+  uInt32 m_userSECAMPalette[256];
 };
 
-#endif // __COLOUR_PALETTE_HPP__
+#endif  // __COLOUR_PALETTE_HPP__

--- a/src/common/Constants.cpp
+++ b/src/common/Constants.cpp
@@ -16,51 +16,51 @@
 #include "Constants.h"
 
 std::string action_to_string(Action a) {
-    static std::string tmp_action_to_string[] = {
-        "PLAYER_A_NOOP"
-        ,"PLAYER_A_FIRE"
-        ,"PLAYER_A_UP"
-        ,"PLAYER_A_RIGHT"
-        ,"PLAYER_A_LEFT"
-        ,"PLAYER_A_DOWN"
-        ,"PLAYER_A_UPRIGHT"
-        ,"PLAYER_A_UPLEFT"
-        ,"PLAYER_A_DOWNRIGHT"
-        ,"PLAYER_A_DOWNLEFT"
-        ,"PLAYER_A_UPFIRE"
-        ,"PLAYER_A_RIGHTFIRE"
-        ,"PLAYER_A_LEFTFIRE"
-        ,"PLAYER_A_DOWNFIRE"
-        ,"PLAYER_A_UPRIGHTFIRE"
-        ,"PLAYER_A_UPLEFTFIRE"
-        ,"PLAYER_A_DOWNRIGHTFIRE"
-        ,"PLAYER_A_DOWNLEFTFIRE"
-        ,"PLAYER_B_NOOP"
-        ,"PLAYER_B_FIRE"
-        ,"PLAYER_B_UP"
-        ,"PLAYER_B_RIGHT"
-        ,"PLAYER_B_LEFT"
-        ,"PLAYER_B_DOWN"
-        ,"PLAYER_B_UPRIGHT"
-        ,"PLAYER_B_UPLEFT"
-        ,"PLAYER_B_DOWNRIGHT"
-        ,"PLAYER_B_DOWNLEFT"
-        ,"PLAYER_B_UPFIRE"
-        ,"PLAYER_B_RIGHTFIRE"
-        ,"PLAYER_B_LEFTFIRE"
-        ,"PLAYER_B_DOWNFIRE"
-        ,"PLAYER_B_UPRIGHTFIRE"
-        ,"PLAYER_B_UPLEFTFIRE"
-        ,"PLAYER_B_DOWNRIGHTFIRE"
-        ,"PLAYER_B_DOWNLEFTFIRE"
-        ,"__invalid__" // 36
-        ,"__invalid__" // 37
-        ,"__invalid__" // 38
-        ,"__invalid__" // 39
-        ,"RESET"       // 40
-        ,"UNDEFINED"   // 41
-        ,"RANDOM"      // 42
-    };
-    assert (a >= 0 && a <= 42);
-    return tmp_action_to_string[a];
+  static std::string tmp_action_to_string[] = {
+      "PLAYER_A_NOOP",
+      "PLAYER_A_FIRE",
+      "PLAYER_A_UP",
+      "PLAYER_A_RIGHT",
+      "PLAYER_A_LEFT",
+      "PLAYER_A_DOWN",
+      "PLAYER_A_UPRIGHT",
+      "PLAYER_A_UPLEFT",
+      "PLAYER_A_DOWNRIGHT",
+      "PLAYER_A_DOWNLEFT",
+      "PLAYER_A_UPFIRE",
+      "PLAYER_A_RIGHTFIRE",
+      "PLAYER_A_LEFTFIRE",
+      "PLAYER_A_DOWNFIRE",
+      "PLAYER_A_UPRIGHTFIRE",
+      "PLAYER_A_UPLEFTFIRE",
+      "PLAYER_A_DOWNRIGHTFIRE",
+      "PLAYER_A_DOWNLEFTFIRE",
+      "PLAYER_B_NOOP",
+      "PLAYER_B_FIRE",
+      "PLAYER_B_UP",
+      "PLAYER_B_RIGHT",
+      "PLAYER_B_LEFT",
+      "PLAYER_B_DOWN",
+      "PLAYER_B_UPRIGHT",
+      "PLAYER_B_UPLEFT",
+      "PLAYER_B_DOWNRIGHT",
+      "PLAYER_B_DOWNLEFT",
+      "PLAYER_B_UPFIRE",
+      "PLAYER_B_RIGHTFIRE",
+      "PLAYER_B_LEFTFIRE",
+      "PLAYER_B_DOWNFIRE",
+      "PLAYER_B_UPRIGHTFIRE",
+      "PLAYER_B_UPLEFTFIRE",
+      "PLAYER_B_DOWNRIGHTFIRE",
+      "PLAYER_B_DOWNLEFTFIRE",
+      "__invalid__",  // 36
+      "__invalid__",  // 37
+      "__invalid__",  // 38
+      "__invalid__",  // 39
+      "RESET",        // 40
+      "UNDEFINED",    // 41
+      "RANDOM",       // 42
+  };
+  assert(a >= 0 && a <= 42);
+  return tmp_action_to_string[a];
 }

--- a/src/common/Log.cpp
+++ b/src/common/Log.cpp
@@ -4,12 +4,11 @@ using namespace ale;
 
 Logger::mode Logger::current_mode = Info;
 
-void Logger::setMode(Logger::mode m){
-    current_mode = m;
-}
+void Logger::setMode(Logger::mode m) { current_mode = m; }
 
-ale::Logger::mode ale::operator<<(ale::Logger::mode log, std::ostream & (*manip)(std::ostream &)) {
-    if(log >= Logger::current_mode)
-        manip(std::cerr);
-    return log;
+ale::Logger::mode ale::operator<<(ale::Logger::mode log,
+                                  std::ostream& (*manip)(std::ostream&)) {
+  if (log >= Logger::current_mode)
+    manip(std::cerr);
+  return log;
 }

--- a/src/common/Log.hpp
+++ b/src/common/Log.hpp
@@ -1,38 +1,34 @@
 #ifndef __LOG_HPP__
 #define __LOG_HPP__
+
 #include <iostream>
-namespace ale
-{
-    class Logger
-    {
-    public:
-        enum mode{
-            Info = 0,
-            Warning = 1,
-            Error = 2
-        };
-        /** @brief Allow to change the level of verbosity
+
+namespace ale {
+
+class Logger {
+ public:
+  enum mode { Info = 0, Warning = 1, Error = 2 };
+  /** @brief Allow to change the level of verbosity
          * @param m Info will print all the messages, Warning only the important ones
          * and Error the critical ones
          */
-        static void setMode(mode m);
-    private:
-        static mode current_mode;
-        friend mode operator<<(mode,std::ostream&(*manip)(std::ostream &));
-        template<typename T>
-        friend mode operator<<(mode, const T&);
-    };
+  static void setMode(mode m);
 
+ private:
+  static mode current_mode;
+  friend mode operator<<(mode, std::ostream& (*manip)(std::ostream&));
+  template <typename T> friend mode operator<<(mode, const T&);
+};
 
-    Logger::mode operator<<(Logger::mode log, std::ostream & (*manip)(std::ostream &));
+Logger::mode operator<<(Logger::mode log,
+                        std::ostream& (*manip)(std::ostream&));
 
-    template<typename T>
-    Logger::mode operator << (Logger::mode log, const T& val){
-        if(log>=Logger::current_mode)
-            std::cerr << val;
-        return log;
-    }
-
-
+template <typename T> Logger::mode operator<<(Logger::mode log, const T& val) {
+  if (log >= Logger::current_mode)
+    std::cerr << val;
+  return log;
 }
+
+} // namespace ale
+
 #endif

--- a/src/common/ScreenExporter.cpp
+++ b/src/common/ScreenExporter.cpp
@@ -23,176 +23,162 @@
 // MGB: These methods originally belonged to ExportScreen. Possibly these should be returned to
 // their own class, rather than be static methods. They are here to avoid exposing the gritty
 // details of PNG generation.
-static void writePNGChunk(std::ofstream& out, const char* type, uInt8* data, int size) {
+static void writePNGChunk(std::ofstream& out, const char* type, uInt8* data,
+                          int size) {
+  // Stuff the length/type into the buffer
+  uInt8 temp[8];
+  temp[0] = size >> 24;
+  temp[1] = size >> 16;
+  temp[2] = size >> 8;
+  temp[3] = size;
+  temp[4] = type[0];
+  temp[5] = type[1];
+  temp[6] = type[2];
+  temp[7] = type[3];
 
-    // Stuff the length/type into the buffer
-    uInt8 temp[8];
-    temp[0] = size >> 24;
-    temp[1] = size >> 16;
-    temp[2] = size >> 8;
-    temp[3] = size;
-    temp[4] = type[0];
-    temp[5] = type[1];
-    temp[6] = type[2];
-    temp[7] = type[3];
+  // Write the header
+  out.write((const char*)temp, 8);
 
-    // Write the header
-    out.write((const char*)temp, 8);
+  // Append the actual data
+  uInt32 crc = crc32(0, temp + 4, 4);
+  if (size > 0) {
+    out.write((const char*)data, size);
+    crc = crc32(crc, data, size);
+  }
 
-    // Append the actual data
-    uInt32 crc = crc32(0, temp + 4, 4);
-    if(size > 0)
-    {
-        out.write((const char*)data, size);
-        crc = crc32(crc, data, size);
+  // Write the CRC
+  temp[0] = crc >> 24;
+  temp[1] = crc >> 16;
+  temp[2] = crc >> 8;
+  temp[3] = crc;
+  out.write((const char*)temp, 4);
+}
+
+static void writePNGHeader(std::ofstream& out, const ALEScreen& screen,
+                           bool doubleWidth = true) {
+  int width = doubleWidth ? screen.width() * 2 : screen.width();
+  int height = screen.height();
+  // PNG file header
+  uInt8 header[8] = {137, 80, 78, 71, 13, 10, 26, 10};
+  out.write((const char*)header, sizeof(header));
+
+  // PNG IHDR
+  uInt8 ihdr[13];
+  ihdr[0] = (width >> 24) & 0xFF; // width
+  ihdr[1] = (width >> 16) & 0xFF;
+  ihdr[2] = (width >> 8) & 0xFF;
+  ihdr[3] = (width >> 0) & 0xFF;
+  ihdr[4] = (height >> 24) & 0xFF; // height
+  ihdr[5] = (height >> 16) & 0xFF;
+  ihdr[6] = (height >> 8) & 0xFF;
+  ihdr[7] = (height >> 0) & 0xFF;
+  ihdr[8] = 8;  // 8 bits per sample (24 bits per pixel)
+  ihdr[9] = 2;  // PNG_COLOR_TYPE_RGB
+  ihdr[10] = 0; // PNG_COMPRESSION_TYPE_DEFAULT
+  ihdr[11] = 0; // PNG_FILTER_TYPE_DEFAULT
+  ihdr[12] = 0; // PNG_INTERLACE_NONE
+  writePNGChunk(out, "IHDR", ihdr, sizeof(ihdr));
+}
+
+static void writePNGData(std::ofstream& out, const ALEScreen& screen,
+                         const ColourPalette& palette,
+                         bool doubleWidth = true) {
+  int dataWidth = screen.width();
+  int width = doubleWidth ? dataWidth * 2 : dataWidth;
+  int height = screen.height();
+
+  // If so desired, double the width
+
+  // Fill the buffer with scanline data
+  int rowbytes = width * 3;
+
+  std::vector<uInt8> buffer((rowbytes + 1) * height, 0);
+  uInt8* buf_ptr = &buffer[0];
+
+  for (int i = 0; i < height; i++) {
+    *buf_ptr++ = 0; // first byte of row is filter type
+    for (int j = 0; j < dataWidth; j++) {
+      int r, g, b;
+
+      palette.getRGB(screen.getArray()[i * dataWidth + j], r, g, b);
+      // Double the pixel width, if so desired
+      int jj = doubleWidth ? 2 * j : j;
+
+      buf_ptr[jj * 3 + 0] = r;
+      buf_ptr[jj * 3 + 1] = g;
+      buf_ptr[jj * 3 + 2] = b;
+
+      if (doubleWidth) {
+        jj = jj + 1;
+
+        buf_ptr[jj * 3 + 0] = r;
+        buf_ptr[jj * 3 + 1] = g;
+        buf_ptr[jj * 3 + 2] = b;
+      }
     }
+    buf_ptr += rowbytes; // add pitch
+  }
 
-    // Write the CRC
-    temp[0] = crc >> 24;
-    temp[1] = crc >> 16;
-    temp[2] = crc >> 8;
-    temp[3] = crc;
-    out.write((const char*)temp, 4);
+  // Compress the data with zlib
+  uLongf compmemsize = (uLongf)((height * (width + 1) * 3 + 1) + 12);
+  std::vector<uInt8> compmem(compmemsize, 0);
+
+  if ((compress(&compmem[0], &compmemsize, &buffer[0],
+                height * (width * 3 + 1)) != Z_OK)) {
+    // @todo -- throw a proper exception
+    ale::Logger::Error << "Error: Couldn't compress PNG" << std::endl;
+    return;
+  }
+
+  // Write the compressed framebuffer data
+  writePNGChunk(out, "IDAT", &compmem[0], compmemsize);
 }
 
-
-static void writePNGHeader(std::ofstream& out, const ALEScreen &screen, bool doubleWidth = true) {
-
-        int width = doubleWidth ? screen.width() * 2: screen.width();
-        int height = screen.height();
-        // PNG file header
-        uInt8 header[8] = { 137, 80, 78, 71, 13, 10, 26, 10 };
-        out.write((const char*)header, sizeof(header));
-
-        // PNG IHDR
-        uInt8 ihdr[13];
-        ihdr[0]  = (width >> 24) & 0xFF;   // width
-        ihdr[1]  = (width >> 16) & 0xFF;
-        ihdr[2]  = (width >>  8) & 0xFF;
-        ihdr[3]  = (width >>  0) & 0xFF;
-        ihdr[4]  = (height >> 24) & 0xFF;  // height
-        ihdr[5]  = (height >> 16) & 0xFF;
-        ihdr[6]  = (height >>  8) & 0xFF;
-        ihdr[7]  = (height >>  0) & 0xFF;
-        ihdr[8]  = 8;  // 8 bits per sample (24 bits per pixel)
-        ihdr[9]  = 2;  // PNG_COLOR_TYPE_RGB
-        ihdr[10] = 0;  // PNG_COMPRESSION_TYPE_DEFAULT
-        ihdr[11] = 0;  // PNG_FILTER_TYPE_DEFAULT
-        ihdr[12] = 0;  // PNG_INTERLACE_NONE
-        writePNGChunk(out, "IHDR", ihdr, sizeof(ihdr));
+static void writePNGEnd(std::ofstream& out) {
+  // Finish up
+  writePNGChunk(out, "IEND", 0, 0);
 }
 
+ScreenExporter::ScreenExporter(ColourPalette& palette)
+    : m_palette(palette), m_frame_number(0), m_frame_field_width(6) {}
 
-static void writePNGData(std::ofstream &out, const ALEScreen &screen, const ColourPalette &palette, bool doubleWidth = true) {
+ScreenExporter::ScreenExporter(ColourPalette& palette, const std::string& path)
+    : m_palette(palette), m_frame_number(0), m_frame_field_width(6),
+      m_path(path) {}
 
-    int dataWidth = screen.width();
-    int width = doubleWidth ? dataWidth * 2 : dataWidth;
-    int height = screen.height();
+void ScreenExporter::save(const ALEScreen& screen,
+                          const std::string& filename) const {
+  // Open file for writing
+  std::ofstream out(filename.c_str(), std::ios_base::binary);
+  if (!out.good()) {
+    // @todo exception
+    ale::Logger::Error << "Could not open " << filename << " for writing"
+                       << std::endl;
+    return;
+  }
 
-    // If so desired, double the width
+  // Now write the PNG proper
+  writePNGHeader(out, screen, true);
+  writePNGData(out, screen, m_palette, true);
+  writePNGEnd(out);
 
-    // Fill the buffer with scanline data
-    int rowbytes = width * 3;
-
-    std::vector<uInt8> buffer((rowbytes + 1) * height, 0);
-    uInt8* buf_ptr = &buffer[0];
-
-    for(int i = 0; i < height; i++) {
-        *buf_ptr++ = 0;                  // first byte of row is filter type
-        for(int j = 0; j < dataWidth; j++) {
-            int r, g, b;
-
-            palette.getRGB(screen.getArray()[i * dataWidth + j], r, g, b);
-            // Double the pixel width, if so desired
-            int jj = doubleWidth ? 2 * j : j;
-
-            buf_ptr[jj * 3 + 0] = r;
-            buf_ptr[jj * 3 + 1] = g;
-            buf_ptr[jj * 3 + 2] = b;
-
-            if (doubleWidth) {
-
-                jj = jj + 1;
-
-                buf_ptr[jj * 3 + 0] = r;
-                buf_ptr[jj * 3 + 1] = g;
-                buf_ptr[jj * 3 + 2] = b;
-            }
-        }
-        buf_ptr += rowbytes;                 // add pitch
-    }
-
-    // Compress the data with zlib
-    uLongf compmemsize = (uLongf)((height * (width + 1) * 3 + 1) + 12);
-    std::vector<uInt8> compmem(compmemsize, 0);
-
-    if((compress(&compmem[0], &compmemsize, &buffer[0], height * (width * 3 + 1)) != Z_OK)) {
-
-        // @todo -- throw a proper exception
-        ale::Logger::Error << "Error: Couldn't compress PNG" << std::endl;
-        return;
-    }
-
-    // Write the compressed framebuffer data
-    writePNGChunk(out, "IDAT", &compmem[0], compmemsize);
+  out.close();
 }
 
+void ScreenExporter::saveNext(const ALEScreen& screen) {
+  // Must have specified a directory.
+  assert(m_path.size() > 0);
 
-static void writePNGEnd(std::ofstream &out) {
+  // MGB: It would be nice here to automagically create paths, but the only way I know of
+  // doing this cleanly is via boost, which we don't include.
 
-    // Finish up
-    writePNGChunk(out, "IEND", 0, 0);
-}
+  // Construct the filename from basepath & current frame number
+  std::ostringstream oss;
+  oss << m_path << "/" << std::setw(m_frame_field_width) << std::setfill('0')
+      << m_frame_number << ".png";
 
-ScreenExporter::ScreenExporter(ColourPalette &palette):
-    m_palette(palette),
-    m_frame_number(0),
-    m_frame_field_width(6) {
-}
+  // Save the png
+  save(screen, oss.str());
 
-
-ScreenExporter::ScreenExporter(ColourPalette &palette, const std::string &path):
-    m_palette(palette),
-    m_frame_number(0),
-    m_frame_field_width(6),
-    m_path(path) {
-}
-
-
-void ScreenExporter::save(const ALEScreen &screen, const std::string &filename) const {
-
-    // Open file for writing
-    std::ofstream out(filename.c_str(), std::ios_base::binary);
-    if (!out.good()) {
-
-        // @todo exception
-        ale::Logger::Error << "Could not open " << filename << " for writing" << std::endl;
-        return;
-    }
-
-    // Now write the PNG proper
-    writePNGHeader(out, screen, true);
-    writePNGData(out, screen, m_palette, true);
-    writePNGEnd(out);
-
-    out.close();
-}
-
-void ScreenExporter::saveNext(const ALEScreen &screen) {
-
-    // Must have specified a directory.
-    assert(m_path.size() > 0);
-
-    // MGB: It would be nice here to automagically create paths, but the only way I know of
-    // doing this cleanly is via boost, which we don't include.
-
-    // Construct the filename from basepath & current frame number
-    std::ostringstream oss;
-    oss << m_path << "/" <<
-        std::setw(m_frame_field_width) << std::setfill('0') << m_frame_number << ".png";
-
-    // Save the png
-    save(screen, oss.str());
-
-    m_frame_number++;
+  m_frame_number++;
 }

--- a/src/common/ScreenExporter.hpp
+++ b/src/common/ScreenExporter.hpp
@@ -22,34 +22,31 @@
 #include "../environment/ale_screen.hpp"
 
 class ScreenExporter {
+ public:
+  /** Creates a new ScreenExporter which can be used to save screens using save(filename). */
+  ScreenExporter(ColourPalette& palette);
 
-    public:
-
-        /** Creates a new ScreenExporter which can be used to save screens using save(filename). */
-        ScreenExporter(ColourPalette &palette);
-
-        /** Creates a new ScreenExporter which will save frames successively in the directory provided.
+  /** Creates a new ScreenExporter which will save frames successively in the directory provided.
             Frames are sequentially named with 6 digits, starting at 000000. */
-        ScreenExporter(ColourPalette &palette, const std::string &path);
+  ScreenExporter(ColourPalette& palette, const std::string& path);
 
-        /** Save the given screen to the given filename. No paths are created. */
-        void save(const ALEScreen &screen, const std::string &filename) const;
+  /** Save the given screen to the given filename. No paths are created. */
+  void save(const ALEScreen& screen, const std::string& filename) const;
 
-        /** Save the given screen according to our own internal numbering. */
-        void saveNext(const ALEScreen &screen);
+  /** Save the given screen according to our own internal numbering. */
+  void saveNext(const ALEScreen& screen);
 
-    private:
+ private:
+  ColourPalette& m_palette;
 
-        ColourPalette &m_palette;
+  /** The next frame number. */
+  int m_frame_number;
 
-        /** The next frame number. */
-        int m_frame_number;
+  /** The width of the frame number when constructing filenames (set to 6). */
+  int m_frame_field_width;
 
-        /** The width of the frame number when constructing filenames (set to 6). */
-        int m_frame_field_width;
-
-        /** The directory where we save successive frames. */
-        std::string m_path;
+  /** The directory where we save successive frames. */
+  std::string m_path;
 };
 
-#endif // __SCREEN_EXPORTER_HPP__
+#endif  // __SCREEN_EXPORTER_HPP__

--- a/src/common/SoundExporter.cpp
+++ b/src/common/SoundExporter.cpp
@@ -1,4 +1,5 @@
 #include "SoundExporter.hpp"
+
 #include <cassert>
 
 namespace ale {
@@ -7,70 +8,58 @@ namespace sound {
 // Sample rate is 60Hz x SamplesPerFrame bytes
 // TODO(mgb): in reality this should be 31,400 Hz, but currently we are just short of this
 static const unsigned int SampleRate = 60 * SoundExporter::SamplesPerFrame;
+
 // Save wav file every 30 seconds
 static const unsigned int WriteInterval = SampleRate * 30;
 
+SoundExporter::SoundExporter(const std::string& filename, int channels)
+    : m_filename(filename), m_channels(channels), m_samples_since_write(0) {}
 
-SoundExporter::SoundExporter(const std::string &filename, int channels):
-    m_filename(filename),
-    m_channels(channels),
-    m_samples_since_write(0) {
-}
+SoundExporter::~SoundExporter() { writeWAVData(); }
 
+void SoundExporter::addSamples(SampleType* s, int len) {
+  // @todo -- currently we only support mono recording
+  assert(m_channels == 1);
 
-SoundExporter::~SoundExporter() {
+  for (int i = 0; i < len; i++)
+    m_data.push_back(s[i]);
 
+  // Periodically flush to disk (to avoid cases where the destructor is not called)
+  m_samples_since_write += len;
+  if (m_samples_since_write >= WriteInterval) {
     writeWAVData();
+    m_samples_since_write = 0;
+  }
 }
-
-
-void SoundExporter::addSamples(SampleType *s, int len) {
-
-    // @todo -- currently we only support mono recording
-    assert(m_channels == 1);
-
-    for (int i = 0; i < len; i++)
-        m_data.push_back(s[i]);
-
-    // Periodically flush to disk (to avoid cases where the destructor is not called)
-    m_samples_since_write += len;
-    if (m_samples_since_write >= WriteInterval) {
-
-        writeWAVData();
-        m_samples_since_write = 0;
-    }
-}
-
 
 void SoundExporter::writeWAVData() {
+  // Taken from http://stackoverflow.com/questions/22226872/two-problems-when-writing-to-wav-c
+  // Open file stream
+  std::ofstream stream(m_filename.c_str(), std::ios::binary);
 
-    // Taken from http://stackoverflow.com/questions/22226872/two-problems-when-writing-to-wav-c
-    // Open file stream
-    std::ofstream stream(m_filename.c_str(), std::ios::binary);
+  // Cast size into a 32-bit integer
+  int bufSize = m_data.size();
 
-    // Cast size into a 32-bit integer
-    int bufSize = m_data.size();
+  // Header
+  stream.write("RIFF", 4);          // sGroupID (RIFF = Resource Interchange File Format)
+  write<int>(stream, 36 + bufSize); // dwFileLength
+  stream.write("WAVE", 4);          // sRiffType
 
-    // Header
-    stream.write("RIFF", 4);                                        // sGroupID (RIFF = Resource Interchange File Format)
-    write<int>(stream, 36 + bufSize);                               // dwFileLength
-    stream.write("WAVE", 4);                                        // sRiffType
+  // Format chunk
+  stream.write("fmt ", 4);          // sGroupID (fmt = format)
+  write<int>(stream, 16);           // Chunk size (of Format Chunk)
+  write<short>(stream, 1);          // Format (1 = PCM)
+  write<short>(stream, m_channels); // Channels
+  write<int>(stream, SampleRate);   // Sample Rate
+  write<int>(stream, SampleRate * m_channels * sizeof(SampleType));  // Byterate
+  write<short>(stream, m_channels * sizeof(SampleType));             // Frame size aka Block align
+  write<short>(stream, 8 * sizeof(SampleType));                      // Bits per sample
 
-    // Format chunk
-    stream.write("fmt ", 4);                                        // sGroupID (fmt = format)
-    write<int>(stream, 16);                                         // Chunk size (of Format Chunk)
-    write<short>(stream, 1);                                        // Format (1 = PCM)
-    write<short>(stream, m_channels);                                 // Channels
-    write<int>(stream, SampleRate);                                 // Sample Rate
-    write<int>(stream, SampleRate * m_channels * sizeof(SampleType)); // Byterate
-    write<short>(stream, m_channels * sizeof(SampleType));            // Frame size aka Block align
-    write<short>(stream, 8 * sizeof(SampleType));                   // Bits per sample
-
-    // Data chunk
-    stream.write("data", 4);                                        // sGroupID (data)
-    stream.write((const char*)&bufSize, 4);                         // Chunk size (of Data, and thus of bufferSize)
-    stream.write((const char*)&m_data[0], bufSize);                 // The samples DATA!!!
+  // Data chunk
+  stream.write("data", 4);                         // sGroupID (data)
+  stream.write((const char*)&bufSize, 4);          // Chunk size (of Data, and thus of bufferSize)
+  stream.write((const char*)&m_data[0], bufSize);  // The samples DATA!!!
 }
 
-} // namespace ale::sound
+} // namespace sound
 } // namespace ale

--- a/src/common/SoundExporter.hpp
+++ b/src/common/SoundExporter.hpp
@@ -29,45 +29,41 @@
 namespace ale {
 namespace sound {
 
-template <typename T>
-void write(std::ofstream& stream, const T& t) {
-    stream.write((const char*)&t, sizeof(T));
+template <typename T> void write(std::ofstream& stream, const T& t) {
+  stream.write((const char*)&t, sizeof(T));
 }
 
 class SoundExporter {
+ public:
+  static const int SamplesPerFrame = 512;
 
-    public:
+  typedef uInt8 SampleType;
 
-        static const int SamplesPerFrame = 512;
+  /** Create a new sound exporter which, on program termination, will write out a wav file. */
+  SoundExporter(const std::string& filename, int channels);
+  ~SoundExporter();
 
-        typedef uInt8 SampleType;
+  /** Adds a buffer of samples. */
+  void addSamples(SampleType* s, int len);
 
-        /** Create a new sound exporter which, on program termination, will write out a wav file. */
-        SoundExporter(const std::string &filename, int channels);
-        ~SoundExporter();
+ private:
+  /** Writes the data to disk. */
+  void writeWAVData();
 
-        /** Adds a buffer of samples. */
-        void addSamples(SampleType *s, int len);
+  /** The file to save our audio to. */
+  std::string m_filename;
 
-    private:
+  /** Number of channels. */
+  int m_channels;
 
-        /** Writes the data to disk. */
-        void writeWAVData();
+  /** The sound data. */
+  std::vector<SampleType> m_data;
 
-        /** The file to save our audio to. */
-        std::string m_filename;
-
-        /** Number of channels. */
-        int m_channels;
-
-        /** The sound data. */
-        std::vector<SampleType> m_data;
-
-        /** Keep track of how many samples have been written since the last write to disk */
-        size_t m_samples_since_write;
+  /** Keep track of how many samples have been written since the last write to disk */
+  size_t m_samples_since_write;
 };
 
-} // namespace ale::sound
+} // namespace sound
 } // namespace ale
 
-#endif // __SOUND_EXPORTER_HPP__
+#endif  // __SOUND_EXPORTER_HPP__

--- a/src/common/display_screen.cpp
+++ b/src/common/display_screen.cpp
@@ -14,191 +14,189 @@
  *  Supports displaying the screen via SDL.
  **************************************************************************** */
 #include "display_screen.h"
+
 #include "SoundSDL.hxx"
+
 using namespace std;
+
 #ifdef __USE_SDL
-DisplayScreen::DisplayScreen(MediaSource* mediaSource,
-                             Sound* sound,
-                             ColourPalette &palette):
-        manual_control_active(false),
-        media_source(mediaSource),
-        my_sound(sound),
-        colour_palette(palette),
-        delay_msec(17)
-{
-    screen_height = media_source->height();
-    screen_width = media_source->width();
-    assert(window_height >= screen_height);
-    assert(window_width >= screen_width);
-    yratio = window_height / (float) screen_height;
-    xratio = window_width / (float) screen_width;
-    if (SDL_Init(SDL_INIT_VIDEO) < 0) {
-        fprintf(stderr, "Could not initialize SDL: %s\n", SDL_GetError());
-        exit(1);
-    }
-    screen = SDL_SetVideoMode(window_width, window_height, 8, SDL_HWPALETTE);
-    if (screen == NULL) {
-        fprintf(stderr, "Couldn't Initialize Screen: %s\n", SDL_GetError());
-        exit(1);
-    }
-    SDL_WM_SetCaption("ALE Viz", NULL);
-    fprintf(stderr, "Screen Display Active. [Manual Control Mode] 'm' "
-            "[Slowdown] 'a' [Speedup] 's' [VolumeDown] '[' [VolumeUp] ']'.\n");
 
-    last_frame_time = SDL_GetTicks();
+DisplayScreen::DisplayScreen(MediaSource* mediaSource, Sound* sound,
+                             ColourPalette& palette)
+    : manual_control_active(false), media_source(mediaSource), my_sound(sound),
+      colour_palette(palette), delay_msec(17) {
+  screen_height = media_source->height();
+  screen_width = media_source->width();
+  assert(window_height >= screen_height);
+  assert(window_width >= screen_width);
+  yratio = window_height / (float)screen_height;
+  xratio = window_width / (float)screen_width;
+  if (SDL_Init(SDL_INIT_VIDEO) < 0) {
+    fprintf(stderr, "Could not initialize SDL: %s\n", SDL_GetError());
+    exit(1);
+  }
+  screen = SDL_SetVideoMode(window_width, window_height, 8, SDL_HWPALETTE);
+  if (screen == NULL) {
+    fprintf(stderr, "Couldn't Initialize Screen: %s\n", SDL_GetError());
+    exit(1);
+  }
+  SDL_WM_SetCaption("ALE Viz", NULL);
+  fprintf(stderr,
+          "Screen Display Active. [Manual Control Mode] 'm' "
+          "[Slowdown] 'a' [Speedup] 's' [VolumeDown] '[' [VolumeUp] ']'.\n");
+
+  last_frame_time = SDL_GetTicks();
 }
 
-DisplayScreen::~DisplayScreen() {
-    SDL_Quit();
-}
+DisplayScreen::~DisplayScreen() { SDL_Quit(); }
 
 void DisplayScreen::display_screen() {
-    if (SDL_MUSTLOCK(screen)) {
-      if (SDL_LockSurface(screen) < 0 ) {
-        fprintf(stderr, "Can't lock screen: %s\n", SDL_GetError());
-        return;
-      }
+  if (SDL_MUSTLOCK(screen)) {
+    if (SDL_LockSurface(screen) < 0) {
+      fprintf(stderr, "Can't lock screen: %s\n", SDL_GetError());
+      return;
     }
-    // Convert the media sources frame into the screen matrix representation
-    int xciel = int(xratio) + 1;
-    int yciel = int(yratio) + 1;
-    uInt8* pi_curr_frame_buffer = media_source->currentFrameBuffer();
-    int y, x, r, g, b;
-    SDL_Rect rect;
-    for (int i = 0; i < screen_width * screen_height; i++) {
-        y = i / screen_width;
-        x = i - (y * screen_width);
-        colour_palette.getRGB(pi_curr_frame_buffer[i], r, g, b);
-        rect.x = (int)(x * xratio);
-        rect.y = (int)(y * yratio);
-        rect.w = xciel;
-        rect.h = yciel;
-        SDL_FillRect(screen, &rect, SDL_MapRGB(screen->format, r, g, b));
-    }
-    if (SDL_MUSTLOCK(screen)) {
-      SDL_UnlockSurface(screen);
-    }
-    SDL_UpdateRect(screen, 0, 0, 0, 0);
-    poll();
+  }
+  // Convert the media sources frame into the screen matrix representation
+  int xciel = int(xratio) + 1;
+  int yciel = int(yratio) + 1;
+  uInt8* pi_curr_frame_buffer = media_source->currentFrameBuffer();
+  int y, x, r, g, b;
+  SDL_Rect rect;
+  for (int i = 0; i < screen_width * screen_height; i++) {
+    y = i / screen_width;
+    x = i - (y * screen_width);
+    colour_palette.getRGB(pi_curr_frame_buffer[i], r, g, b);
+    rect.x = (int)(x * xratio);
+    rect.y = (int)(y * yratio);
+    rect.w = xciel;
+    rect.h = yciel;
+    SDL_FillRect(screen, &rect, SDL_MapRGB(screen->format, r, g, b));
+  }
+  if (SDL_MUSTLOCK(screen)) {
+    SDL_UnlockSurface(screen);
+  }
+  SDL_UpdateRect(screen, 0, 0, 0, 0);
+  poll();
 
-    // Wait a while, calibrating so that the delay remains the same
-    Uint32 newTime = SDL_GetTicks();
-    Uint32 delta = newTime - min(last_frame_time, newTime);
+  // Wait a while, calibrating so that the delay remains the same
+  Uint32 newTime = SDL_GetTicks();
+  Uint32 delta = newTime - min(last_frame_time, newTime);
 
-    if (delta < delay_msec) {
-        SDL_Delay(delay_msec - delta);
-    } else {
-        // Try to keep up with the delay
-        last_frame_time = SDL_GetTicks() + delta - delay_msec;
-    }
+  if (delta < delay_msec) {
+    SDL_Delay(delay_msec - delta);
+  } else {
+    // Try to keep up with the delay
+    last_frame_time = SDL_GetTicks() + delta - delay_msec;
+  }
 }
 
 void DisplayScreen::poll() {
-    SDL_Event event;
-    while(SDL_PollEvent(&event)) {
-        handleSDLEvent(event);
-    }
+  SDL_Event event;
+  while (SDL_PollEvent(&event)) {
+    handleSDLEvent(event);
+  }
 };
 
 void DisplayScreen::handleSDLEvent(const SDL_Event& event) {
-    switch (event.type) {
-        case SDL_QUIT:
-            exit(0);
-            break;
-        case SDL_KEYDOWN:
-            switch(event.key.keysym.sym) {
-                case SDLK_m:
-                    manual_control_active = !manual_control_active;
-                    if (manual_control_active) {
-                        fprintf(stderr, "Manual Control Enabled: [Move] "
-                                "Arrow keys [Fire] Space [NO-OP] Return.\n");
-                    } else {
-                        fprintf(stderr, "Manual Control Disabled\n");
-                    }
-                    break;
-                case SDLK_s:
-                    delay_msec = delay_msec > 5 ? delay_msec - 5 : 0;
-                    fprintf(stderr, "[Speedup] %d msec delay\n", delay_msec);
-                    break;
-                case SDLK_a:
-                    delay_msec = delay_msec + 5;
-                    fprintf(stderr, "[Slowdown] %d msec delay\n", delay_msec);
-                    break;
+  switch (event.type) {
+    case SDL_QUIT:
+      exit(0);
+      break;
+    case SDL_KEYDOWN:
+      switch (event.key.keysym.sym) {
+        case SDLK_m:
+          manual_control_active = !manual_control_active;
+          if (manual_control_active) {
+            fprintf(stderr, "Manual Control Enabled: [Move] "
+                            "Arrow keys [Fire] Space [NO-OP] Return.\n");
+          } else {
+            fprintf(stderr, "Manual Control Disabled\n");
+          }
+          break;
+        case SDLK_s:
+          delay_msec = delay_msec > 5 ? delay_msec - 5 : 0;
+          fprintf(stderr, "[Speedup] %d msec delay\n", delay_msec);
+          break;
+        case SDLK_a:
+          delay_msec = delay_msec + 5;
+          fprintf(stderr, "[Slowdown] %d msec delay\n", delay_msec);
+          break;
 #ifdef SOUND_SUPPORT
-                case SDLK_LEFTBRACKET:
-                    fprintf(stderr, "[VolumeDown]\n");
-                    for (int i=0; i<5; ++i) {
-                        ((SoundSDL*)my_sound)->adjustVolume(-1);
-                    }
-                    break;
-                case SDLK_RIGHTBRACKET:
-                    fprintf(stderr, "[VolumeUp]\n");
-                    for (int i=0; i<5; ++i) {
-                        ((SoundSDL*)my_sound)->adjustVolume(1);
-                    }
-                    break;
+        case SDLK_LEFTBRACKET:
+          fprintf(stderr, "[VolumeDown]\n");
+          for (int i = 0; i < 5; ++i) {
+            ((SoundSDL*)my_sound)->adjustVolume(-1);
+          }
+          break;
+        case SDLK_RIGHTBRACKET:
+          fprintf(stderr, "[VolumeUp]\n");
+          for (int i = 0; i < 5; ++i) {
+            ((SoundSDL*)my_sound)->adjustVolume(1);
+          }
+          break;
 #endif
-                default:
-                    break;
-            }
-            break;
         default:
-            break;
-    }
+          break;
+      }
+      break;
+    default:
+      break;
+  }
 };
 
 Action DisplayScreen::getUserAction() {
-    if (!manual_control_active) {
-        return UNDEFINED;
-    }
-    Action a = PLAYER_A_NOOP;
-    poll();
-    SDL_PumpEvents();
-    Uint8* keymap = SDL_GetKeyState(NULL);
-    // Break out of this loop if the 'p' key is pressed
-    if (keymap[SDLK_p]) {
-      return PLAYER_A_NOOP;
-      // Triple Actions
-    } else if (keymap[SDLK_UP] && keymap[SDLK_RIGHT] && keymap[SDLK_SPACE]) {
-      a = PLAYER_A_UPRIGHTFIRE;
-    } else if (keymap[SDLK_UP] && keymap[SDLK_LEFT] && keymap[SDLK_SPACE]) {
-      a = PLAYER_A_UPLEFTFIRE;
-    } else if (keymap[SDLK_DOWN] && keymap[SDLK_RIGHT] && keymap[SDLK_SPACE]) {
-      a = PLAYER_A_DOWNRIGHTFIRE;
-    } else if (keymap[SDLK_DOWN] && keymap[SDLK_LEFT] && keymap[SDLK_SPACE]) {
-      a = PLAYER_A_DOWNLEFTFIRE;
-      // Double Actions
-    } else if (keymap[SDLK_UP] && keymap[SDLK_LEFT]) {
-      a = PLAYER_A_UPLEFT;
-    } else if (keymap[SDLK_UP] && keymap[SDLK_RIGHT]) {
-      a = PLAYER_A_UPRIGHT;
-    } else if (keymap[SDLK_DOWN] && keymap[SDLK_LEFT]) {
-      a = PLAYER_A_DOWNLEFT;
-    } else if (keymap[SDLK_DOWN] && keymap[SDLK_RIGHT]) {
-      a = PLAYER_A_DOWNRIGHT;
-    } else if (keymap[SDLK_UP] && keymap[SDLK_SPACE]) {
-      a = PLAYER_A_UPFIRE;
-    } else if (keymap[SDLK_DOWN] && keymap[SDLK_SPACE]) {
-      a = PLAYER_A_DOWNFIRE;
-    } else if (keymap[SDLK_LEFT] && keymap[SDLK_SPACE]) {
-      a = PLAYER_A_LEFTFIRE;
-    } else if (keymap[SDLK_RIGHT] && keymap[SDLK_SPACE]) {
-      a = PLAYER_A_RIGHTFIRE;
-      // Single Actions
-    } else if (keymap[SDLK_SPACE]) {
-      a = PLAYER_A_FIRE;
-    } else if (keymap[SDLK_RETURN]) {
-      a = PLAYER_A_NOOP;
-    } else if (keymap[SDLK_LEFT]) {
-      a = PLAYER_A_LEFT;
-    } else if (keymap[SDLK_RIGHT]) {
-      a = PLAYER_A_RIGHT;
-    } else if (keymap[SDLK_UP]) {
-      a = PLAYER_A_UP;
-    } else if (keymap[SDLK_DOWN]) {
-      a = PLAYER_A_DOWN;
-    }
-    return a;
+  if (!manual_control_active) {
+    return UNDEFINED;
+  }
+  Action a = PLAYER_A_NOOP;
+  poll();
+  SDL_PumpEvents();
+  Uint8* keymap = SDL_GetKeyState(NULL);
+  // Break out of this loop if the 'p' key is pressed
+  if (keymap[SDLK_p]) {
+    return PLAYER_A_NOOP;
+    // Triple Actions
+  } else if (keymap[SDLK_UP] && keymap[SDLK_RIGHT] && keymap[SDLK_SPACE]) {
+    a = PLAYER_A_UPRIGHTFIRE;
+  } else if (keymap[SDLK_UP] && keymap[SDLK_LEFT] && keymap[SDLK_SPACE]) {
+    a = PLAYER_A_UPLEFTFIRE;
+  } else if (keymap[SDLK_DOWN] && keymap[SDLK_RIGHT] && keymap[SDLK_SPACE]) {
+    a = PLAYER_A_DOWNRIGHTFIRE;
+  } else if (keymap[SDLK_DOWN] && keymap[SDLK_LEFT] && keymap[SDLK_SPACE]) {
+    a = PLAYER_A_DOWNLEFTFIRE;
+    // Double Actions
+  } else if (keymap[SDLK_UP] && keymap[SDLK_LEFT]) {
+    a = PLAYER_A_UPLEFT;
+  } else if (keymap[SDLK_UP] && keymap[SDLK_RIGHT]) {
+    a = PLAYER_A_UPRIGHT;
+  } else if (keymap[SDLK_DOWN] && keymap[SDLK_LEFT]) {
+    a = PLAYER_A_DOWNLEFT;
+  } else if (keymap[SDLK_DOWN] && keymap[SDLK_RIGHT]) {
+    a = PLAYER_A_DOWNRIGHT;
+  } else if (keymap[SDLK_UP] && keymap[SDLK_SPACE]) {
+    a = PLAYER_A_UPFIRE;
+  } else if (keymap[SDLK_DOWN] && keymap[SDLK_SPACE]) {
+    a = PLAYER_A_DOWNFIRE;
+  } else if (keymap[SDLK_LEFT] && keymap[SDLK_SPACE]) {
+    a = PLAYER_A_LEFTFIRE;
+  } else if (keymap[SDLK_RIGHT] && keymap[SDLK_SPACE]) {
+    a = PLAYER_A_RIGHTFIRE;
+    // Single Actions
+  } else if (keymap[SDLK_SPACE]) {
+    a = PLAYER_A_FIRE;
+  } else if (keymap[SDLK_RETURN]) {
+    a = PLAYER_A_NOOP;
+  } else if (keymap[SDLK_LEFT]) {
+    a = PLAYER_A_LEFT;
+  } else if (keymap[SDLK_RIGHT]) {
+    a = PLAYER_A_RIGHT;
+  } else if (keymap[SDLK_UP]) {
+    a = PLAYER_A_UP;
+  } else if (keymap[SDLK_DOWN]) {
+    a = PLAYER_A_DOWN;
+  }
+  return a;
 }
 
-#endif // __USE_SDL
+#endif  // __USE_SDL

--- a/src/controllers/ale_controller.cpp
+++ b/src/controllers/ale_controller.cpp
@@ -22,16 +22,14 @@
 #include "../common/display_screen.h"
 #include "../common/Log.hpp"
 
-ALEController::ALEController(OSystem* osystem):
-  m_osystem(osystem),
-  m_settings(buildRomRLWrapper(m_osystem->settings().getString("rom_file"))),
-  m_environment(m_osystem, m_settings.get()) {
-
+ALEController::ALEController(OSystem* osystem)
+    : m_osystem(osystem), m_settings(buildRomRLWrapper(
+                              m_osystem->settings().getString("rom_file"))),
+      m_environment(m_osystem, m_settings.get()) {
   if (m_settings.get() == NULL) {
     ale::Logger::Warning << "Unsupported ROM file: " << std::endl;
     exit(1);
-  }
-  else {
+  } else {
     m_environment.reset();
   }
 }

--- a/src/controllers/ale_controller.hpp
+++ b/src/controllers/ale_controller.hpp
@@ -25,26 +25,25 @@
 #include <memory>
 
 class ALEController {
-  public:
-    ALEController(OSystem * osystem);
-    virtual ~ALEController() {}
+ public:
+  ALEController(OSystem* osystem);
+  virtual ~ALEController() {}
 
-    /** Main loop. Returns once ALE terminates. */
-    virtual void run() = 0;
+  /** Main loop. Returns once ALE terminates. */
+  virtual void run() = 0;
 
-  protected:
-    friend class ALEInterface;
+ protected:
+  friend class ALEInterface;
 
-    /** Applies the given action to the environment (e.g. by emulating or resetting) */
-    reward_t applyActions(Action a, Action b);
-    /** Support for SDL display... available to all controllers. Simply call it from run(). */
-    void display();
+  /** Applies the given action to the environment (e.g. by emulating or resetting) */
+  reward_t applyActions(Action a, Action b);
+  /** Support for SDL display... available to all controllers. Simply call it from run(). */
+  void display();
 
-  protected:
-    OSystem* m_osystem;
-    std::unique_ptr<RomSettings> m_settings;
-    StellaEnvironment m_environment;
+ protected:
+  OSystem* m_osystem;
+  std::unique_ptr<RomSettings> m_settings;
+  StellaEnvironment m_environment;
 };
 
-
-#endif // __ALE_CONTROLLER_HPP__
+#endif  // __ALE_CONTROLLER_HPP__

--- a/src/controllers/fifo_controller.cpp
+++ b/src/controllers/fifo_controller.cpp
@@ -22,27 +22,26 @@
 
 #define MAX_RUN_LENGTH (0xFF)
 
-static const char hexval[] = {
-    '0', '1', '2', '3', '4', '5', '6', '7',
-    '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'
-};
+static const char hexval[] = {'0', '1', '2', '3', '4', '5', '6', '7',
+                              '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
 
 /* appends a pixels value to the string buffer, returning the number of characters written */
-inline void appendByte(char *buf, uInt8 v) {
-    *buf = hexval[(v >> 4)];
-    *(buf+1) = hexval[v & 0xF];
+inline void appendByte(char* buf, uInt8 v) {
+  *buf = hexval[(v >> 4)];
+  *(buf + 1) = hexval[v & 0xF];
 }
 
-FIFOController::FIFOController(OSystem* _osystem, bool named_pipes) :
-  ALEController(_osystem),
-  m_named_pipes(named_pipes) {
+FIFOController::FIFOController(OSystem* _osystem, bool named_pipes)
+    : ALEController(_osystem), m_named_pipes(named_pipes) {
   m_max_num_frames = m_osystem->settings().getInt("max_num_frames");
   m_run_length_encoding = m_osystem->settings().getBool("run_length_encoding");
 }
 
 FIFOController::~FIFOController() {
-  if (m_fout != NULL) fclose(m_fout);
-  if (m_fin != NULL) fclose(m_fin);
+  if (m_fout != NULL)
+    fclose(m_fout);
+  if (m_fin != NULL)
+    fclose(m_fin);
 }
 
 void FIFOController::run() {
@@ -67,13 +66,14 @@ void FIFOController::run() {
 
   // Send a termination signal to the agent, if they're still around
   if (!feof(m_fout))
-    fprintf (m_fout, "DIE\n");
+    fprintf(m_fout, "DIE\n");
 }
 
 bool FIFOController::isDone() {
   // Die once we reach enough samples
-  return ((m_max_num_frames > 0 && m_environment.getFrameNumber() >= m_max_num_frames) ||
-    feof(m_fin) || feof(m_fout) || ferror(m_fout));
+  return ((m_max_num_frames > 0 &&
+           m_environment.getFrameNumber() >= m_max_num_frames) ||
+          feof(m_fin) || feof(m_fout) || ferror(m_fout));
 }
 
 void FIFOController::handshake() {
@@ -81,34 +81,34 @@ void FIFOController::handshake() {
   if (m_named_pipes) {
     openNamedPipes();
   } else { // Otherwise read from stdin and output to stdout
-      m_fout = stdout;
-      m_fin = stdin;
-      assert(m_fin != NULL && m_fout != NULL);
+    m_fout = stdout;
+    m_fin = stdin;
+    assert(m_fin != NULL && m_fout != NULL);
   }
 
   // send the width and height of the screen through the pipe
-  char out_buffer [1024];
+  char out_buffer[1024];
 
-  snprintf (out_buffer, sizeof(out_buffer), "%d-%d\n",
-    (int)m_environment.getScreen().width(),
-    (int)m_environment.getScreen().height());
+  snprintf(out_buffer, sizeof(out_buffer), "%d-%d\n",
+           (int)m_environment.getScreen().width(),
+           (int)m_environment.getScreen().height());
 
   fputs(out_buffer, m_fout);
-  fflush (m_fout);
+  fflush(m_fout);
 
   // Read in agent's response
-  char in_buffer [1024];
-  if (fgets (in_buffer, sizeof(in_buffer), m_fin) == NULL) {
+  char in_buffer[1024];
+  if (fgets(in_buffer, sizeof(in_buffer), m_fin) == NULL) {
     // If The agent hung up, stop the handshake.
     return;
   }
 
   // Parse response: send_screen, send_ram, <obsolete>, send_RL
-  char * token = strtok (in_buffer,",\n");
+  char* token = strtok(in_buffer, ",\n");
   m_send_screen = atoi(token);
-  token = strtok (NULL,",\n");
+  token = strtok(NULL, ",\n");
   m_send_ram = atoi(token);
-  token = strtok (NULL,",\n");
+  token = strtok(NULL, ",\n");
   // Used to be frame skip; now obsolete
   token = strtok(NULL, ",\n");
   m_send_rl = atoi(token);
@@ -130,9 +130,12 @@ void FIFOController::openNamedPipes() {
 }
 
 void FIFOController::sendData() {
-  if (m_send_ram) sendRAM();
-  if (m_send_screen) sendScreen();
-  if (m_send_rl) sendRL();
+  if (m_send_ram)
+    sendRAM();
+  if (m_send_screen)
+    sendScreen();
+  if (m_send_rl)
+    sendRL();
   // Send the terminating newline
   fputc('\n', m_fout);
   fflush(m_fout);
@@ -153,7 +156,7 @@ void FIFOController::sendScreen() {
 
   // Append terminating stuff, send
   buffer[sn] = ':';
-  buffer[sn+1] = 0;
+  buffer[sn + 1] = 0;
 
   fputs(buffer, m_fout);
 }
@@ -221,12 +224,12 @@ void FIFOController::sendRAM() {
 
   // Output RAM
   buffer[sn] = ':';
-  buffer[sn+1] = 0;
+  buffer[sn + 1] = 0;
   fputs(buffer, m_fout);
 }
 
 void FIFOController::sendRL() {
-  int r = (int) latest_reward;
+  int r = (int)latest_reward;
   bool is_terminal = m_environment.isTerminal();
 
   fprintf(m_fout, "%d,%d:", is_terminal, r);
@@ -235,7 +238,7 @@ void FIFOController::sendRL() {
 void FIFOController::readAction(Action& action_a, Action& action_b) {
   // Read the new action from the pipe, as a comma-separated pair
   char in_buffer[2048];
-  if (fgets (in_buffer, sizeof(in_buffer), m_fin) == NULL) {
+  if (fgets(in_buffer, sizeof(in_buffer), m_fin) == NULL) {
     // If fgets returns NULL, we set the two actions to NOOP here. This is probably because the
     // other side has hung up. We'll let the process terminate as usual.
     action_a = PLAYER_A_NOOP;
@@ -243,9 +246,9 @@ void FIFOController::readAction(Action& action_a, Action& action_b) {
     return;
   }
 
-  char * token = strtok (in_buffer,",\n");
+  char* token = strtok(in_buffer, ",\n");
   action_a = (Action)atoi(token);
 
-  token = strtok (NULL,",\n");
+  token = strtok(NULL, ",\n");
   action_b = (Action)atoi(token);
 }

--- a/src/controllers/fifo_controller.hpp
+++ b/src/controllers/fifo_controller.hpp
@@ -20,40 +20,41 @@
 #include "ale_controller.hpp"
 
 class FIFOController : public ALEController {
-  public:
-    FIFOController(OSystem* osystem, bool named_pipes = false);
-    virtual ~FIFOController();
+ public:
+  FIFOController(OSystem* osystem, bool named_pipes = false);
+  virtual ~FIFOController();
 
-    virtual void run();
+  virtual void run();
 
-  private:
-    void handshake(); // Perform handshaking
-    void openNamedPipes();
+ private:
+  void handshake(); // Perform handshaking
+  void openNamedPipes();
 
-    bool isDone();
-    void sendData();
-    void readAction(Action& action_a, Action& action_b);
+  bool isDone();
+  void sendData();
+  void readAction(Action& action_a, Action& action_b);
 
-    void sendScreen();
-    int stringScreenRLE(const ALEScreen& screen, char * buffer);
-    int stringScreenFull(const ALEScreen& screen, char * buffer);
-    void sendRAM();
-    void sendRL();
+  void sendScreen();
+  int stringScreenRLE(const ALEScreen& screen, char* buffer);
+  int stringScreenFull(const ALEScreen& screen, char* buffer);
+  void sendRAM();
+  void sendRL();
 
-  private:
-    bool m_named_pipes; // Whether to use named pipes
+ private:
+  bool m_named_pipes; // Whether to use named pipes
 
-    int m_max_num_frames; // Maximum number of total frames before we stop
-    bool m_run_length_encoding; // Whether to encode the data in a run-length fashion
+  int m_max_num_frames; // Maximum number of total frames before we stop
+  bool
+      m_run_length_encoding; // Whether to encode the data in a run-length fashion
 
-    bool m_send_screen; // Agent requested screen data
-    bool m_send_ram; // Agent requested RAM data
-    bool m_send_rl; // Agent requested RL data
+  bool m_send_screen; // Agent requested screen data
+  bool m_send_ram;    // Agent requested RAM data
+  bool m_send_rl;     // Agent requested RL data
 
-    FILE* m_fout;
-    FILE* m_fin;
+  FILE* m_fout;
+  FILE* m_fin;
 
-    reward_t latest_reward; // Most recent reward
+  reward_t latest_reward; // Most recent reward
 };
 
-#endif // __FIFO_CONTROLLER_HPP__
+#endif  // __FIFO_CONTROLLER_HPP__

--- a/src/controllers/rlglue_controller.cpp
+++ b/src/controllers/rlglue_controller.cpp
@@ -18,6 +18,7 @@
 #include "rlglue_controller.hpp"
 
 #ifdef __USE_RLGLUE
+
 #include <stdio.h>
 #include <stdlib.h> // getenv
 #include <cassert>
@@ -27,8 +28,8 @@
 
 #include "../common/Log.hpp"
 
-RLGlueController::RLGlueController(OSystem* _osystem) :
-  ALEController(_osystem) {
+RLGlueController::RLGlueController(OSystem* _osystem)
+    : ALEController(_osystem) {
   m_max_num_frames = m_osystem->settings().getInt("max_num_frames");
   if (m_osystem->settings().getBool("restricted_action_set")) {
     available_actions = m_settings->getMinimalActionSet();
@@ -38,8 +39,7 @@ RLGlueController::RLGlueController(OSystem* _osystem) :
   m_send_rgb = m_osystem->settings().getBool("send_rgb");
 }
 
-RLGlueController::~RLGlueController() {
-}
+RLGlueController::~RLGlueController() {}
 
 void RLGlueController::run() {
   // First perform handshaking
@@ -54,7 +54,8 @@ void RLGlueController::run() {
 
 bool RLGlueController::isDone() {
   // Die once we reach enough samples
-  return ((m_max_num_frames > 0 && m_environment.getFrameNumber() >= m_max_num_frames));
+  return ((m_max_num_frames > 0 &&
+           m_environment.getFrameNumber() >= m_max_num_frames));
 }
 
 void RLGlueController::initRLGlue() {
@@ -98,7 +99,7 @@ void RLGlueController::rlGlueLoop() {
     rlRecvBufferData(m_connection, &m_buffer, &envState);
 
     // Switch statement fills m_buffer with some data for RL-Glue
-    switch(envState) {
+    switch (envState) {
       case kEnvInit:
         envInit();
         break;
@@ -123,7 +124,8 @@ void RLGlueController::rlGlueLoop() {
         break;
 
       default:
-        ale::Logger::Error << "Unknown RL-Glue command: " << envState << std::endl;
+        ale::Logger::Error << "Unknown RL-Glue command: " << envState
+                           << std::endl;
         error = true;
         break;
     };
@@ -140,10 +142,11 @@ void RLGlueController::envInit() {
   unsigned int offset = 0;
   unsigned int observation_dimensions;
   std::stringstream taskSpec;
-  taskSpec << "VERSION RL-Glue-3.0 "
-    "PROBLEMTYPE episodic "
-    "DISCOUNTFACTOR 1 " // Goal is to maximize score... avoid unpleasant tradeoffs with 1
-    "OBSERVATIONS INTS (128 0 255)"; //RAM
+  taskSpec
+      << "VERSION RL-Glue-3.0 "
+         "PROBLEMTYPE episodic "
+         "DISCOUNTFACTOR 1 " // Goal is to maximize score... avoid unpleasant tradeoffs with 1
+         "OBSERVATIONS INTS (128 0 255)"; //RAM
   if (m_send_rgb) {
     taskSpec << "(100800 0 255) "; // Screen specified as an RGB triple per pixel
     observation_dimensions = 128 + 210 * 160 * 3;
@@ -151,9 +154,11 @@ void RLGlueController::envInit() {
     taskSpec << "(33600 0 127) "; // Screen specified as one pallette index per pixel
     observation_dimensions = 128 + 210 * 160;
   }
-  taskSpec << "ACTIONS INTS (0 " << available_actions.size() << ") "
-    "REWARDS (UNSPEC UNSPEC) " // While rewards are technically bounded, this is safer
-    "EXTRA Name: Arcade Learning Environment ";
+  taskSpec
+      << "ACTIONS INTS (0 " << available_actions.size()
+      << ") "
+         "REWARDS (UNSPEC UNSPEC) " // While rewards are technically bounded, this is safer
+         "EXTRA Name: Arcade Learning Environment ";
   // Allocate...?
   allocateRLStruct(&m_rlglue_action, 1, 0, 0);
   allocateRLStruct(&m_observation, observation_dimensions, 0, 0);
@@ -162,7 +167,8 @@ void RLGlueController::envInit() {
   unsigned int taskSpecLength = taskSpec.str().size();
   offset += rlBufferWrite(&m_buffer, offset, &taskSpecLength, 1, sizeof(int));
   // Then the string itself
-  rlBufferWrite(&m_buffer, offset, taskSpec.str().c_str(), taskSpecLength, sizeof(char));
+  rlBufferWrite(&m_buffer, offset, taskSpec.str().c_str(), taskSpecLength,
+                sizeof(char));
 }
 
 /** Sends the first observation out -- beginning an episode */
@@ -194,7 +200,7 @@ void RLGlueController::envStep() {
     player_a_action_index = 0;
   }
   Action player_a_action = available_actions[player_a_action_index];
-  Action player_b_action = (Action) PLAYER_B_NOOP;
+  Action player_b_action = (Action)PLAYER_B_NOOP;
 
   // Filter out non-regular actions ... let RL-Glue deal with those
   filterActions(player_a_action, player_b_action);
@@ -227,7 +233,7 @@ void RLGlueController::envMessage() {
   offset = rlBufferRead(&m_buffer, offset, &messageLength, 1, sizeof(int));
   // This could, of course, be stored somewhere for efficiency reasons
   if (messageLength > 0) {
-    char * message = new char[messageLength+1];
+    char* message = new char[messageLength + 1];
     rlBufferRead(&m_buffer, offset, message, messageLength, sizeof(char));
     // Null terminate the string :(
     message[messageLength] = 0;
@@ -238,19 +244,21 @@ void RLGlueController::envMessage() {
   }
 }
 
-void RLGlueController::filterActions(Action& player_a_action, Action& player_b_action) {
+void RLGlueController::filterActions(Action& player_a_action,
+                                     Action& player_b_action) {
   if (player_a_action >= PLAYER_A_MAX)
     player_a_action = PLAYER_A_NOOP;
   if (player_b_action < PLAYER_B_NOOP || player_b_action >= PLAYER_B_MAX)
     player_b_action = PLAYER_B_NOOP;
 }
 
-reward_observation_terminal_t RLGlueController::constructRewardObservationTerminal(reward_t reward) {
+reward_observation_terminal_t
+RLGlueController::constructRewardObservationTerminal(reward_t reward) {
   reward_observation_terminal_t ro;
 
   int index = 0;
-  const ALERAM & ram = m_environment.getRAM();
-  const ALEScreen & screen = m_environment.getScreen();
+  const ALERAM& ram = m_environment.getRAM();
+  const ALEScreen& screen = m_environment.getScreen();
 
   // Copy RAM and screen into our big int-vector observation
   for (size_t i = 0; i < ram.size(); i++)
@@ -260,9 +268,9 @@ reward_observation_terminal_t RLGlueController::constructRewardObservationTermin
 
   if (m_send_rgb) {
     // Make sure we've allocated enough space for this
-    assert (arraySize * 3 + ram.size() == m_observation.numInts);
+    assert(arraySize * 3 + ram.size() == m_observation.numInts);
 
-    pixel_t *screenArray = screen.getArray();
+    pixel_t* screenArray = screen.getArray();
     int red, green, blue;
     for (size_t i = 0; i < arraySize; i++) {
       m_osystem->colourPalette().getRGB(screenArray[i], red, green, blue);
@@ -271,7 +279,7 @@ reward_observation_terminal_t RLGlueController::constructRewardObservationTermin
       m_observation.intArray[index++] = blue;
     }
   } else {
-    assert (arraySize + ram.size() == m_observation.numInts);
+    assert(arraySize + ram.size() == m_observation.numInts);
     for (size_t i = 0; i < arraySize; i++)
       m_observation.intArray[index++] = screen.getArray()[i];
   }
@@ -289,14 +297,14 @@ reward_observation_terminal_t RLGlueController::constructRewardObservationTermin
 
 #else
 
-RLGlueController::RLGlueController(OSystem* system):
-  ALEController(system) {
-}
+RLGlueController::RLGlueController(OSystem* system) : ALEController(system) {}
 
 void RLGlueController::run() {
-  ale::Logger::Error << "RL-Glue interface unavailable. Please recompile with RL-Glue support." <<
-    std::endl;
+  ale::Logger::Error
+      << "RL-Glue interface unavailable. Please recompile with RL-Glue support."
+      << std::endl;
 
   // We should return and terminate gracefully, since we can.
 }
-#endif // __USE_RLGLUE
+
+#endif  // __USE_RLGLUE

--- a/src/controllers/rlglue_controller.hpp
+++ b/src/controllers/rlglue_controller.hpp
@@ -21,69 +21,73 @@
 #include "../common/Constants.h"
 
 #ifdef __USE_RLGLUE
+
 // We namespace the whole RL-Glue business to avoid name conflicts
 #include <rlglue/Environment_common.h>
 #include <rlglue/network/RL_network.h>
 
 class RLGlueController : public ALEController {
-  public:
-    RLGlueController(OSystem* osystem);
-    virtual ~RLGlueController();
+ public:
+  RLGlueController(OSystem* osystem);
+  virtual ~RLGlueController();
 
-    virtual void run();
+  virtual void run();
 
-  private:
-    /** Initializes the RL-Glue business */
-    void initRLGlue();
-    /** Closes the RL-Glue connection */
-    void endRLGlue();
-    /** Loops through the RL-Glue statement machine until termination. */
-    void rlGlueLoop();
+ private:
+  /** Initializes the RL-Glue business */
+  void initRLGlue();
+  /** Closes the RL-Glue connection */
+  void endRLGlue();
+  /** Loops through the RL-Glue statement machine until termination. */
+  void rlGlueLoop();
 
-    bool isDone();
+  bool isDone();
 
-    /** RL-Glue interface methods. These methods' output mechanism is to fill the RL buffer
+  /** RL-Glue interface methods. These methods' output mechanism is to fill the RL buffer
       *  with data. */
 
-    /** Initializes the environment; sends a 'task spec' */
-    void envInit();
-    /** Sends the first observation out -- beginning an episode */
-    void envStart();
-    /** Reads in an action, returns the next observation-reward-terminal tuple */
-    void envStep();
-    /** Performs some RL-Glue related cleanup */
-    void envCleanup();
-    /** RL-Glue custom messages */
-    void envMessage();
+  /** Initializes the environment; sends a 'task spec' */
+  void envInit();
+  /** Sends the first observation out -- beginning an episode */
+  void envStart();
+  /** Reads in an action, returns the next observation-reward-terminal tuple */
+  void envStep();
+  /** Performs some RL-Glue related cleanup */
+  void envCleanup();
+  /** RL-Glue custom messages */
+  void envMessage();
 
-    /** RL-Glue helper methods. */
+  /** RL-Glue helper methods. */
 
-    reward_observation_terminal_t constructRewardObservationTerminal(reward_t reward);
-    /** Filters the action received by RL-Glue */
-    void filterActions(Action& player_a_action, Action& player_b_action);
+  reward_observation_terminal_t
+  constructRewardObservationTerminal(reward_t reward);
+  /** Filters the action received by RL-Glue */
+  void filterActions(Action& player_a_action, Action& player_b_action);
 
-  private:
-    /** RL-Glue variables */
-    rlBuffer m_buffer;
-    int m_connection;
-    observation_t m_observation;
-    action_t m_rlglue_action;
+ private:
+  /** RL-Glue variables */
+  rlBuffer m_buffer;
+  int m_connection;
+  observation_t m_observation;
+  action_t m_rlglue_action;
 
-    int m_max_num_frames; // Maximum number of total frames before we stop
+  int m_max_num_frames; // Maximum number of total frames before we stop
 
-    ActionVect available_actions;
-    bool m_send_rgb;
+  ActionVect available_actions;
+  bool m_send_rgb;
 };
+
 #else
+
 class RLGlueController : public ALEController {
-  public:
-    RLGlueController(OSystem* osystem);
-    virtual ~RLGlueController() {}
+ public:
+  RLGlueController(OSystem* osystem);
+  virtual ~RLGlueController() {}
 
-    /** This prints an error message and terminate. */
-    virtual void run();
+  /** This prints an error message and terminate. */
+  virtual void run();
 };
-#endif // __USE_RLGLUE
 
+#endif  // __USE_RLGLUE
 
-#endif // __RLGLUE_CONTROLLER_HPP__
+#endif  // __RLGLUE_CONTROLLER_HPP__

--- a/src/environment/ale_ram.hpp
+++ b/src/environment/ale_ram.hpp
@@ -26,43 +26,42 @@ typedef unsigned char byte_t;
 
 /** A simple wrapper around the Atari RAM. */
 class ALERAM {
-  public:
-    ALERAM();
-    ALERAM(const ALERAM &rhs);
+ public:
+  ALERAM();
+  ALERAM(const ALERAM& rhs);
 
-    ALERAM& operator=(const ALERAM &rhs);
+  ALERAM& operator=(const ALERAM& rhs);
 
-    /** Byte accessors */
-    byte_t get(unsigned int x) const;
-    byte_t *byte(unsigned int x);
+  /** Byte accessors */
+  byte_t get(unsigned int x) const;
+  byte_t* byte(unsigned int x);
 
-    /** Returns the whole array (equivalent to byte(0)). */
-    byte_t *array() const { return (byte_t*)(m_ram); }
+  /** Returns the whole array (equivalent to byte(0)). */
+  byte_t* array() const { return (byte_t*)(m_ram); }
 
-    size_t size() const { return sizeof(m_ram); }
-    /** Returns whether two copies of the RAM are equal */
-    bool equals(const ALERAM &rhs) const;
+  size_t size() const { return sizeof(m_ram); }
+  /** Returns whether two copies of the RAM are equal */
+  bool equals(const ALERAM& rhs) const;
 
-  protected:
-    byte_t m_ram[RAM_SIZE];
+ protected:
+  byte_t m_ram[RAM_SIZE];
 };
 
-inline ALERAM::ALERAM() {
-}
+inline ALERAM::ALERAM() {}
 
-inline ALERAM::ALERAM(const ALERAM &rhs) {
+inline ALERAM::ALERAM(const ALERAM& rhs) {
   // Copy data over
   memcpy(m_ram, rhs.m_ram, sizeof(m_ram));
 }
 
-inline ALERAM& ALERAM::operator=(const ALERAM &rhs) {
+inline ALERAM& ALERAM::operator=(const ALERAM& rhs) {
   // Copy data over
   memcpy(m_ram, rhs.m_ram, sizeof(m_ram));
 
   return *this;
 }
 
-inline bool ALERAM::equals(const ALERAM &rhs) const {
+inline bool ALERAM::equals(const ALERAM& rhs) const {
   return (memcmp(m_ram, rhs.m_ram, size()) == 0);
 }
 
@@ -72,8 +71,6 @@ inline byte_t ALERAM::get(unsigned int x) const {
   return m_ram[x & 0x7F];
 }
 
-inline byte_t* ALERAM::byte(unsigned int x) {
-  return &m_ram[x & 0x7F];
-}
+inline byte_t* ALERAM::byte(unsigned int x) { return &m_ram[x & 0x7F]; }
 
-#endif // __ALE_RAM_HPP__
+#endif  // __ALE_RAM_HPP__

--- a/src/environment/ale_screen.hpp
+++ b/src/environment/ale_screen.hpp
@@ -27,55 +27,48 @@ typedef unsigned char pixel_t;
 
 /** A simple wrapper around an Atari screen. */
 class ALEScreen {
-  public:
-    ALEScreen(int h, int w);
-    ALEScreen(const ALEScreen &rhs);
+ public:
+  ALEScreen(int h, int w);
+  ALEScreen(const ALEScreen& rhs);
 
-    ALEScreen& operator=(const ALEScreen &rhs);
+  ALEScreen& operator=(const ALEScreen& rhs);
 
-    /** pixel accessors, (row, column)-ordered */
-    pixel_t get(int r, int c) const;
-    pixel_t *pixel(int r, int c);
+  /** pixel accessors, (row, column)-ordered */
+  pixel_t get(int r, int c) const;
+  pixel_t* pixel(int r, int c);
 
-    /** Access a whole row */
-    pixel_t *getRow(int r) const;
+  /** Access a whole row */
+  pixel_t* getRow(int r) const;
 
-    /** Access the whole array */
-    pixel_t *getArray() const { return const_cast<pixel_t *>(&m_pixels[0]); }
+  /** Access the whole array */
+  pixel_t* getArray() const { return const_cast<pixel_t*>(&m_pixels[0]); }
 
-    /** Dimensionality information */
-    size_t height() const { return m_rows; }
-    size_t width() const { return m_columns; }
+  /** Dimensionality information */
+  size_t height() const { return m_rows; }
+  size_t width() const { return m_columns; }
 
-    /** Returns the size of the underlying array */
-    size_t arraySize() const { return m_rows * m_columns * sizeof(pixel_t); }
+  /** Returns the size of the underlying array */
+  size_t arraySize() const { return m_rows * m_columns * sizeof(pixel_t); }
 
-    /** Returns whether two screens are equal */
-    bool equals(const ALEScreen &rhs) const;
+  /** Returns whether two screens are equal */
+  bool equals(const ALEScreen& rhs) const;
 
-  protected:
-    int m_rows;
-    int m_columns;
+ protected:
+  int m_rows;
+  int m_columns;
 
-    std::vector<pixel_t> m_pixels;
+  std::vector<pixel_t> m_pixels;
 };
 
-inline ALEScreen::ALEScreen(int h, int w):
-  m_rows(h),
-  m_columns(w),
-  // Create a pixel array of the requisite size
-  m_pixels(m_rows * m_columns) {
-}
+inline ALEScreen::ALEScreen(int h, int w)
+    : m_rows(h), m_columns(w),
+      // Create a pixel array of the requisite size
+      m_pixels(m_rows * m_columns) {}
 
-inline ALEScreen::ALEScreen(const ALEScreen &rhs):
-  m_rows(rhs.m_rows),
-  m_columns(rhs.m_columns),
-  m_pixels(rhs.m_pixels) {
+inline ALEScreen::ALEScreen(const ALEScreen& rhs)
+    : m_rows(rhs.m_rows), m_columns(rhs.m_columns), m_pixels(rhs.m_pixels) {}
 
-}
-
-inline ALEScreen& ALEScreen::operator=(const ALEScreen &rhs) {
-
+inline ALEScreen& ALEScreen::operator=(const ALEScreen& rhs) {
   m_rows = rhs.m_rows;
   m_columns = rhs.m_columns;
 
@@ -86,30 +79,28 @@ inline ALEScreen& ALEScreen::operator=(const ALEScreen &rhs) {
   return *this;
 }
 
-inline bool ALEScreen::equals(const ALEScreen &rhs) const {
-  return (m_rows == rhs.m_rows &&
-          m_columns == rhs.m_columns &&
-          (memcmp(&m_pixels[0], &rhs.m_pixels[0], arraySize()) == 0) );
+inline bool ALEScreen::equals(const ALEScreen& rhs) const {
+  return (m_rows == rhs.m_rows && m_columns == rhs.m_columns &&
+          (memcmp(&m_pixels[0], &rhs.m_pixels[0], arraySize()) == 0));
 }
 
 // pixel accessors, (row, column)-ordered
 inline pixel_t ALEScreen::get(int r, int c) const {
   // Perform some bounds-checking
-  assert (r >= 0 && r < m_rows && c >= 0 && c < m_columns);
+  assert(r >= 0 && r < m_rows && c >= 0 && c < m_columns);
   return m_pixels[r * m_columns + c];
 }
 
 inline pixel_t* ALEScreen::pixel(int r, int c) {
   // Perform some bounds-checking
-  assert (r >= 0 && r < m_rows && c >= 0 && c < m_columns);
+  assert(r >= 0 && r < m_rows && c >= 0 && c < m_columns);
   return &m_pixels[r * m_columns + c];
 }
 
 // Access a whole row
 inline pixel_t* ALEScreen::getRow(int r) const {
-  assert (r >= 0 && r < m_rows);
+  assert(r >= 0 && r < m_rows);
   return const_cast<pixel_t*>(&m_pixels[r * m_columns]);
 }
 
-
-#endif // __ALE_SCREEN_HPP__
+#endif  // __ALE_SCREEN_HPP__

--- a/src/environment/ale_state.cpp
+++ b/src/environment/ale_state.cpp
@@ -10,6 +10,7 @@
  * *****************************************************************************
  */
 #include "ale_state.hpp"
+
 #include "../emucore/m6502/src/System.hxx"
 #include "../emucore/Event.hxx"
 #include "../emucore/Deserializer.hxx"
@@ -21,30 +22,28 @@
 #include <stdexcept>
 
 /** Default constructor - loads settings from system */
-ALEState::ALEState():
-  m_left_paddle(PADDLE_DEFAULT_VALUE),
-  m_right_paddle(PADDLE_DEFAULT_VALUE),
-  m_paddle_min(PADDLE_MIN),
-  m_paddle_max(PADDLE_MAX),
-  m_frame_number(0),
-  m_episode_frame_number(0),
-  m_mode(0),
-  m_difficulty(0) {
-}
+ALEState::ALEState()
+    : m_left_paddle(PADDLE_DEFAULT_VALUE),
+      m_right_paddle(PADDLE_DEFAULT_VALUE),
+      m_paddle_min(PADDLE_MIN),
+      m_paddle_max(PADDLE_MAX),
+      m_frame_number(0),
+      m_episode_frame_number(0),
+      m_mode(0),
+      m_difficulty(0) {}
 
-ALEState::ALEState(const ALEState &rhs, const std::string &serialized):
-  m_left_paddle(rhs.m_left_paddle),
-  m_right_paddle(rhs.m_right_paddle),
-  m_paddle_min(rhs.m_paddle_min),
-  m_paddle_max(rhs.m_paddle_max),
-  m_frame_number(rhs.m_frame_number),
-  m_episode_frame_number(rhs.m_episode_frame_number),
-  m_serialized_state(serialized),
-  m_mode(rhs.m_mode),
-  m_difficulty(rhs.m_difficulty) {
-}
+ALEState::ALEState(const ALEState& rhs, const std::string& serialized)
+    : m_left_paddle(rhs.m_left_paddle),
+      m_right_paddle(rhs.m_right_paddle),
+      m_paddle_min(rhs.m_paddle_min),
+      m_paddle_max(rhs.m_paddle_max),
+      m_frame_number(rhs.m_frame_number),
+      m_episode_frame_number(rhs.m_episode_frame_number),
+      m_serialized_state(serialized),
+      m_mode(rhs.m_mode),
+      m_difficulty(rhs.m_difficulty) {}
 
-ALEState::ALEState(const std::string &serialized) {
+ALEState::ALEState(const std::string& serialized) {
   Deserializer des(serialized);
   this->m_left_paddle = des.getInt();
   this->m_right_paddle = des.getInt();
@@ -57,10 +56,9 @@ ALEState::ALEState(const std::string &serialized) {
   this->m_paddle_max = des.getInt();
 }
 
-
 /** Restores ALE to the given previously saved state. */
-void ALEState::load(OSystem* osystem, RomSettings* settings, std::string md5, const ALEState &rhs,
-    bool load_system) {
+void ALEState::load(OSystem* osystem, RomSettings* settings, std::string md5,
+                    const ALEState& rhs, bool load_system) {
   assert(rhs.m_serialized_state.length() > 0);
 
   // Deserialize the stored string into the emulator state
@@ -68,8 +66,8 @@ void ALEState::load(OSystem* osystem, RomSettings* settings, std::string md5, co
 
   // A primitive check to produce a meaningful error if this state does not contain osystem info.
   if (deser.getBool() != load_system)
-    throw new std::runtime_error("Attempting to load an ALEState which does not contain "
-        "system information.");
+    throw new std::runtime_error("Attempting to load an ALEState which does "
+                                 "not contain system information.");
 
   osystem->console().system().loadState(md5, deser);
   // If we have osystem data, load it as well
@@ -88,8 +86,8 @@ void ALEState::load(OSystem* osystem, RomSettings* settings, std::string md5, co
   m_difficulty = rhs.m_difficulty;
 }
 
-ALEState ALEState::save(OSystem* osystem, RomSettings* settings, std::string md5,
-    bool save_system) {
+ALEState ALEState::save(OSystem* osystem, RomSettings* settings,
+                        std::string md5, bool save_system) {
   // Use the emulator's built-in serialization to save the state
   Serializer ser;
 
@@ -106,13 +104,11 @@ ALEState ALEState::save(OSystem* osystem, RomSettings* settings, std::string md5
 }
 
 void ALEState::incrementFrame(int steps /* = 1 */) {
-    m_frame_number += steps;
-    m_episode_frame_number += steps;
+  m_frame_number += steps;
+  m_episode_frame_number += steps;
 }
 
-void ALEState::resetEpisodeFrameNumber() {
-    m_episode_frame_number = 0;
-}
+void ALEState::resetEpisodeFrameNumber() { m_episode_frame_number = 0; }
 
 std::string ALEState::serialize() {
   Serializer ser;
@@ -130,21 +126,19 @@ std::string ALEState::serialize() {
   return ser.get_str();
 }
 
-
-
 /* ***************************************************************************
  *  Calculates the Paddle resistance, based on the given x val
  * ***************************************************************************/
 int ALEState::calcPaddleResistance(int x_val) {
-  return x_val;  // this is different from the original stella implemebtation
+  return x_val; // this is different from the original stella implemebtation
 }
 
-void ALEState::resetPaddles(Event * event) {
+void ALEState::resetPaddles(Event* event) {
   int paddle_default = (m_paddle_min + m_paddle_max) / 2;
   setPaddles(event, paddle_default, paddle_default);
 }
 
-void ALEState::setPaddles(Event * event, int left, int right) {
+void ALEState::setPaddles(Event* event, int left, int right) {
   m_left_paddle = left;
   m_right_paddle = right;
 
@@ -168,31 +162,32 @@ void ALEState::setPaddleLimits(int paddle_min_val, int paddle_max_val) {
  *  Updates the positions of the paddles, and sets an event for
  *  updating the corresponding paddle's resistance
  * ********************************************************************/
- void ALEState::updatePaddlePositions(Event* event, int delta_left, int delta_right) {
-    // Cap paddle outputs
+void ALEState::updatePaddlePositions(Event* event, int delta_left,
+                                     int delta_right) {
+  // Cap paddle outputs
 
-    m_left_paddle += delta_left;
-    if (m_left_paddle < m_paddle_min) {
-        m_left_paddle = m_paddle_min;
-    }
-    if (m_left_paddle >  m_paddle_max) {
-        m_left_paddle = m_paddle_max;
-    }
+  m_left_paddle += delta_left;
+  if (m_left_paddle < m_paddle_min) {
+    m_left_paddle = m_paddle_min;
+  }
+  if (m_left_paddle > m_paddle_max) {
+    m_left_paddle = m_paddle_max;
+  }
 
-    m_right_paddle += delta_right;
-    if (m_right_paddle < m_paddle_min) {
-        m_right_paddle = m_paddle_min;
-    }
-    if (m_right_paddle >  m_paddle_max) {
-        m_right_paddle = m_paddle_max;
-    }
+  m_right_paddle += delta_right;
+  if (m_right_paddle < m_paddle_min) {
+    m_right_paddle = m_paddle_min;
+  }
+  if (m_right_paddle > m_paddle_max) {
+    m_right_paddle = m_paddle_max;
+  }
 
-    // Now set the paddle to their new value
-    setPaddles(event, m_left_paddle, m_right_paddle);
+  // Now set the paddle to their new value
+  setPaddles(event, m_left_paddle, m_right_paddle);
 }
 
-
-void ALEState::applyActionPaddles(Event* event, int player_a_action, int player_b_action) {
+void ALEState::applyActionPaddles(Event* event, int player_a_action,
+                                  int player_b_action) {
   // Reset keys
   resetKeys(event);
 
@@ -201,51 +196,51 @@ void ALEState::applyActionPaddles(Event* event, int player_a_action, int player_
   int delta_left;
   int delta_right;
 
-    switch(player_a_action) {
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_UPRIGHT:
-        case PLAYER_A_DOWNRIGHT:
-        case PLAYER_A_UPRIGHTFIRE:
-        case PLAYER_A_DOWNRIGHTFIRE:
-          delta_left = -PADDLE_DELTA;
-            break;
+  switch (player_a_action) {
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_UPRIGHT:
+    case PLAYER_A_DOWNRIGHT:
+    case PLAYER_A_UPRIGHTFIRE:
+    case PLAYER_A_DOWNRIGHTFIRE:
+      delta_left = -PADDLE_DELTA;
+      break;
 
-        case PLAYER_A_LEFT:
-        case PLAYER_A_LEFTFIRE:
-        case PLAYER_A_UPLEFT:
-        case PLAYER_A_DOWNLEFT:
-        case PLAYER_A_UPLEFTFIRE:
-        case PLAYER_A_DOWNLEFTFIRE:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_LEFTFIRE:
+    case PLAYER_A_UPLEFT:
+    case PLAYER_A_DOWNLEFT:
+    case PLAYER_A_UPLEFTFIRE:
+    case PLAYER_A_DOWNLEFTFIRE:
       delta_left = PADDLE_DELTA;
-            break;
+      break;
     default:
       delta_left = 0;
       break;
-    }
+  }
 
-    switch(player_b_action) {
-        case PLAYER_B_RIGHT:
-        case PLAYER_B_RIGHTFIRE:
-        case PLAYER_B_UPRIGHT:
-        case PLAYER_B_DOWNRIGHT:
-        case PLAYER_B_UPRIGHTFIRE:
-        case PLAYER_B_DOWNRIGHTFIRE:
-          delta_right = -PADDLE_DELTA;
-            break;
+  switch (player_b_action) {
+    case PLAYER_B_RIGHT:
+    case PLAYER_B_RIGHTFIRE:
+    case PLAYER_B_UPRIGHT:
+    case PLAYER_B_DOWNRIGHT:
+    case PLAYER_B_UPRIGHTFIRE:
+    case PLAYER_B_DOWNRIGHTFIRE:
+      delta_right = -PADDLE_DELTA;
+      break;
 
-        case PLAYER_B_LEFT:
-        case PLAYER_B_LEFTFIRE:
-        case PLAYER_B_UPLEFT:
-        case PLAYER_B_DOWNLEFT:
-        case PLAYER_B_UPLEFTFIRE:
-        case PLAYER_B_DOWNLEFTFIRE:
+    case PLAYER_B_LEFT:
+    case PLAYER_B_LEFTFIRE:
+    case PLAYER_B_UPLEFT:
+    case PLAYER_B_DOWNLEFT:
+    case PLAYER_B_UPLEFTFIRE:
+    case PLAYER_B_DOWNLEFTFIRE:
       delta_right = PADDLE_DELTA;
-            break;
+      break;
     default:
       delta_right = 0;
       break;
-    }
+  }
 
   // Now update the paddle positions
   updatePaddlePositions(event, delta_left, delta_right);
@@ -256,34 +251,34 @@ void ALEState::applyActionPaddles(Event* event, int player_a_action, int player_
 
   // Now add the fire event
   switch (player_a_action) {
-        case PLAYER_A_FIRE:
-        case PLAYER_A_UPFIRE:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_LEFTFIRE:
-        case PLAYER_A_DOWNFIRE:
-        case PLAYER_A_UPRIGHTFIRE:
-        case PLAYER_A_UPLEFTFIRE:
-        case PLAYER_A_DOWNRIGHTFIRE:
-        case PLAYER_A_DOWNLEFTFIRE:
-            event->set(Event::PaddleZeroFire, 1);
-            break;
+    case PLAYER_A_FIRE:
+    case PLAYER_A_UPFIRE:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_LEFTFIRE:
+    case PLAYER_A_DOWNFIRE:
+    case PLAYER_A_UPRIGHTFIRE:
+    case PLAYER_A_UPLEFTFIRE:
+    case PLAYER_A_DOWNRIGHTFIRE:
+    case PLAYER_A_DOWNLEFTFIRE:
+      event->set(Event::PaddleZeroFire, 1);
+      break;
     default:
       // Nothing
       break;
   }
 
   switch (player_b_action) {
-        case PLAYER_B_FIRE:
-        case PLAYER_B_UPFIRE:
-        case PLAYER_B_RIGHTFIRE:
-        case PLAYER_B_LEFTFIRE:
-        case PLAYER_B_DOWNFIRE:
-        case PLAYER_B_UPRIGHTFIRE:
-        case PLAYER_B_UPLEFTFIRE:
-        case PLAYER_B_DOWNRIGHTFIRE:
-        case PLAYER_B_DOWNLEFTFIRE:
-            event->set(Event::PaddleOneFire, 1);
-            break;
+    case PLAYER_B_FIRE:
+    case PLAYER_B_UPFIRE:
+    case PLAYER_B_RIGHTFIRE:
+    case PLAYER_B_LEFTFIRE:
+    case PLAYER_B_DOWNFIRE:
+    case PLAYER_B_UPRIGHTFIRE:
+    case PLAYER_B_UPLEFTFIRE:
+    case PLAYER_B_DOWNRIGHTFIRE:
+    case PLAYER_B_DOWNLEFTFIRE:
+      event->set(Event::PaddleOneFire, 1);
+      break;
     default:
       // Nothing
       break;
@@ -304,200 +299,201 @@ void ALEState::setDifficultySwitches(Event* event, unsigned int value) {
   event->set(Event::ConsoleRightDifficultyB, !((value & 2) >> 1));
 }
 
-void ALEState::setActionJoysticks(Event* event, int player_a_action, int player_b_action) {
+void ALEState::setActionJoysticks(Event* event, int player_a_action,
+                                  int player_b_action) {
   // Reset keys
   resetKeys(event);
 
-  switch(player_a_action) {
-      case PLAYER_A_NOOP:
-          break;
+  switch (player_a_action) {
+    case PLAYER_A_NOOP:
+      break;
 
-      case PLAYER_A_FIRE:
-          event->set(Event::JoystickZeroFire, 1);
-          break;
+    case PLAYER_A_FIRE:
+      event->set(Event::JoystickZeroFire, 1);
+      break;
 
-      case PLAYER_A_UP:
-          event->set(Event::JoystickZeroUp, 1);
-          break;
+    case PLAYER_A_UP:
+      event->set(Event::JoystickZeroUp, 1);
+      break;
 
-      case PLAYER_A_RIGHT:
-          event->set(Event::JoystickZeroRight, 1);
-          break;
+    case PLAYER_A_RIGHT:
+      event->set(Event::JoystickZeroRight, 1);
+      break;
 
-      case PLAYER_A_LEFT:
-          event->set(Event::JoystickZeroLeft, 1);
-          break;
+    case PLAYER_A_LEFT:
+      event->set(Event::JoystickZeroLeft, 1);
+      break;
 
-      case PLAYER_A_DOWN:
-          event->set(Event::JoystickZeroDown, 1);
-          break;
+    case PLAYER_A_DOWN:
+      event->set(Event::JoystickZeroDown, 1);
+      break;
 
-      case PLAYER_A_UPRIGHT:
-          event->set(Event::JoystickZeroUp, 1);
-          event->set(Event::JoystickZeroRight, 1);
-          break;
+    case PLAYER_A_UPRIGHT:
+      event->set(Event::JoystickZeroUp, 1);
+      event->set(Event::JoystickZeroRight, 1);
+      break;
 
-      case PLAYER_A_UPLEFT:
-          event->set(Event::JoystickZeroUp, 1);
-          event->set(Event::JoystickZeroLeft, 1);
-          break;
+    case PLAYER_A_UPLEFT:
+      event->set(Event::JoystickZeroUp, 1);
+      event->set(Event::JoystickZeroLeft, 1);
+      break;
 
-      case PLAYER_A_DOWNRIGHT:
-          event->set(Event::JoystickZeroDown, 1);
-          event->set(Event::JoystickZeroRight, 1);
-          break;
+    case PLAYER_A_DOWNRIGHT:
+      event->set(Event::JoystickZeroDown, 1);
+      event->set(Event::JoystickZeroRight, 1);
+      break;
 
-      case PLAYER_A_DOWNLEFT:
-          event->set(Event::JoystickZeroDown, 1);
-          event->set(Event::JoystickZeroLeft, 1);
-          break;
+    case PLAYER_A_DOWNLEFT:
+      event->set(Event::JoystickZeroDown, 1);
+      event->set(Event::JoystickZeroLeft, 1);
+      break;
 
-      case PLAYER_A_UPFIRE:
-          event->set(Event::JoystickZeroUp, 1);
-          event->set(Event::JoystickZeroFire, 1);
-          break;
+    case PLAYER_A_UPFIRE:
+      event->set(Event::JoystickZeroUp, 1);
+      event->set(Event::JoystickZeroFire, 1);
+      break;
 
-      case PLAYER_A_RIGHTFIRE:
-          event->set(Event::JoystickZeroRight, 1);
-          event->set(Event::JoystickZeroFire, 1);
-          break;
+    case PLAYER_A_RIGHTFIRE:
+      event->set(Event::JoystickZeroRight, 1);
+      event->set(Event::JoystickZeroFire, 1);
+      break;
 
-      case PLAYER_A_LEFTFIRE:
-          event->set(Event::JoystickZeroLeft, 1);
-          event->set(Event::JoystickZeroFire, 1);
-          break;
+    case PLAYER_A_LEFTFIRE:
+      event->set(Event::JoystickZeroLeft, 1);
+      event->set(Event::JoystickZeroFire, 1);
+      break;
 
-      case PLAYER_A_DOWNFIRE:
-          event->set(Event::JoystickZeroDown, 1);
-          event->set(Event::JoystickZeroFire, 1);
-          break;
+    case PLAYER_A_DOWNFIRE:
+      event->set(Event::JoystickZeroDown, 1);
+      event->set(Event::JoystickZeroFire, 1);
+      break;
 
-      case PLAYER_A_UPRIGHTFIRE:
-          event->set(Event::JoystickZeroUp, 1);
-          event->set(Event::JoystickZeroRight, 1);
-          event->set(Event::JoystickZeroFire, 1);
-          break;
+    case PLAYER_A_UPRIGHTFIRE:
+      event->set(Event::JoystickZeroUp, 1);
+      event->set(Event::JoystickZeroRight, 1);
+      event->set(Event::JoystickZeroFire, 1);
+      break;
 
-      case PLAYER_A_UPLEFTFIRE:
-          event->set(Event::JoystickZeroUp, 1);
-          event->set(Event::JoystickZeroLeft, 1);
-          event->set(Event::JoystickZeroFire, 1);
-          break;
+    case PLAYER_A_UPLEFTFIRE:
+      event->set(Event::JoystickZeroUp, 1);
+      event->set(Event::JoystickZeroLeft, 1);
+      event->set(Event::JoystickZeroFire, 1);
+      break;
 
-      case PLAYER_A_DOWNRIGHTFIRE:
-          event->set(Event::JoystickZeroDown, 1);
-          event->set(Event::JoystickZeroRight, 1);
-          event->set(Event::JoystickZeroFire, 1);
-          break;
+    case PLAYER_A_DOWNRIGHTFIRE:
+      event->set(Event::JoystickZeroDown, 1);
+      event->set(Event::JoystickZeroRight, 1);
+      event->set(Event::JoystickZeroFire, 1);
+      break;
 
-      case PLAYER_A_DOWNLEFTFIRE:
-          event->set(Event::JoystickZeroDown, 1);
-          event->set(Event::JoystickZeroLeft, 1);
-          event->set(Event::JoystickZeroFire, 1);
-          break;
-      case RESET:
-          event->set(Event::ConsoleReset, 1);
-          break;
-      default:
-          ale::Logger::Error << "Invalid Player A Action: " << player_a_action;
-          exit(-1);
-
+    case PLAYER_A_DOWNLEFTFIRE:
+      event->set(Event::JoystickZeroDown, 1);
+      event->set(Event::JoystickZeroLeft, 1);
+      event->set(Event::JoystickZeroFire, 1);
+      break;
+    case RESET:
+      event->set(Event::ConsoleReset, 1);
+      break;
+    default:
+      ale::Logger::Error << "Invalid Player A Action: " << player_a_action;
+      exit(-1);
   }
 
-  switch(player_b_action) {
-  case PLAYER_B_NOOP:
-          break;
+  switch (player_b_action) {
+    case PLAYER_B_NOOP:
+      break;
 
-      case PLAYER_B_FIRE:
-          event->set(Event::JoystickOneFire, 1);
-          break;
+    case PLAYER_B_FIRE:
+      event->set(Event::JoystickOneFire, 1);
+      break;
 
-      case PLAYER_B_UP:
-          event->set(Event::JoystickOneUp, 1);
-          break;
+    case PLAYER_B_UP:
+      event->set(Event::JoystickOneUp, 1);
+      break;
 
-      case PLAYER_B_RIGHT:
-          event->set(Event::JoystickOneRight, 1);
-          break;
+    case PLAYER_B_RIGHT:
+      event->set(Event::JoystickOneRight, 1);
+      break;
 
-      case PLAYER_B_LEFT:
-          event->set(Event::JoystickOneLeft, 1);
-          break;
+    case PLAYER_B_LEFT:
+      event->set(Event::JoystickOneLeft, 1);
+      break;
 
-      case PLAYER_B_DOWN:
-          event->set(Event::JoystickOneDown, 1);
-          break;
+    case PLAYER_B_DOWN:
+      event->set(Event::JoystickOneDown, 1);
+      break;
 
-      case PLAYER_B_UPRIGHT:
-          event->set(Event::JoystickOneUp, 1);
-          event->set(Event::JoystickOneRight, 1);
-          break;
+    case PLAYER_B_UPRIGHT:
+      event->set(Event::JoystickOneUp, 1);
+      event->set(Event::JoystickOneRight, 1);
+      break;
 
-      case PLAYER_B_UPLEFT:
-          event->set(Event::JoystickOneUp, 1);
-          event->set(Event::JoystickOneLeft, 1);
-          break;
+    case PLAYER_B_UPLEFT:
+      event->set(Event::JoystickOneUp, 1);
+      event->set(Event::JoystickOneLeft, 1);
+      break;
 
-      case PLAYER_B_DOWNRIGHT:
-          event->set(Event::JoystickOneDown, 1);
-          event->set(Event::JoystickOneRight, 1);
-          break;
+    case PLAYER_B_DOWNRIGHT:
+      event->set(Event::JoystickOneDown, 1);
+      event->set(Event::JoystickOneRight, 1);
+      break;
 
-      case PLAYER_B_DOWNLEFT:
-          event->set(Event::JoystickOneDown, 1);
-          event->set(Event::JoystickOneLeft, 1);
-          break;
+    case PLAYER_B_DOWNLEFT:
+      event->set(Event::JoystickOneDown, 1);
+      event->set(Event::JoystickOneLeft, 1);
+      break;
 
-      case PLAYER_B_UPFIRE:
-          event->set(Event::JoystickOneUp, 1);
-          event->set(Event::JoystickOneFire, 1);
-          break;
+    case PLAYER_B_UPFIRE:
+      event->set(Event::JoystickOneUp, 1);
+      event->set(Event::JoystickOneFire, 1);
+      break;
 
-      case PLAYER_B_RIGHTFIRE:
-          event->set(Event::JoystickOneRight, 1);
-          event->set(Event::JoystickOneFire, 1);
-          break;
+    case PLAYER_B_RIGHTFIRE:
+      event->set(Event::JoystickOneRight, 1);
+      event->set(Event::JoystickOneFire, 1);
+      break;
 
-      case PLAYER_B_LEFTFIRE:
-          event->set(Event::JoystickOneLeft, 1);
-          event->set(Event::JoystickOneFire, 1);
-          break;
+    case PLAYER_B_LEFTFIRE:
+      event->set(Event::JoystickOneLeft, 1);
+      event->set(Event::JoystickOneFire, 1);
+      break;
 
-      case PLAYER_B_DOWNFIRE:
-          event->set(Event::JoystickOneDown, 1);
-          event->set(Event::JoystickOneFire, 1);
-          break;
+    case PLAYER_B_DOWNFIRE:
+      event->set(Event::JoystickOneDown, 1);
+      event->set(Event::JoystickOneFire, 1);
+      break;
 
-      case PLAYER_B_UPRIGHTFIRE:
-          event->set(Event::JoystickOneUp, 1);
-          event->set(Event::JoystickOneRight, 1);
-          event->set(Event::JoystickOneFire, 1);
-          break;
+    case PLAYER_B_UPRIGHTFIRE:
+      event->set(Event::JoystickOneUp, 1);
+      event->set(Event::JoystickOneRight, 1);
+      event->set(Event::JoystickOneFire, 1);
+      break;
 
-      case PLAYER_B_UPLEFTFIRE:
-          event->set(Event::JoystickOneUp, 1);
-          event->set(Event::JoystickOneLeft, 1);
-          event->set(Event::JoystickOneFire, 1);
-          break;
+    case PLAYER_B_UPLEFTFIRE:
+      event->set(Event::JoystickOneUp, 1);
+      event->set(Event::JoystickOneLeft, 1);
+      event->set(Event::JoystickOneFire, 1);
+      break;
 
-      case PLAYER_B_DOWNRIGHTFIRE:
-          event->set(Event::JoystickOneDown, 1);
-          event->set(Event::JoystickOneRight, 1);
-          event->set(Event::JoystickOneFire, 1);
-          break;
+    case PLAYER_B_DOWNRIGHTFIRE:
+      event->set(Event::JoystickOneDown, 1);
+      event->set(Event::JoystickOneRight, 1);
+      event->set(Event::JoystickOneFire, 1);
+      break;
 
-      case PLAYER_B_DOWNLEFTFIRE:
-          event->set(Event::JoystickOneDown, 1);
-          event->set(Event::JoystickOneLeft, 1);
-          event->set(Event::JoystickOneFire, 1);
-          break;
-      case RESET:
-          event->set(Event::ConsoleReset, 1);
-          ale::Logger::Info << "Sending Reset..." << std::endl;
-          break;
-      default:
-          ale::Logger::Error << "Invalid Player B Action: " << player_b_action << std::endl;
-          exit(-1);
+    case PLAYER_B_DOWNLEFTFIRE:
+      event->set(Event::JoystickOneDown, 1);
+      event->set(Event::JoystickOneLeft, 1);
+      event->set(Event::JoystickOneFire, 1);
+      break;
+    case RESET:
+      event->set(Event::ConsoleReset, 1);
+      ale::Logger::Info << "Sending Reset..." << std::endl;
+      break;
+    default:
+      ale::Logger::Error << "Invalid Player B Action: " << player_b_action
+                         << std::endl;
+      exit(-1);
   }
 }
 
@@ -506,33 +502,32 @@ void ALEState::setActionJoysticks(Event* event, int player_a_action, int player_
     Unpresses all control-relevant keys
  * ***************************************************************************/
 void ALEState::resetKeys(Event* event) {
-    event->set(Event::ConsoleReset, 0);
-    event->set(Event::ConsoleSelect, 0);
-    event->set(Event::JoystickZeroFire, 0);
-    event->set(Event::JoystickZeroUp, 0);
-    event->set(Event::JoystickZeroDown, 0);
-    event->set(Event::JoystickZeroRight, 0);
-    event->set(Event::JoystickZeroLeft, 0);
-    event->set(Event::JoystickOneFire, 0);
-    event->set(Event::JoystickOneUp, 0);
-    event->set(Event::JoystickOneDown, 0);
-    event->set(Event::JoystickOneRight, 0);
-    event->set(Event::JoystickOneLeft, 0);
+  event->set(Event::ConsoleReset, 0);
+  event->set(Event::ConsoleSelect, 0);
+  event->set(Event::JoystickZeroFire, 0);
+  event->set(Event::JoystickZeroUp, 0);
+  event->set(Event::JoystickZeroDown, 0);
+  event->set(Event::JoystickZeroRight, 0);
+  event->set(Event::JoystickZeroLeft, 0);
+  event->set(Event::JoystickOneFire, 0);
+  event->set(Event::JoystickOneUp, 0);
+  event->set(Event::JoystickOneDown, 0);
+  event->set(Event::JoystickOneRight, 0);
+  event->set(Event::JoystickOneLeft, 0);
 
-    // also reset paddle fire
-    event->set(Event::PaddleZeroFire, 0);
-    event->set(Event::PaddleOneFire, 0);
+  // also reset paddle fire
+  event->set(Event::PaddleZeroFire, 0);
+  event->set(Event::PaddleOneFire, 0);
 
-    // Set the difficulty switches accordingly for this time step.
-    setDifficultySwitches(event, m_difficulty);
+  // Set the difficulty switches accordingly for this time step.
+  setDifficultySwitches(event, m_difficulty);
 }
 
-bool ALEState::equals(ALEState &rhs) {
+bool ALEState::equals(ALEState& rhs) {
   return (rhs.m_serialized_state == this->m_serialized_state &&
-    rhs.m_left_paddle == this->m_left_paddle &&
-    rhs.m_right_paddle == this->m_right_paddle &&
-    rhs.m_frame_number == this->m_frame_number &&
-    rhs.m_episode_frame_number == this->m_episode_frame_number &&
-    rhs.m_mode == this->m_mode &&
-    rhs.m_difficulty == this->m_difficulty);
+          rhs.m_left_paddle == this->m_left_paddle &&
+          rhs.m_right_paddle == this->m_right_paddle &&
+          rhs.m_frame_number == this->m_frame_number &&
+          rhs.m_episode_frame_number == this->m_episode_frame_number &&
+          rhs.m_mode == this->m_mode && rhs.m_difficulty == this->m_difficulty);
 }

--- a/src/environment/ale_state.hpp
+++ b/src/environment/ale_state.hpp
@@ -18,9 +18,10 @@
 #ifndef __ALE_STATE_HPP__
 #define __ALE_STATE_HPP__
 
+#include <string>
+
 #include "../emucore/OSystem.hxx"
 #include "../emucore/Event.hxx"
-#include <string>
 #include "../common/Log.hpp"
 
 class RomSettings;
@@ -34,107 +35,108 @@ class RomSettings;
 #define PADDLE_DEFAULT_VALUE (((PADDLE_MAX - PADDLE_MIN) / 2) + PADDLE_MIN)
 
 class ALEState {
-  public:
-    ALEState();
-    // Makes a copy of this state, also storing emulator information provided as a string
-    ALEState(const ALEState &rhs, const std::string &serialized);
+ public:
+  ALEState();
+  // Makes a copy of this state, also storing emulator information provided as a string
+  ALEState(const ALEState& rhs, const std::string& serialized);
 
-    // Restores a serialized ALEState
-    ALEState(const std::string &serialized);
+  // Restores a serialized ALEState
+  ALEState(const std::string& serialized);
 
-    /** Resets the system to its start state. numResetSteps 'RESET' actions are taken after the
+  /** Resets the system to its start state. numResetSteps 'RESET' actions are taken after the
       *  start. */
-    void reset(int numResetSteps = 1);
+  void reset(int numResetSteps = 1);
 
-    /** Returns true if the two states contain the same saved information */
-    bool equals(ALEState &state);
+  /** Returns true if the two states contain the same saved information */
+  bool equals(ALEState& state);
 
-    void resetPaddles(Event*);
+  void resetPaddles(Event*);
 
-    //Apply the special select action
-    void pressSelect(Event* event_obj);
+  //Apply the special select action
+  void pressSelect(Event* event_obj);
 
-    /** Applies paddle actions. This actually modifies the game state by updating the paddle
+  /** Applies paddle actions. This actually modifies the game state by updating the paddle
       *  resistances. */
-    void applyActionPaddles(Event* event_obj, int player_a_action, int player_b_action);
-    /** Sets the joystick events. No effect until the emulator is run forward. */
-    void setActionJoysticks(Event* event_obj, int player_a_action, int player_b_action);
+  void applyActionPaddles(Event* event_obj, int player_a_action,
+                          int player_b_action);
+  /** Sets the joystick events. No effect until the emulator is run forward. */
+  void setActionJoysticks(Event* event_obj, int player_a_action,
+                          int player_b_action);
 
-    void incrementFrame(int steps = 1);
+  void incrementFrame(int steps = 1);
 
-    void resetEpisodeFrameNumber();
+  void resetEpisodeFrameNumber();
 
-    //Get the frames executed so far
-    int getFrameNumber() const { return m_frame_number;   }
+  //Get the frames executed so far
+  int getFrameNumber() const { return m_frame_number; }
 
-    //Get the number of frames executed this episode.
-    int getEpisodeFrameNumber() const { return m_episode_frame_number; }
+  //Get the number of frames executed this episode.
+  int getEpisodeFrameNumber() const { return m_episode_frame_number; }
 
-    /** set the difficulty according to the value.
+  /** set the difficulty according to the value.
       * If the first bit is 1, then it will put the left difficulty switch to A (otherwise leave it on B)
       * If the second bit is 1, then it will put the right difficulty switch to A (otherwise leave it on B)
       */
-    void setDifficulty(unsigned int value) { m_difficulty = value; }
+  void setDifficulty(unsigned int value) { m_difficulty = value; }
 
-    // Returns the current difficulty setting.
-    unsigned int getDifficulty() const { return m_difficulty; }
+  // Returns the current difficulty setting.
+  unsigned int getDifficulty() const { return m_difficulty; }
 
-    //Save the current mode we are supposed to be in.
-    void setCurrentMode(game_mode_t value) { m_mode = value; }
+  //Save the current mode we are supposed to be in.
+  void setCurrentMode(game_mode_t value) { m_mode = value; }
 
-    //Get the current mode we are in.
-    game_mode_t getCurrentMode() const { return m_mode; }
+  //Get the current mode we are in.
+  game_mode_t getCurrentMode() const { return m_mode; }
 
-    std::string serialize();
+  std::string serialize();
 
+ protected:
+  // Let StellaEnvironment access these methods: they are needed for emulation purposes
+  friend class StellaEnvironment;
 
-  protected:
-    // Let StellaEnvironment access these methods: they are needed for emulation purposes
-    friend class StellaEnvironment;
-
-    // The two methods below are meant to be used by StellaEnvironment.
-    /** Restores the environment to a previously saved state. If load_system == true, we also
+  // The two methods below are meant to be used by StellaEnvironment.
+  /** Restores the environment to a previously saved state. If load_system == true, we also
         restore system-specific information (such as the RNG state). */
-    void load(OSystem* osystem, RomSettings* settings, std::string md5, const ALEState &rhs,
-              bool load_system);
+  void load(OSystem* osystem, RomSettings* settings, std::string md5,
+            const ALEState& rhs, bool load_system);
 
-    /** Returns a "copy" of the current state, including the information necessary to restore
+  /** Returns a "copy" of the current state, including the information necessary to restore
       *  the emulator. If save_system == true, this includes the RNG state. */
-    ALEState save(OSystem* osystem, RomSettings* settings, std::string md5, bool save_system);
+  ALEState save(OSystem* osystem, RomSettings* settings, std::string md5,
+                bool save_system);
 
-    /** Reset key presses */
-    void resetKeys(Event* event_obj);
+  /** Reset key presses */
+  void resetKeys(Event* event_obj);
 
-    /** Sets the paddle to a given position */
-    void setPaddles(Event* event_obj, int left, int right);
+  /** Sets the paddle to a given position */
+  void setPaddles(Event* event_obj, int left, int right);
 
-    /** Set the paddle min/max values */
-    void setPaddleLimits(int paddle_min_val, int paddle_max_val);
+  /** Set the paddle min/max values */
+  void setPaddleLimits(int paddle_min_val, int paddle_max_val);
 
-    /** Updates the paddle position by a delta amount. */
-    void updatePaddlePositions(Event* event_obj, int delta_x, int delta_y);
+  /** Updates the paddle position by a delta amount. */
+  void updatePaddlePositions(Event* event_obj, int delta_x, int delta_y);
 
-    /** Calculates the Paddle resistance, based on the given x val */
-    int calcPaddleResistance(int x_val);
+  /** Calculates the Paddle resistance, based on the given x val */
+  int calcPaddleResistance(int x_val);
 
-    /** Applies the current difficulty setting, which is effectively part of the action */
-    void setDifficultySwitches(Event* event_obj, unsigned int value);
+  /** Applies the current difficulty setting, which is effectively part of the action */
+  void setDifficultySwitches(Event* event_obj, unsigned int value);
 
-  private:
-    int m_left_paddle;   // Current value for the left-paddle
-    int m_right_paddle;  // Current value for the right-paddle
+ private:
+  int m_left_paddle;               // Current value for the left-paddle
+  int m_right_paddle;              // Current value for the right-paddle
 
-    int m_paddle_min;    // Minimum value for paddle
-    int m_paddle_max;    // Maximum value for paddle
+  int m_paddle_min;                // Minimum value for paddle
+  int m_paddle_max;                // Maximum value for paddle
 
-    int m_frame_number; // How many frames since the start
-    int m_episode_frame_number; // How many frames since the beginning of this episode
+  int m_frame_number;              // How many frames since the start
+  int m_episode_frame_number;      // How many frames since the beginning of this episode
 
-    std::string m_serialized_state; // The stored environment state, if this is a saved state
+  std::string m_serialized_state;  // The stored environment state, if this is a saved state
 
-    game_mode_t m_mode; //The current mode we are in
-    difficulty_t m_difficulty; //The current difficulty we are in
-
+  game_mode_t m_mode;              // The current mode we are in
+  difficulty_t m_difficulty;       // The current difficulty we are in
 };
 
-#endif // __ALE_STATE_HPP__
+#endif  // __ALE_STATE_HPP__

--- a/src/environment/phosphor_blend.cpp
+++ b/src/environment/phosphor_blend.cpp
@@ -17,9 +17,7 @@
 #include "phosphor_blend.hpp"
 #include "../emucore/Console.hxx"
 
-PhosphorBlend::PhosphorBlend(OSystem * osystem):
-    m_osystem(osystem) {
-
+PhosphorBlend::PhosphorBlend(OSystem* osystem) : m_osystem(osystem) {
   // Taken from default Stella settings
   m_phosphor_blend_ratio = 77;
 
@@ -30,8 +28,8 @@ void PhosphorBlend::process(ALEScreen& screen) {
   Console& console = m_osystem->console();
 
   // Fetch current and previous frame buffers from the emulator
-  uInt8 * current_buffer  = console.mediaSource().currentFrameBuffer();
-  uInt8 * previous_buffer = console.mediaSource().previousFrameBuffer();
+  uInt8* current_buffer = console.mediaSource().currentFrameBuffer();
+  uInt8* previous_buffer = console.mediaSource().previousFrameBuffer();
 
   // Process each pixel in turn
   for (size_t i = 0; i < screen.arraySize(); i++) {
@@ -46,8 +44,7 @@ void PhosphorBlend::process(ALEScreen& screen) {
   }
 }
 void PhosphorBlend::makeAveragePalette() {
-
-  ColourPalette &palette = m_osystem->colourPalette();
+  ColourPalette& palette = m_osystem->colourPalette();
 
   // Precompute the average RGB values for phosphor-averaged colors c1 and c2.
   for (int c1 = 0; c1 < 256; c1 += 2) {
@@ -101,8 +98,10 @@ uInt8 PhosphorBlend::getPhosphor(uInt8 v1, uInt8 v2) {
   }
 
   uInt32 blendedValue = ((v1 - v2) * m_phosphor_blend_ratio) / 100 + v2;
-  if (blendedValue > 255) return 255;
-  else return (uInt8) blendedValue;
+  if (blendedValue > 255)
+    return 255;
+  else
+    return (uInt8)blendedValue;
 }
 
 uInt32 PhosphorBlend::makeRGB(uInt8 r, uInt8 g, uInt8 b) {

--- a/src/environment/phosphor_blend.hpp
+++ b/src/environment/phosphor_blend.hpp
@@ -21,25 +21,25 @@
 #include "ale_screen.hpp"
 
 class PhosphorBlend {
-  public:
-    PhosphorBlend(OSystem *);
+ public:
+  PhosphorBlend(OSystem*);
 
-    void process(ALEScreen& screen);
+  void process(ALEScreen& screen);
 
-  private:
-    void makeAveragePalette();
-    uInt8 getPhosphor(uInt8 v1, uInt8 v2);
-    uInt32 makeRGB(uInt8 r, uInt8 g, uInt8 b);
-    /** Converts a RGB value to an 8-bit format */
-    uInt8 rgbToNTSC(uInt32 rgb);
+ private:
+  void makeAveragePalette();
+  uInt8 getPhosphor(uInt8 v1, uInt8 v2);
+  uInt32 makeRGB(uInt8 r, uInt8 g, uInt8 b);
+  /** Converts a RGB value to an 8-bit format */
+  uInt8 rgbToNTSC(uInt32 rgb);
 
-  private:
-    OSystem * m_osystem;
+ private:
+  OSystem* m_osystem;
 
-    uInt8 m_rgb_ntsc[64][64][64];
+  uInt8 m_rgb_ntsc[64][64][64];
 
-    uInt32 m_avg_palette[256][256];
-    uInt8 m_phosphor_blend_ratio;
+  uInt32 m_avg_palette[256][256];
+  uInt8 m_phosphor_blend_ratio;
 };
 
-#endif // __PHOSPHOR_BLEND_HPP__
+#endif  // __PHOSPHOR_BLEND_HPP__

--- a/src/environment/stella_environment.hpp
+++ b/src/environment/stella_environment.hpp
@@ -34,111 +34,112 @@
 #include <memory>
 
 class StellaEnvironment {
-  public:
-    StellaEnvironment(OSystem * system, RomSettings * settings);
+ public:
+  StellaEnvironment(OSystem* system, RomSettings* settings);
 
-    /** Resets the system to its start state. */
-    void reset();
+  /** Resets the system to its start state. */
+  void reset();
 
-    /** Save/restore the environment state onto the stack. */
-    void save();
-    void load();
+  /** Save/restore the environment state onto the stack. */
+  void save();
+  void load();
 
-    /** Returns a copy of the current emulator state. Note that this doesn't include
+  /** Returns a copy of the current emulator state. Note that this doesn't include
         pseudorandomness, so that clone/restoreState are suitable for planning. */
-    ALEState cloneState();
-    /** Restores a previously saved copy of the state. */
-    void restoreState(const ALEState&);
+  ALEState cloneState();
+  /** Restores a previously saved copy of the state. */
+  void restoreState(const ALEState&);
 
-    /** Returns a copy of the current emulator state. This includes RNG state information, and
+  /** Returns a copy of the current emulator state. This includes RNG state information, and
         more generally should lead to exactly reproducibility. */
-    ALEState cloneSystemState();
-    /** Restores a previously saved copy of the state, including RNG state information. */
-    void restoreSystemState(const ALEState&);
+  ALEState cloneSystemState();
+  /** Restores a previously saved copy of the state, including RNG state information. */
+  void restoreSystemState(const ALEState&);
 
-    /** Applies the given actions (e.g. updating paddle positions when the paddle is used)
+  /** Applies the given actions (e.g. updating paddle positions when the paddle is used)
       *  and performs one simulation step in Stella. Returns the resultant reward. When
       *  frame skip is set to > 1, up the corresponding number of simulation steps are performed.
       *  Note that the post-act() frame number might not correspond to the pre-act() frame
       *  number plus the frame skip.
       */
-    reward_t act(Action player_a_action, Action player_b_action);
+  reward_t act(Action player_a_action, Action player_b_action);
 
-    /** This functions emulates a push on the reset button of the console */
-    void softReset();
+  /** This functions emulates a push on the reset button of the console */
+  void softReset();
 
-    /** Keep pressing the console select button for a given amount of time*/
-    void pressSelect(size_t num_steps = 1);
+  /** Keep pressing the console select button for a given amount of time*/
+  void pressSelect(size_t num_steps = 1);
 
-    /** Set the difficulty according to the value.
+  /** Set the difficulty according to the value.
       * If the first bit is 1, then it will put the left difficulty switch to A (otherwise leave it on B)
       * If the second bit is 1, then it will put the right difficulty switch to A (otherwise leave it on B)
       *
       * This change takes effect at the immediate next time step.
       */
-    void setDifficulty(difficulty_t value);
+  void setDifficulty(difficulty_t value);
 
-    /** Set the game mode according to the value. The new mode will not take effect until reset() is
+  /** Set the game mode according to the value. The new mode will not take effect until reset() is
       * called */
-    void setMode(game_mode_t value);
+  void setMode(game_mode_t value);
 
-    /** Returns true once we reach a terminal state */
-    bool isTerminal() const;
+  /** Returns true once we reach a terminal state */
+  bool isTerminal() const;
 
-    /** Accessor methods for the environment state. */
-    void setState(const ALEState & state);
-    const ALEState &getState() const;
+  /** Accessor methods for the environment state. */
+  void setState(const ALEState& state);
+  const ALEState& getState() const;
 
-    /** Returns the current screen after processing (e.g. colour averaging) */
-    const ALEScreen &getScreen() const { return m_screen; }
-    const ALERAM &getRAM() const { return m_ram; }
+  /** Returns the current screen after processing (e.g. colour averaging) */
+  const ALEScreen& getScreen() const { return m_screen; }
+  const ALERAM& getRAM() const { return m_ram; }
 
-    int getFrameNumber() const { return m_state.getFrameNumber(); }
-    int getEpisodeFrameNumber() const { return m_state.getEpisodeFrameNumber(); }
+  int getFrameNumber() const { return m_state.getFrameNumber(); }
+  int getEpisodeFrameNumber() const { return m_state.getEpisodeFrameNumber(); }
 
-    /** Returns a wrapper providing #include-free access to our methods. */
-    std::unique_ptr<StellaEnvironmentWrapper> getWrapper();
+  /** Returns a wrapper providing #include-free access to our methods. */
+  std::unique_ptr<StellaEnvironmentWrapper> getWrapper();
 
-  private:
-    /** This applies an action exactly one time step. Helper function to act(). */
-    reward_t oneStepAct(Action player_a_action, Action player_b_action);
+ private:
+  /** This applies an action exactly one time step. Helper function to act(). */
+  reward_t oneStepAct(Action player_a_action, Action player_b_action);
 
-    /** Actually emulates the emulator for a given number of steps. */
-    void emulate(Action player_a_action, Action player_b_action, size_t num_steps = 1);
+  /** Actually emulates the emulator for a given number of steps. */
+  void emulate(Action player_a_action, Action player_b_action,
+               size_t num_steps = 1);
 
-    /** Drops illegal actions, such as the fire button in skiing. Note that this is different
+  /** Drops illegal actions, such as the fire button in skiing. Note that this is different
       *   from the minimal set of actions. */
-    void noopIllegalActions(Action& player_a_action, Action& player_b_action);
+  void noopIllegalActions(Action& player_a_action, Action& player_b_action);
 
-    /** Processes the current emulator screen and saves it in m_screen */
-    void processScreen();
-    /** Processes the emulator RAM and saves it in m_ram */
-    void processRAM();
+  /** Processes the current emulator screen and saves it in m_screen */
+  void processScreen();
+  /** Processes the emulator RAM and saves it in m_ram */
+  void processRAM();
 
-  private:
-    OSystem *m_osystem;
-    RomSettings *m_settings;
-    PhosphorBlend m_phosphor_blend; // For performing phosphor colour averaging, if so desired
-    std::string m_cartridge_md5; // Necessary for saving and loading emulator state
+ private:
+  OSystem* m_osystem;
+  RomSettings* m_settings;
+  PhosphorBlend m_phosphor_blend; // For performing phosphor colour averaging, if so desired
+  std::string m_cartridge_md5; // Necessary for saving and loading emulator state
 
-    std::stack<ALEState> m_saved_states; // States are saved on a stack
+  std::stack<ALEState> m_saved_states; // States are saved on a stack
 
-    ALEState m_state; // Current environment state
-    ALEScreen m_screen; // The current ALE screen (possibly colour-averaged)
-    ALERAM m_ram; // The current ALE RAM
+  ALEState m_state;   // Current environment state
+  ALEScreen m_screen; // The current ALE screen (possibly colour-averaged)
+  ALERAM m_ram;       // The current ALE RAM
 
-    bool m_use_paddles;  // Whether this game uses paddles
+  bool m_use_paddles; // Whether this game uses paddles
 
-    /** Parameters loaded from Settings. */
-    int m_num_reset_steps; // Number of RESET frames per reset
-    bool m_colour_averaging; // Whether to average frames
-    int m_max_num_frames_per_episode; // Maxmimum number of frames per episode
-    size_t m_frame_skip; // How many frames to emulate per act()
-    float m_repeat_action_probability; // Stochasticity of the environment
-    std::unique_ptr<ScreenExporter> m_screen_exporter; // Automatic screen recorder
+  /** Parameters loaded from Settings. */
+  int m_num_reset_steps;             // Number of RESET frames per reset
+  bool m_colour_averaging;           // Whether to average frames
+  int m_max_num_frames_per_episode;  // Maxmimum number of frames per episode
+  size_t m_frame_skip;               // How many frames to emulate per act()
+  float m_repeat_action_probability; // Stochasticity of the environment
+  std::unique_ptr<ScreenExporter> m_screen_exporter; // Automatic screen recorder
 
-    // The last actions taken by our players
-    Action m_player_a_action, m_player_b_action;
+  // The last actions taken by our players
+  Action m_player_a_action, m_player_b_action;
 };
 
-#endif // __STELLA_ENVIRONMENT_HPP__
+#endif  // __STELLA_ENVIRONMENT_HPP__

--- a/src/environment/stella_environment_wrapper.cpp
+++ b/src/environment/stella_environment_wrapper.cpp
@@ -1,18 +1,17 @@
 #include "stella_environment.hpp"
 #include "stella_environment_wrapper.hpp"
 
-StellaEnvironmentWrapper::StellaEnvironmentWrapper(StellaEnvironment &environment) :
-    m_environment(environment) {
+StellaEnvironmentWrapper::StellaEnvironmentWrapper(
+    StellaEnvironment& environment)
+    : m_environment(environment) {}
+
+reward_t StellaEnvironmentWrapper::act(Action player_a_action,
+                                       Action player_b_action) {
+  return m_environment.act(player_a_action, player_b_action);
 }
 
-reward_t StellaEnvironmentWrapper::act(Action player_a_action, Action player_b_action) {
-    return m_environment.act(player_a_action, player_b_action);
-}
-
-void StellaEnvironmentWrapper::softReset() {
-    m_environment.softReset();
-}
+void StellaEnvironmentWrapper::softReset() { m_environment.softReset(); }
 
 void StellaEnvironmentWrapper::pressSelect(size_t num_steps) {
-    m_environment.pressSelect(num_steps);
+  m_environment.pressSelect(num_steps);
 }

--- a/src/environment/stella_environment_wrapper.hpp
+++ b/src/environment/stella_environment_wrapper.hpp
@@ -25,13 +25,13 @@ class StellaEnvironmentWrapper {
   // A wrapper for actions within the StellaEnvironment.
   // Allows us to call environment methods without requiring to #include
   // stella_environment.hpp.
-  public:
-    StellaEnvironmentWrapper(StellaEnvironment &environment);
-    reward_t act(Action player_a_action, Action player_b_action);
-    void softReset();
-    void pressSelect(size_t num_steps = 1);
+ public:
+  StellaEnvironmentWrapper(StellaEnvironment& environment);
+  reward_t act(Action player_a_action, Action player_b_action);
+  void softReset();
+  void pressSelect(size_t num_steps = 1);
 
-    StellaEnvironment &m_environment;
+  StellaEnvironment& m_environment;
 };
 
-#endif // __STELLA_ENVIRONMENT_WRAPPER_HPP__
+#endif  // __STELLA_ENVIRONMENT_WRAPPER_HPP__

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,11 +23,11 @@
 #include "emucore/OSystem.hxx"
 
 #if (defined(WIN32) || defined(__MINGW32__))
-#   include "os_dependent/SettingsWin32.hxx"
-#   include "os_dependent/OSystemWin32.hxx"
+#include "os_dependent/SettingsWin32.hxx"
+#include "os_dependent/OSystemWin32.hxx"
 #else
-#   include "os_dependent/SettingsUNIX.hxx"
-#   include "os_dependent/OSystemUNIX.hxx"
+#include "os_dependent/SettingsUNIX.hxx"
+#include "os_dependent/OSystemUNIX.hxx"
 #endif
 
 #include "controllers/ale_controller.hpp"
@@ -41,23 +41,21 @@ static std::unique_ptr<OSystem> theOSystem;
 static std::unique_ptr<Settings> theSettings;
 
 static ALEController* createController(OSystem* osystem, std::string type) {
-  if(type.empty()){
-    std::cerr << "You must specify a controller type (via -game_controller)." << std::endl;
+  if (type.empty()) {
+    std::cerr << "You must specify a controller type (via -game_controller)."
+              << std::endl;
     exit(1);
-  }
-  else if (type == "fifo") {
+  } else if (type == "fifo") {
     std::cerr << "Game will be controlled through FIFO pipes." << std::endl;
     return new FIFOController(osystem, false);
-  }
-  else if (type == "fifo_named") {
-    std::cerr << "Game will be controlled through named FIFO pipes." << std::endl;
+  } else if (type == "fifo_named") {
+    std::cerr << "Game will be controlled through named FIFO pipes."
+              << std::endl;
     return new FIFOController(osystem, true);
-  }
-  else if (type == "rlglue") {
+  } else if (type == "rlglue") {
     std::cerr << "Game will be controlled through RL-Glue." << std::endl;
     return new RLGlueController(osystem);
-  }
-  else {
+  } else {
     std::cerr << "Invalid controller type: " << type << " " << std::endl;
     exit(1);
   }
@@ -65,7 +63,6 @@ static ALEController* createController(OSystem* osystem, std::string type) {
 
 /* application entry point */
 int main(int argc, char* argv[]) {
-
   ALEInterface::disableBufferedIO();
 
   std::cerr << ALEInterface::welcomeMessage() << std::endl;
@@ -77,8 +74,10 @@ int main(int argc, char* argv[]) {
   ALEInterface::loadSettings(romfile, theOSystem);
 
   // Create the game controller
-  std::string controller_type = theOSystem->settings().getString("game_controller");
-  std::unique_ptr<ALEController> controller(createController(theOSystem.get(), controller_type));
+  std::string controller_type =
+      theOSystem->settings().getString("game_controller");
+  std::unique_ptr<ALEController> controller(
+      createController(theOSystem.get(), controller_type));
 
   controller->run();
 


### PR DESCRIPTION
This change only modifies whitespace (and adds one or two #ifdef
comments). The reformatting is based on clang-format, with manual
review and tweaking.

The goal to harmonize the source code formatting, which is currently
using a variety of local styles. The chosen format is a "compact"
one (as per clang-format default): 2-space indent, Egyptian braces.
Nonetheless, vertical whitespace has been adjusted generously, so as
to have line comments preceded by a blank line for easy visual
segmentation.