### PR TITLE
[ale_state] Makes "paddle min/max" configurable.

### DIFF
--- a/src/environment/ale_state.hpp
+++ b/src/environment/ale_state.hpp
@@ -108,6 +108,9 @@ class ALEState {
     /** Sets the paddle to a given position */
     void setPaddles(Event* event_obj, int left, int right);
 
+    /** Set the paddle min/max values */
+    void setPaddleLimits(int paddle_min_val, int paddle_max_val);
+
     /** Updates the paddle position by a delta amount. */
     void updatePaddlePositions(Event* event_obj, int delta_x, int delta_y);
 
@@ -120,6 +123,9 @@ class ALEState {
   private:
     int m_left_paddle;   // Current value for the left-paddle
     int m_right_paddle;  // Current value for the right-paddle
+
+    int m_paddle_min;    // Minimum value for paddle
+    int m_paddle_max;    // Maximum value for paddle
 
     int m_frame_number; // How many frames since the start
     int m_episode_frame_number; // How many frames since the beginning of this episode

--- a/src/environment/stella_environment.cpp
+++ b/src/environment/stella_environment.cpp
@@ -32,6 +32,10 @@ StellaEnvironment::StellaEnvironment(OSystem* osystem, RomSettings* settings):
   if (m_osystem->console().properties().get(Controller_Left) == "PADDLES" ||
       m_osystem->console().properties().get(Controller_Right) == "PADDLES") {
     m_use_paddles = true;
+    int paddle_min_val = m_osystem->settings().getInt("paddle_min");
+    int paddle_max_val = m_osystem->settings().getInt("paddle_max");
+    m_state.setPaddleLimits(paddle_min_val != -1 ? paddle_min_val : PADDLE_MIN,
+                            paddle_max_val != -1 ? paddle_max_val : PADDLE_MAX);
     m_state.resetPaddles(m_osystem->event());
   } else {
     m_use_paddles = false;


### PR DESCRIPTION
Previously, the values were hardcoded macros. Those are retained as
the default value, but the effective values may now be set
programmatically.

This changes the serialization format (the paddle values now appear as
the last two values).