### PR TITLE
Reformat games ALE files

### DIFF
--- a/src/games/RomSettings.cpp
+++ b/src/games/RomSettings.cpp
@@ -19,7 +19,6 @@
 
 RomSettings::RomSettings() {}
 
-
 bool RomSettings::isLegal(const Action& a) const {
   return true;
 }
@@ -54,7 +53,7 @@ ModeVect RomSettings::getAvailableModes() {
 
 void RomSettings::setMode(game_mode_t m, System&, std::unique_ptr<StellaEnvironmentWrapper>) {
   //By default, 0 is the only available mode
-  if(m != 0) {
+  if (m != 0) {
     throw std::runtime_error("This mode is not currently available for this game");
   }
 }

--- a/src/games/RomSettings.hpp
+++ b/src/games/RomSettings.hpp
@@ -1,4 +1,4 @@
-  /* *****************************************************************************
+/* *****************************************************************************
  * The line 78 is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
@@ -46,68 +46,69 @@ class System;
 
 // rom support interface
 class RomSettings {
+ public:
+  RomSettings();
 
-public:
-    RomSettings();
+  virtual ~RomSettings() {}
 
-    virtual ~RomSettings() {}
+  // reset
+  virtual void reset() {}
 
-    // reset
-    virtual void reset(){};
+  // is end of game
+  virtual bool isTerminal() const = 0;
 
-    // is end of game
-    virtual bool isTerminal() const = 0;
+  // get the most recently observed reward
+  virtual reward_t getReward() const = 0;
 
-    // get the most recently observed reward
-    virtual reward_t getReward() const = 0;
+  // the rom-name
+  virtual const char* rom() const = 0;
 
-    // the rom-name
-    virtual const char *rom() const = 0;
+  // create a new instance of the rom
+  virtual RomSettings* clone() const = 0;
 
-    // create a new instance of the rom
-    virtual RomSettings *clone() const = 0;
+  // is an action part of the minimal set?
+  virtual bool isMinimal(const Action& a) const = 0;
 
-    // is an action part of the minimal set?
-    virtual bool isMinimal(const Action &a) const = 0;
+  // process the latest information from ALE
+  virtual void step(const System& system) = 0;
 
-    // process the latest information from ALE
-    virtual void step(const System &system) = 0;
+  // saves the state of the rom settings
+  virtual void saveState(Serializer& ser) = 0;
 
-    // saves the state of the rom settings
-    virtual void saveState(Serializer & ser) = 0;
+  // loads the state of the rom settings
+  virtual void loadState(Deserializer& ser) = 0;
 
-    // loads the state of the rom settings
-    virtual void loadState(Deserializer & ser) = 0;
+  // is an action legal (default: yes)
+  virtual bool isLegal(const Action& a) const;
 
-    // is an action legal (default: yes)
-    virtual bool isLegal(const Action &a) const;
+  // Remaining lives.
+  virtual int lives() {
+    return isTerminal() ? 0 : 1;
+  }
 
-    // Remaining lives.
-    virtual int lives() { return isTerminal() ? 0 : 1; }
+  // Returns a restricted (minimal) set of actions. If not overriden, this is all actions.
+  virtual ActionVect getMinimalActionSet();
 
-    // Returns a restricted (minimal) set of actions. If not overriden, this is all actions.
-    virtual ActionVect getMinimalActionSet();
+  // Returns the set of all legal actions
+  ActionVect getAllActions();
 
-    // Returns the set of all legal actions
-    ActionVect getAllActions();
+  // Returns a list of actions that are required to start the game.
+  // By default this is an empty list.
+  virtual ActionVect getStartingActions();
 
-    // Returns a list of actions that are required to start the game.
-    // By default this is an empty list.
-    virtual ActionVect getStartingActions();
+  // Returns a list of mode that the game can be played in.
+  // By default, there is only one available mode.
+  virtual ModeVect getAvailableModes();
 
-    // Returns a list of mode that the game can be played in.
-    // By default, there is only one available mode.
-    virtual ModeVect getAvailableModes();
+  // Set the mode of the game. The given mode must be
+  // one returned by the previous function.
+  virtual void setMode(
+      game_mode_t, System& system,
+      std::unique_ptr<StellaEnvironmentWrapper> environment);
 
-    // Set the mode of the game. The given mode must be
-    // one returned by the previous function.
-    virtual void setMode(game_mode_t, System &system,
-                         std::unique_ptr<StellaEnvironmentWrapper> environment);
-
-    // Returns a list of difficulties that the game can be played in.
-    // By default, there is only one available difficulty.
-    virtual DifficultyVect getAvailableDifficulties();
+  // Returns a list of difficulties that the game can be played in.
+  // By default, there is only one available difficulty.
+  virtual DifficultyVect getAvailableDifficulties();
 };
 
-
-#endif // __ROMSETTINGS_HPP__
+#endif  // __ROMSETTINGS_HPP__

--- a/src/games/RomUtils.cpp
+++ b/src/games/RomUtils.cpp
@@ -18,56 +18,50 @@
 
 #include "System.hxx"
 
-
 /* reads a byte at a memory location between 0 and 128 */
 int readRam(const System* system, int offset) {
+  // peek modifies data-bus state, but is logically const from
+  // the point of view of the RL interface
+  System* sys = const_cast<System*>(system);
 
-    // peek modifies data-bus state, but is logically const from
-    // the point of view of the RL interface
-    System* sys = const_cast<System*>(system);
-
-    return sys->peek((offset & 0x7F) + 0x80);
+  return sys->peek((offset & 0x7F) + 0x80);
 }
 
 /* extracts a decimal value from a byte */
 int getDecimalScore(int index, const System* system) {
+  int score = 0;
+  int digits_val = readRam(system, index);
+  int right_digit = digits_val & 15;
+  int left_digit = digits_val >> 4;
+  score += ((10 * left_digit) + right_digit);
 
-    int score = 0;
-    int digits_val = readRam(system, index);
-    int right_digit = digits_val & 15;
-    int left_digit = digits_val >> 4;
-    score += ((10 * left_digit) + right_digit);
-
-    return score;
+  return score;
 }
-
 
 /* extracts a decimal value from 2 bytes */
 int getDecimalScore(int lower_index, int higher_index, const System* system) {
-
-    int score = 0;
-    int lower_digits_val = readRam(system, lower_index);
-    int lower_right_digit = lower_digits_val & 15;
-    int lower_left_digit = (lower_digits_val - lower_right_digit) >> 4;
-    score += ((10 * lower_left_digit) + lower_right_digit);
-    if (higher_index < 0) {
-        return score;
-    }
-    int higher_digits_val = readRam(system, higher_index);
-    int higher_right_digit = higher_digits_val & 15;
-    int higher_left_digit = (higher_digits_val - higher_right_digit) >> 4;
-    score += ((1000 * higher_left_digit) + 100 * higher_right_digit);
+  int score = 0;
+  int lower_digits_val = readRam(system, lower_index);
+  int lower_right_digit = lower_digits_val & 15;
+  int lower_left_digit = (lower_digits_val - lower_right_digit) >> 4;
+  score += ((10 * lower_left_digit) + lower_right_digit);
+  if (higher_index < 0) {
     return score;
+  }
+  int higher_digits_val = readRam(system, higher_index);
+  int higher_right_digit = higher_digits_val & 15;
+  int higher_left_digit = (higher_digits_val - higher_right_digit) >> 4;
+  score += ((1000 * higher_left_digit) + 100 * higher_right_digit);
+  return score;
 }
 
-
 /* extracts a decimal value from 3 bytes */
-int getDecimalScore(int lower_index, int middle_index, int higher_index, const System* system) {
-
-    int score = getDecimalScore(lower_index, middle_index, system);
-    int higher_digits_val = readRam(system, higher_index);
-    int higher_right_digit = higher_digits_val & 15;
-    int higher_left_digit = (higher_digits_val - higher_right_digit) >> 4;
-    score += ((100000 * higher_left_digit) + 10000 * higher_right_digit);
-    return score;
+int getDecimalScore(int lower_index, int middle_index, int higher_index,
+                    const System* system) {
+  int score = getDecimalScore(lower_index, middle_index, system);
+  int higher_digits_val = readRam(system, higher_index);
+  int higher_right_digit = higher_digits_val & 15;
+  int higher_left_digit = (higher_digits_val - higher_right_digit) >> 4;
+  score += ((100000 * higher_left_digit) + 10000 * higher_right_digit);
+  return score;
 }

--- a/src/games/RomUtils.hpp
+++ b/src/games/RomUtils.hpp
@@ -27,4 +27,4 @@ extern int getDecimalScore(int idx, const System* system);
 extern int getDecimalScore(int lo, int hi, const System* system);
 extern int getDecimalScore(int lo, int mid, int hi, const System* system);
 
-#endif // __ROMUTILS_HPP__
+#endif  // __ROMUTILS_HPP__

--- a/src/games/Roms.cpp
+++ b/src/games/Roms.cpp
@@ -90,9 +90,8 @@
 #include "supported/YarsRevenge.hpp"
 #include "supported/Zaxxon.hpp"
 
-
 /* list of supported games */
-static const RomSettings *roms[]  = {
+static const RomSettings* roms[] = {
     new AdventureSettings(),
     new AirRaidSettings(),
     new AlienSettings(),
@@ -171,19 +170,18 @@ static const RomSettings *roms[]  = {
     new ZaxxonSettings(),
 };
 
-
 /* looks for the RL wrapper corresponding to a particular rom title */
-RomSettings *buildRomRLWrapper(const std::string &rom) {
+RomSettings* buildRomRLWrapper(const std::string& rom) {
+  size_t slash_ind = rom.find_last_of("/\\");
+  std::string rom_str = rom.substr(slash_ind + 1);
+  size_t dot_idx = rom_str.find_first_of(".");
+  rom_str = rom_str.substr(0, dot_idx);
+  std::transform(rom_str.begin(), rom_str.end(), rom_str.begin(), ::tolower);
 
-    size_t slash_ind = rom.find_last_of("/\\");
-    std::string rom_str = rom.substr(slash_ind + 1);
-    size_t dot_idx = rom_str.find_first_of(".");
-    rom_str = rom_str.substr(0, dot_idx);
-    std::transform(rom_str.begin(), rom_str.end(), rom_str.begin(), ::tolower);
+  for (size_t i = 0; i < sizeof(roms) / sizeof(roms[0]); i++) {
+    if (rom_str == roms[i]->rom())
+      return roms[i]->clone();
+  }
 
-    for (size_t i=0; i < sizeof(roms)/sizeof(roms[0]); i++) {
-        if (rom_str == roms[i]->rom()) return roms[i]->clone();
-    }
-
-    return NULL;
+  return NULL;
 }

--- a/src/games/Roms.hpp
+++ b/src/games/Roms.hpp
@@ -12,12 +12,11 @@
 #ifndef __ROMS_HPP__
 #define __ROMS_HPP__
 
-#include "RomSettings.hpp"
-
 #include <string>
 
+#include "RomSettings.hpp"
+
 // looks for the RL wrapper corresponding to a particular rom title
-extern RomSettings *buildRomRLWrapper(const std::string &rom);
+extern RomSettings* buildRomRLWrapper(const std::string& rom);
 
-
-#endif // __ROMS_HPP__
+#endif  // __ROMS_HPP__

--- a/src/games/supported/Adventure.cpp
+++ b/src/games/supported/Adventure.cpp
@@ -27,14 +27,10 @@
 
 #include "../RomUtils.hpp"
 
-AdventureSettings::AdventureSettings() {
-
-  reset();
-}
+AdventureSettings::AdventureSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* AdventureSettings::clone() const {
-
   RomSettings* rval = new AdventureSettings();
   *rval = *this;
   return rval;
@@ -42,7 +38,6 @@ RomSettings* AdventureSettings::clone() const {
 
 /* process the latest information from ALE */
 void AdventureSettings::step(const System& system) {
-
   int chalice_status = readRam(&system, 0xB9);
   bool chalice_in_yellow_castle = chalice_status == 0x12;
 
@@ -57,67 +52,59 @@ void AdventureSettings::step(const System& system) {
 }
 
 /* is end of game */
-bool AdventureSettings::isTerminal() const {
-
-  return m_terminal;
-}
+bool AdventureSettings::isTerminal() const { return m_terminal; }
 
 /* get the most recently observed reward */
-reward_t AdventureSettings::getReward() const {
-
-  return m_reward;
-}
+reward_t AdventureSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool AdventureSettings::isMinimal(const Action &a) const {
-
+bool AdventureSettings::isMinimal(const Action& a) const {
   switch (a) {
-  case PLAYER_A_NOOP:
-  case PLAYER_A_FIRE:
-  case PLAYER_A_UP:
-  case PLAYER_A_RIGHT:
-  case PLAYER_A_LEFT:
-  case PLAYER_A_DOWN:
-  case PLAYER_A_UPRIGHT:
-  case PLAYER_A_UPLEFT:
-  case PLAYER_A_DOWNRIGHT:
-  case PLAYER_A_DOWNLEFT:
-  case PLAYER_A_UPFIRE:
-  case PLAYER_A_RIGHTFIRE:
-  case PLAYER_A_LEFTFIRE:
-  case PLAYER_A_DOWNFIRE:
-  case PLAYER_A_UPRIGHTFIRE:
-  case PLAYER_A_UPLEFTFIRE:
-  case PLAYER_A_DOWNRIGHTFIRE:
-  case PLAYER_A_DOWNLEFTFIRE:
-    return true;
-  default:
-    return false;
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_UP:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_DOWN:
+    case PLAYER_A_UPRIGHT:
+    case PLAYER_A_UPLEFT:
+    case PLAYER_A_DOWNRIGHT:
+    case PLAYER_A_DOWNLEFT:
+    case PLAYER_A_UPFIRE:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_LEFTFIRE:
+    case PLAYER_A_DOWNFIRE:
+    case PLAYER_A_UPRIGHTFIRE:
+    case PLAYER_A_UPLEFTFIRE:
+    case PLAYER_A_DOWNRIGHTFIRE:
+    case PLAYER_A_DOWNLEFTFIRE:
+      return true;
+    default:
+      return false;
   }
 }
 
 /* reset the state of the game */
 void AdventureSettings::reset() {
-
   m_reward = 0;
   m_terminal = false;
 }
 
 /* saves the state of the rom settings */
-void AdventureSettings::saveState(Serializer & ser) {
+void AdventureSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putBool(m_terminal);
 }
 
 // loads the state of the rom settings
-void AdventureSettings::loadState(Deserializer & ser) {
+void AdventureSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_terminal = ser.getBool();
 }
 
 // Returns the supported modes for the game.
 ModeVect AdventureSettings::getAvailableModes() {
-    return ModeVect() = {0, 1, 2};
+  return ModeVect() = {0, 1, 2};
 }
 
 // Set the game mode.
@@ -133,25 +120,25 @@ ModeVect AdventureSettings::getAvailableModes() {
 //   low byte of its internal frame counter at RAM address 0xE5 to seed the rng.
 //   Due to the way game modes are set below this will always be the same value
 //   at present so only 1/256 randomised configuration is available.
-void AdventureSettings::setMode(game_mode_t m, System &system,
+void AdventureSettings::setMode(
+    game_mode_t m, System& system,
     std::unique_ptr<StellaEnvironmentWrapper> environment) {
-
-    if (m < 3) {
-        // Read the mode we are currently in.
-        unsigned char mode = (readRam(&system, 0xDD) >> 1) & 0x03;
-        // Press select until the correct mode is reached.
-        while (mode != m) {
-            environment->pressSelect(2);
-            // Adventure uses a debouncer so need to wait before the select
-            // take effect.
-            environment->act(PLAYER_A_NOOP, PLAYER_B_NOOP);
-            mode = (readRam(&system, 0xDD) >> 1) & 0x03;
-        }
-        // Reset the environment to apply changes.
-        environment->softReset();
-    } else {
-        throw std::runtime_error("This game mode is not supported.");
+  if (m < 3) {
+    // Read the mode we are currently in.
+    unsigned char mode = (readRam(&system, 0xDD) >> 1) & 0x03;
+    // Press select until the correct mode is reached.
+    while (mode != m) {
+      environment->pressSelect(2);
+      // Adventure uses a debouncer so need to wait before the select
+      // take effect.
+      environment->act(PLAYER_A_NOOP, PLAYER_B_NOOP);
+      mode = (readRam(&system, 0xDD) >> 1) & 0x03;
     }
+    // Reset the environment to apply changes.
+    environment->softReset();
+  } else {
+    throw std::runtime_error("This game mode is not supported.");
+  }
 }
 
 // Return the supported difficulty settings for the game.
@@ -159,5 +146,5 @@ void AdventureSettings::setMode(game_mode_t m, System &system,
 // one difficulty switch controls controls the dragons' bite speed, and one
 // causes them to flee when the player is wielding the sword.
 DifficultyVect AdventureSettings::getAvailableDifficulties() {
-    return DifficultyVect() = {0, 1, 2, 3};
+  return DifficultyVect() = {0, 1, 2, 3};
 }

--- a/src/games/supported/Adventure.hpp
+++ b/src/games/supported/Adventure.hpp
@@ -28,58 +28,54 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Adventure settings */
 class AdventureSettings : public RomSettings {
+ public:
+  AdventureSettings();
 
-    public:
+  // reset
+  void reset();
 
-        AdventureSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "adventure"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // the rom-name
-        const char* rom() const { return "adventure"; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  virtual int lives() { return 1; }
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  // Return the supported game modes.
+  ModeVect getAvailableModes();
 
-        virtual int lives() { return 1; }
+  // Set the game mode.
+  // The given mode must be one returned by the previous function.
+  void setMode(game_mode_t, System& system,
+               std::unique_ptr<StellaEnvironmentWrapper> environment);
 
-        // Return the supported game modes.
-        ModeVect getAvailableModes();
+  // Return the supported difficulty settings for the game.
+  virtual DifficultyVect getAvailableDifficulties();
 
-        // Set the game mode.
-        // The given mode must be one returned by the previous function.
-        void setMode(game_mode_t, System &system,
-                     std::unique_ptr<StellaEnvironmentWrapper> environment);
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+};
 
-        // Return the supported difficulty settings for the game.
-        virtual DifficultyVect getAvailableDifficulties();
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
- };
-
-#endif // __ADVENTURE_HPP__
+#endif  // __ADVENTURE_HPP__

--- a/src/games/supported/AirRaid.cpp
+++ b/src/games/supported/AirRaid.cpp
@@ -13,128 +13,106 @@
 
 #include "../RomUtils.hpp"
 
-
-AirRaidSettings::AirRaidSettings() {
-
-    reset();
-}
-
+AirRaidSettings::AirRaidSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* AirRaidSettings::clone() const {
-
-    RomSettings* rval = new AirRaidSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new AirRaidSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void AirRaidSettings::step(const System& system) {
+  // update the reward
+  reward_t score = getDecimalScore(0xAA, 0xA9, 0xA8, &system);
+  m_reward = score - m_score;
+  m_score = score;
 
-    // update the reward
-    reward_t score = getDecimalScore(0xAA, 0xA9, 0xA8, &system);
-    m_reward = score - m_score;
-    m_score = score;
-
-    // update terminal status
-    int lives = readRam(&system, 0xA7);
-    m_terminal = lives == 0xFF;
+  // update terminal status
+  int lives = readRam(&system, 0xA7);
+  m_terminal = lives == 0xFF;
 }
-
 
 /* is end of game */
-bool AirRaidSettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool AirRaidSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t AirRaidSettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t AirRaidSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool AirRaidSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_LEFTFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool AirRaidSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_LEFTFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void AirRaidSettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
 }
 
 /* saves the state of the rom settings */
-void AirRaidSettings::saveState(Serializer & ser) {
+void AirRaidSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
 }
 
 // loads the state of the rom settings
-void AirRaidSettings::loadState(Deserializer & ser) {
+void AirRaidSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();
 }
 
 ActionVect AirRaidSettings::getStartingActions() {
-    ActionVect startingActions;
-    startingActions.push_back(PLAYER_A_FIRE);
-    return startingActions;
+  ActionVect startingActions;
+  startingActions.push_back(PLAYER_A_FIRE);
+  return startingActions;
 }
-
 
 // returns a list of mode that the game can be played in
 ModeVect AirRaidSettings::getAvailableModes() {
-    ModeVect modes(getNumModes());
-    for (unsigned int i = 0; i < modes.size(); i++) {
-        modes[i] = i + 1;
-    }
-    return modes;
+  ModeVect modes(getNumModes());
+  for (unsigned int i = 0; i < modes.size(); i++) {
+    modes[i] = i + 1;
+  }
+  return modes;
 }
 
 // set the mode of the game
 // the given mode must be one returned by the previous function
-void AirRaidSettings::setMode(game_mode_t m, System &system,
-                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
-
-    if(m == 0) {
-        m = 1; // the default mode is not valid in this game
+void AirRaidSettings::setMode(
+    game_mode_t m, System& system,
+    std::unique_ptr<StellaEnvironmentWrapper> environment) {
+  if (m == 0) {
+    m = 1; // the default mode is not valid in this game
+  }
+  if (m >= 1 && m <= getNumModes()) {
+    //open the mode selection panel
+    environment->pressSelect(20);
+    // read the mode we are currently in
+    unsigned char mode = readRam(&system, 0xAA);
+    // press select until the correct mode is reached
+    while (mode != m) {
+      // hold select button for 10 frames
+      environment->pressSelect(10);
+      mode = readRam(&system, 0xAA);
     }
-    if(m >= 1 && m <= getNumModes()) {
-        //open the mode selection panel
-        environment->pressSelect(20);
-        // read the mode we are currently in
-        unsigned char mode = readRam(&system, 0xAA);
-        // press select until the correct mode is reached
-        while (mode != m) {
-            // hold select button for 10 frames
-            environment->pressSelect(10);
-            mode = readRam(&system, 0xAA);
-        }
-        //reset the environment to apply changes.
-        environment->softReset();
-    }
-    else {
-        throw std::runtime_error("This mode doesn't currently exist for this game");
-    }
- }
+    //reset the environment to apply changes.
+    environment->softReset();
+  } else {
+    throw std::runtime_error("This mode doesn't currently exist for this game");
+  }
+}

--- a/src/games/supported/AirRaid.hpp
+++ b/src/games/supported/AirRaid.hpp
@@ -14,61 +14,56 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Air Raid settings */
 class AirRaidSettings : public RomSettings {
+ public:
+  AirRaidSettings();
 
-    public:
+  // reset
+  void reset();
 
-        AirRaidSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "air_raid"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // get the available number of modes
+  unsigned int getNumModes() const { return 8; }
 
-        // the rom-name
-        const char* rom() const { return "air_raid"; }
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // get the available number of modes
-        unsigned int getNumModes() const { return 8; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  ActionVect getStartingActions();
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  // returns a list of mode that the game can be played in
+  // in this game, there are 8 available modes
+  ModeVect getAvailableModes();
 
-        ActionVect getStartingActions();
+  // set the mode of the game
+  // the given mode must be one returned by the previous function
+  void setMode(game_mode_t, System& system,
+               std::unique_ptr<StellaEnvironmentWrapper> environment);
 
-
-        // returns a list of mode that the game can be played in
-        // in this game, there are 8 available modes
-        ModeVect getAvailableModes();
-
-        // set the mode of the game
-        // the given mode must be one returned by the previous function
-        void setMode(game_mode_t, System &system,
-                     std::unique_ptr<StellaEnvironmentWrapper> environment);
-
-     private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
 };
 
-#endif // __AIRRAID_HPP__
+#endif  // __AIRRAID_HPP__

--- a/src/games/supported/Alien.cpp
+++ b/src/games/supported/Alien.cpp
@@ -28,106 +28,84 @@
 
 #include "../RomUtils.hpp"
 
-
-AlienSettings::AlienSettings() {
-
-    reset();
-}
-
+AlienSettings::AlienSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* AlienSettings::clone() const {
-
-    RomSettings* rval = new AlienSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new AlienSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void AlienSettings::step(const System& system) {
+  // update the reward
+  int b1 = getDigit(system, 0x8B);
+  int b2 = getDigit(system, 0x89);
+  int b3 = getDigit(system, 0x87);
+  int b4 = getDigit(system, 0x85);
+  int b5 = getDigit(system, 0x83);
+  reward_t score = b1 + b2 * 10 + b3 * 100 + b4 * 1000 + b5 * 10000;
+  score *= 10;
+  m_reward = score - m_score;
+  m_score = score;
 
-    // update the reward
-    int b1 = getDigit(system, 0x8B);
-    int b2 = getDigit(system, 0x89);
-    int b3 = getDigit(system, 0x87);
-    int b4 = getDigit(system, 0x85);
-    int b5 = getDigit(system, 0x83);
-    reward_t score = b1 + b2 * 10 + b3 * 100 + b4 * 1000 + b5 * 10000;
-    score *= 10;
-    m_reward = score - m_score;
-    m_score = score;
-
-    // update terminal status
-    int byte = readRam(&system, 0xC0);
-    byte = byte & 15;
-    m_terminal = byte <= 0;
-    m_lives = byte;
+  // update terminal status
+  int byte = readRam(&system, 0xC0);
+  byte = byte & 15;
+  m_terminal = byte <= 0;
+  m_lives = byte;
 }
-
 
 /* is end of game */
-bool AlienSettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool AlienSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t AlienSettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t AlienSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool AlienSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_UP:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_DOWN:
-        case PLAYER_A_UPRIGHT:
-        case PLAYER_A_UPLEFT:
-        case PLAYER_A_DOWNRIGHT:
-        case PLAYER_A_DOWNLEFT:
-        case PLAYER_A_UPFIRE:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_LEFTFIRE:
-        case PLAYER_A_DOWNFIRE:
-        case PLAYER_A_UPRIGHTFIRE:
-        case PLAYER_A_UPLEFTFIRE:
-        case PLAYER_A_DOWNRIGHTFIRE:
-        case PLAYER_A_DOWNLEFTFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool AlienSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_UP:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_DOWN:
+    case PLAYER_A_UPRIGHT:
+    case PLAYER_A_UPLEFT:
+    case PLAYER_A_DOWNRIGHT:
+    case PLAYER_A_DOWNLEFT:
+    case PLAYER_A_UPFIRE:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_LEFTFIRE:
+    case PLAYER_A_DOWNFIRE:
+    case PLAYER_A_UPRIGHTFIRE:
+    case PLAYER_A_UPLEFTFIRE:
+    case PLAYER_A_DOWNRIGHTFIRE:
+    case PLAYER_A_DOWNLEFTFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void AlienSettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
-    m_lives    = 3;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
+  m_lives = 3;
 }
-
 
 /* special code to read digits for Alien */
 int AlienSettings::getDigit(const System& system, int address) const {
-
-    int byte = readRam(&system, address);
-    return byte == 0x80 ? 0 : byte >> 3;
+  int byte = readRam(&system, address);
+  return byte == 0x80 ? 0 : byte >> 3;
 }
 
 /* saves the state of the rom settings */
-void AlienSettings::saveState(Serializer & ser) {
+void AlienSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
@@ -135,7 +113,7 @@ void AlienSettings::saveState(Serializer & ser) {
 }
 
 // loads the state of the rom settings
-void AlienSettings::loadState(Deserializer & ser) {
+void AlienSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();
@@ -144,39 +122,38 @@ void AlienSettings::loadState(Deserializer & ser) {
 
 // returns a list of mode that the game can be played in
 ModeVect AlienSettings::getAvailableModes() {
-    ModeVect modes(getNumModes());
-    for (unsigned int i = 0; i < modes.size(); i++) {
-        modes[i] = i;
-    }
-    return modes;
+  ModeVect modes(getNumModes());
+  for (unsigned int i = 0; i < modes.size(); i++) {
+    modes[i] = i;
+  }
+  return modes;
 }
 
 // set the mode of the game
 // the given mode must be one returned by the previous function
-void AlienSettings::setMode(game_mode_t m, System &system,
-                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
-
-    if(m < getNumModes()) {
-        // read the mode we are currently in
-        unsigned char mode = readRam(&system, 0x81);
-        // press select until the correct mode is reached
-        while (mode != m) {
-            environment->pressSelect();
-            mode = readRam(&system, 0x81);
-        }
-        //update the number of lives
-        int byte = readRam(&system, 0xC0);
-        byte = byte & 15;
-        m_lives = byte;
-        //reset the environment to apply changes.
-        environment->softReset();
+void AlienSettings::setMode(
+    game_mode_t m, System& system,
+    std::unique_ptr<StellaEnvironmentWrapper> environment) {
+  if (m < getNumModes()) {
+    // read the mode we are currently in
+    unsigned char mode = readRam(&system, 0x81);
+    // press select until the correct mode is reached
+    while (mode != m) {
+      environment->pressSelect();
+      mode = readRam(&system, 0x81);
     }
-    else {
-        throw std::runtime_error("This mode doesn't currently exist for this game");
-    }
- }
+    //update the number of lives
+    int byte = readRam(&system, 0xC0);
+    byte = byte & 15;
+    m_lives = byte;
+    //reset the environment to apply changes.
+    environment->softReset();
+  } else {
+    throw std::runtime_error("This mode doesn't currently exist for this game");
+  }
+}
 
 DifficultyVect AlienSettings::getAvailableDifficulties() {
-    DifficultyVect diff = {0, 1, 2, 3};
-    return diff;
+  DifficultyVect diff = {0, 1, 2, 3};
+  return diff;
 }

--- a/src/games/supported/Alien.hpp
+++ b/src/games/supported/Alien.hpp
@@ -29,68 +29,64 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Alien settings */
 class AlienSettings : public RomSettings {
+ public:
+  AlienSettings();
 
-    public:
+  // reset
+  void reset();
 
-        AlienSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "alien"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // get the available number of modes
+  unsigned int getNumModes() const { return 4; }
 
-        // the rom-name
-        const char* rom() const { return "alien"; }
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // get the available number of modes
-        unsigned int getNumModes() const { return 4; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  virtual int lives() { return m_lives; }
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  // list of modes that the game can be played in
+  // in this game, there are 4 available modes
+  ModeVect getAvailableModes();
 
-        virtual int lives() { return m_lives; }
+  // set the mode of the game
+  // the given mode must be one returned by the previous function
+  void setMode(game_mode_t, System& system,
+               std::unique_ptr<StellaEnvironmentWrapper> environment);
 
-        // list of modes that the game can be played in
-        // in this game, there are 4 available modes
-        ModeVect getAvailableModes();
+  // returns a list of difficulties that the game can be played in
+  // in this game, there are 4 available difficulties
+  DifficultyVect getAvailableDifficulties();
 
-        // set the mode of the game
-        // the given mode must be one returned by the previous function
-        void setMode(game_mode_t, System &system,
-                     std::unique_ptr<StellaEnvironmentWrapper> environment);
+ private:
+  // special code to read digits for Alien
+  int getDigit(const System& system, int address) const;
 
-        // returns a list of difficulties that the game can be played in
-        // in this game, there are 4 available difficulties
-        DifficultyVect getAvailableDifficulties();
-
-    private:
-
-        // special code to read digits for Alien
-        int getDigit(const System& system, int address) const;
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 };
 
-#endif // __ALIEN_HPP__
+#endif  // __ALIEN_HPP__

--- a/src/games/supported/Amidar.cpp
+++ b/src/games/supported/Amidar.cpp
@@ -28,87 +28,66 @@
 
 #include "../RomUtils.hpp"
 
-
-AmidarSettings::AmidarSettings() {
-
-    reset();
-}
-
+AmidarSettings::AmidarSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* AmidarSettings::clone() const {
-
-    RomSettings* rval = new AmidarSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new AmidarSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void AmidarSettings::step(const System& system) {
+  // update the reward
+  reward_t score = getDecimalScore(0xD9, 0xDA, 0xDB, &system);
+  m_reward = score - m_score;
+  m_score = score;
 
-    // update the reward
-    reward_t score = getDecimalScore(0xD9, 0xDA, 0xDB, &system);
-    m_reward = score - m_score;
-    m_score = score;
+  // update terminal status
+  int livesByte = readRam(&system, 0xD6);
 
-    // update terminal status
-    int livesByte = readRam(&system, 0xD6);
-
-    // MGB it takes one step for the system to reset; this assumes we've
-    //  reset
-    m_terminal = (livesByte == 0x80);
-    m_lives = (livesByte & 0xF);
+  // MGB it takes one step for the system to reset; this assumes we've
+  //  reset
+  m_terminal = (livesByte == 0x80);
+  m_lives = (livesByte & 0xF);
 }
-
 
 /* is end of game */
-bool AmidarSettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool AmidarSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t AmidarSettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t AmidarSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool AmidarSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_UP:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_DOWN:
-        case PLAYER_A_UPFIRE:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_LEFTFIRE:
-        case PLAYER_A_DOWNFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool AmidarSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_UP:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_DOWN:
+    case PLAYER_A_UPFIRE:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_LEFTFIRE:
+    case PLAYER_A_DOWNFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void AmidarSettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
-    m_lives    = 3;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
+  m_lives = 3;
 }
 
-
 /* saves the state of the rom settings */
-void AmidarSettings::saveState(Serializer & ser) {
+void AmidarSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
@@ -116,7 +95,7 @@ void AmidarSettings::saveState(Serializer & ser) {
 }
 
 // loads the state of the rom settings
-void AmidarSettings::loadState(Deserializer & ser) {
+void AmidarSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();
@@ -124,6 +103,6 @@ void AmidarSettings::loadState(Deserializer & ser) {
 }
 
 DifficultyVect AmidarSettings::getAvailableDifficulties() {
-    DifficultyVect diff = {0, 3};
-    return diff;
+  DifficultyVect diff = {0, 3};
+  return diff;
 }

--- a/src/games/supported/Amidar.hpp
+++ b/src/games/supported/Amidar.hpp
@@ -29,53 +29,49 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Amidar settings */
 class AmidarSettings : public RomSettings {
+ public:
+  AmidarSettings();
 
-    public:
+  // reset
+  void reset();
 
-        AmidarSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "amidar"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // the rom-name
-        const char* rom() const { return "amidar"; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  // returns a list of difficulties that the game can be played in
+  // in this game, there are 2 available difficulties
+  DifficultyVect getAvailableDifficulties();
 
-        virtual int lives() { return isTerminal() ? 0 : m_lives; }
-
-        // returns a list of difficulties that the game can be played in
-        // in this game, there are 2 available difficulties
-        DifficultyVect getAvailableDifficulties();
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 };
 
-#endif // __AMIDAR_HPP__
+#endif  // __AMIDAR_HPP__

--- a/src/games/supported/Assault.cpp
+++ b/src/games/supported/Assault.cpp
@@ -28,79 +28,59 @@
 
 #include "../RomUtils.hpp"
 
-
-AssaultSettings::AssaultSettings() {
-
-    reset();
-}
-
+AssaultSettings::AssaultSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* AssaultSettings::clone() const {
-
-    RomSettings* rval = new AssaultSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new AssaultSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void AssaultSettings::step(const System& system) {
+  // update the reward
+  reward_t score = getDecimalScore(0x82, 0x81, 0x80, &system);
+  m_reward = score - m_score;
+  m_score = score;
 
-    // update the reward
-    reward_t score = getDecimalScore(0x82, 0x81, 0x80, &system);
-    m_reward = score - m_score;
-    m_score = score;
-
-    // update terminal status
-    m_lives = readRam(&system, 0xE5);
-    m_terminal = (m_lives == 0);
+  // update terminal status
+  m_lives = readRam(&system, 0xE5);
+  m_terminal = (m_lives == 0);
 }
-
 
 /* is end of game */
-bool AssaultSettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool AssaultSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t AssaultSettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t AssaultSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool AssaultSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_UP:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_LEFTFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool AssaultSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_UP:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_LEFTFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void AssaultSettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
-    m_lives    = 4;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
+  m_lives = 4;
 }
 
 /* saves the state of the rom settings */
-void AssaultSettings::saveState(Serializer & ser) {
+void AssaultSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
@@ -108,7 +88,7 @@ void AssaultSettings::saveState(Serializer & ser) {
 }
 
 // loads the state of the rom settings
-void AssaultSettings::loadState(Deserializer & ser) {
+void AssaultSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();

--- a/src/games/supported/Assault.hpp
+++ b/src/games/supported/Assault.hpp
@@ -29,49 +29,45 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Assault settings */
 class AssaultSettings : public RomSettings {
+ public:
+  AssaultSettings();
 
-    public:
+  // reset
+  void reset();
 
-        AssaultSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "assault"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // the rom-name
-        const char* rom() const { return "assault"; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
-
-        virtual int lives() { return isTerminal() ? 0 : m_lives; }
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 };
 
-#endif // __ASSAULT_HPP__
+#endif  // __ASSAULT_HPP__

--- a/src/games/supported/Asterix.cpp
+++ b/src/games/supported/Asterix.cpp
@@ -28,86 +28,66 @@
 
 #include "../RomUtils.hpp"
 
-
-AsterixSettings::AsterixSettings() {
-
-    reset();
-}
-
+AsterixSettings::AsterixSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* AsterixSettings::clone() const {
-
-    RomSettings* rval = new AsterixSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new AsterixSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void AsterixSettings::step(const System& system) {
+  // update the reward
+  reward_t score = getDecimalScore(0xE0, 0xDF, 0xDE, &system);
+  m_reward = score - m_score;
+  m_score = score;
 
-    // update the reward
-    reward_t score = getDecimalScore(0xE0, 0xDF, 0xDE, &system);
-    m_reward = score - m_score;
-    m_score = score;
+  // update terminal status
+  m_lives = readRam(&system, 0xD3) & 0xF;
+  int death_counter = readRam(&system, 0xC7);
 
-    // update terminal status
-    m_lives = readRam(&system, 0xD3) & 0xF;
-    int death_counter = readRam(&system, 0xC7);
-
-    // we cannot wait for lives to be set to 0, because the agent has the
-    // option of the restarting the game on the very last frame (when lives==1
-    // and death_counter == 0x01) by holding 'fire'
-    m_terminal = (death_counter == 0x01 && m_lives == 1);
+  // we cannot wait for lives to be set to 0, because the agent has the
+  // option of the restarting the game on the very last frame (when lives==1
+  // and death_counter == 0x01) by holding 'fire'
+  m_terminal = (death_counter == 0x01 && m_lives == 1);
 }
-
 
 /* is end of game */
-bool AsterixSettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool AsterixSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t AsterixSettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t AsterixSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool AsterixSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_UP:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_DOWN:
-        case PLAYER_A_UPRIGHT:
-        case PLAYER_A_UPLEFT:
-        case PLAYER_A_DOWNRIGHT:
-        case PLAYER_A_DOWNLEFT:
-            return true;
-        default:
-            return false;
-    }
+bool AsterixSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_UP:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_DOWN:
+    case PLAYER_A_UPRIGHT:
+    case PLAYER_A_UPLEFT:
+    case PLAYER_A_DOWNRIGHT:
+    case PLAYER_A_DOWNLEFT:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void AsterixSettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
-    m_lives    = 3;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
+  m_lives = 3;
 }
 
 /* saves the state of the rom settings */
-void AsterixSettings::saveState(Serializer & ser) {
+void AsterixSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
@@ -115,7 +95,7 @@ void AsterixSettings::saveState(Serializer & ser) {
 }
 
 // loads the state of the rom settings
-void AsterixSettings::loadState(Deserializer & ser) {
+void AsterixSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();
@@ -123,7 +103,7 @@ void AsterixSettings::loadState(Deserializer & ser) {
 }
 
 ActionVect AsterixSettings::getStartingActions() {
-    ActionVect startingActions;
-    startingActions.push_back(PLAYER_A_FIRE);
-    return startingActions;
+  ActionVect startingActions;
+  startingActions.push_back(PLAYER_A_FIRE);
+  return startingActions;
 }

--- a/src/games/supported/Asterix.hpp
+++ b/src/games/supported/Asterix.hpp
@@ -29,52 +29,48 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Asterix */
 class AsterixSettings : public RomSettings {
+ public:
+  AsterixSettings();
 
-    public:
+  // reset
+  void reset();
 
-        AsterixSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "asterix"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // the rom-name
-        const char* rom() const { return "asterix"; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  // Asterix requires the fire action to start the game
+  ActionVect getStartingActions();
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
-        // Asterix requires the fire action to start the game
-        ActionVect getStartingActions();
-
-        virtual int lives() { return isTerminal() ? 0 : m_lives; }
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 };
 
-#endif // __ASTERIX_HPP__
+#endif  // __ASTERIX_HPP__

--- a/src/games/supported/Asteroids.cpp
+++ b/src/games/supported/Asteroids.cpp
@@ -28,95 +28,74 @@
 
 #include "../RomUtils.hpp"
 
-
-AsteroidsSettings::AsteroidsSettings() {
-
-    reset();
-}
-
+AsteroidsSettings::AsteroidsSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* AsteroidsSettings::clone() const {
-
-    RomSettings* rval = new AsteroidsSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new AsteroidsSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void AsteroidsSettings::step(const System& system) {
+  // update the reward
+  reward_t score = getDecimalScore(0xBE, 0xBD, &system);
+  score *= 10;
+  m_reward = score - m_score;
+  // Deal with score wrapping. In truth this should be done for all games and in a more
+  // uniform fashion.
+  if (m_reward < 0) {
+    const int WRAP_SCORE = 100000;
+    m_reward += WRAP_SCORE;
+  }
+  m_score = score;
 
-    // update the reward
-    reward_t score = getDecimalScore(0xBE, 0xBD, &system);
-    score *= 10;
-    m_reward = score - m_score;
-    // Deal with score wrapping. In truth this should be done for all games and in a more
-    // uniform fashion.
-    if (m_reward < 0) {
-        const int WRAP_SCORE = 100000;
-        m_reward += WRAP_SCORE;
-    }
-    m_score = score;
-
-    // update terminal status
-    int byte = readRam(&system, 0xBC);
-    m_lives = (byte - (byte & 15)) >> 4;
-    m_terminal = (m_lives == 0);
+  // update terminal status
+  int byte = readRam(&system, 0xBC);
+  m_lives = (byte - (byte & 15)) >> 4;
+  m_terminal = (m_lives == 0);
 }
-
 
 /* is end of game */
-bool AsteroidsSettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool AsteroidsSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t AsteroidsSettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t AsteroidsSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool AsteroidsSettings::isMinimal(const Action &a) const {
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_UP:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_DOWN:
-        case PLAYER_A_UPRIGHT:
-        case PLAYER_A_UPLEFT:
-        case PLAYER_A_UPFIRE:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_LEFTFIRE:
-        case PLAYER_A_DOWNFIRE:
-        case PLAYER_A_UPRIGHTFIRE:
-        case PLAYER_A_UPLEFTFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool AsteroidsSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_UP:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_DOWN:
+    case PLAYER_A_UPRIGHT:
+    case PLAYER_A_UPLEFT:
+    case PLAYER_A_UPFIRE:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_LEFTFIRE:
+    case PLAYER_A_DOWNFIRE:
+    case PLAYER_A_UPRIGHTFIRE:
+    case PLAYER_A_UPLEFTFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void AsteroidsSettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
-    m_lives    = 4;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
+  m_lives = 4;
 }
 
-
-
 /* saves the state of the rom settings */
-void AsteroidsSettings::saveState(Serializer & ser) {
+void AsteroidsSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
@@ -124,7 +103,7 @@ void AsteroidsSettings::saveState(Serializer & ser) {
 }
 
 // loads the state of the rom settings
-void AsteroidsSettings::loadState(Deserializer & ser) {
+void AsteroidsSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();
@@ -133,36 +112,35 @@ void AsteroidsSettings::loadState(Deserializer & ser) {
 
 // returns a list of mode that the game can be played in
 ModeVect AsteroidsSettings::getAvailableModes() {
-    ModeVect modes(getNumModes() - 1);
-    for (unsigned int i = 0; i < modes.size(); i++) {
-        modes[i] = i;
-    }
-    modes.push_back(0x80); //this is the "kids" mode
-    return modes;
+  ModeVect modes(getNumModes() - 1);
+  for (unsigned int i = 0; i < modes.size(); i++) {
+    modes[i] = i;
+  }
+  modes.push_back(0x80); //this is the "kids" mode
+  return modes;
 }
 
 // set the mode of the game
 // the given mode must be one returned by the previous function
-void AsteroidsSettings::setMode(game_mode_t m, System &system,
-                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
-
-    if(m < 32 || m == 0x80) {
-        // read the mode we are currently in
-        unsigned char mode = readRam(&system, 0x80);
-        // press select until the correct mode is reached
-        while (mode != m) {
-            environment->pressSelect(2);
-            mode = readRam(&system, 0x80);
-        }
-        //reset the environment to apply changes.
-        environment->softReset();
+void AsteroidsSettings::setMode(
+    game_mode_t m, System& system,
+    std::unique_ptr<StellaEnvironmentWrapper> environment) {
+  if (m < 32 || m == 0x80) {
+    // read the mode we are currently in
+    unsigned char mode = readRam(&system, 0x80);
+    // press select until the correct mode is reached
+    while (mode != m) {
+      environment->pressSelect(2);
+      mode = readRam(&system, 0x80);
     }
-    else {
-        throw std::runtime_error("This mode doesn't currently exist for this game");
-    }
- }
+    //reset the environment to apply changes.
+    environment->softReset();
+  } else {
+    throw std::runtime_error("This mode doesn't currently exist for this game");
+  }
+}
 
 DifficultyVect AsteroidsSettings::getAvailableDifficulties() {
-    DifficultyVect diff = {0, 3};
-    return diff;
+  DifficultyVect diff = {0, 3};
+  return diff;
 }

--- a/src/games/supported/Asteroids.hpp
+++ b/src/games/supported/Asteroids.hpp
@@ -29,65 +29,61 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Asteroids */
 class AsteroidsSettings : public RomSettings {
+ public:
+  AsteroidsSettings();
 
-    public:
+  // reset
+  void reset();
 
-        AsteroidsSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "asteroids"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // get the available number of modes
+  unsigned int getNumModes() const { return 33; }
 
-        // the rom-name
-        const char* rom() const { return "asteroids"; }
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // get the available number of modes
-        unsigned int getNumModes() const { return 33; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  // returns a list of mode that the game can be played in
+  // in this game, there are 33 available modes
+  ModeVect getAvailableModes();
 
-        virtual int lives()  { return isTerminal() ? 0 : m_lives; }
+  // set the mode of the game
+  // the given mode must be one returned by the previous function
+  void setMode(game_mode_t, System& system,
+               std::unique_ptr<StellaEnvironmentWrapper> environment);
 
-        // returns a list of mode that the game can be played in
-        // in this game, there are 33 available modes
-        ModeVect getAvailableModes();
+  // returns a list of difficulties that the game can be played in
+  // in this game, there are 2 available difficulties
+  DifficultyVect getAvailableDifficulties();
 
-        // set the mode of the game
-        // the given mode must be one returned by the previous function
-        void setMode(game_mode_t, System &system,
-                     std::unique_ptr<StellaEnvironmentWrapper> environment);
-
-        // returns a list of difficulties that the game can be played in
-        // in this game, there are 2 available difficulties
-        DifficultyVect getAvailableDifficulties();
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 };
 
-#endif // __ASTEROIDS_HPP__
+#endif  // __ASTEROIDS_HPP__

--- a/src/games/supported/Atlantis.cpp
+++ b/src/games/supported/Atlantis.cpp
@@ -28,92 +28,69 @@
 
 #include "../RomUtils.hpp"
 
-
-AtlantisSettings::AtlantisSettings() {
-
-    reset();
-}
-
+AtlantisSettings::AtlantisSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* AtlantisSettings::clone() const {
-
-    RomSettings* rval = new AtlantisSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new AtlantisSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void AtlantisSettings::step(const System& system) {
+  // update the reward. Score in Atlantis is a bit funky: when you "roll" the score, it increments
+  // the *lowest* digit. E.g., 999900 -> 000001.
+  reward_t score = getDecimalScore(0xA2, 0xA3, 0xA1, &system);
+  score *= 100;
+  m_reward = score - m_score;
+  reward_t old_score = m_score;
+  m_score = score;
 
-    // update the reward. Score in Atlantis is a bit funky: when you "roll" the score, it increments
-    // the *lowest* digit. E.g., 999900 -> 000001.
-    reward_t score = getDecimalScore(0xA2, 0xA3, 0xA1, &system);
-    score *= 100;
-    m_reward = score - m_score;
-    reward_t old_score = m_score;
-    m_score = score;
+  // update terminal status
+  m_lives = readRam(&system, 0xF1);
+  m_terminal = (m_lives == 0xFF);
 
-    // update terminal status
-    m_lives = readRam(&system, 0xF1);
-    m_terminal = (m_lives == 0xFF);
+  //when the game terminates, some garbage gets written on a1, screwing up the score computation
+  //since it is not possible to score on the very last frame, we can safely set the reward to 0.
+  if (m_terminal) {
+    m_reward = 0;
+    m_score = old_score;
+  }
 
-    //when the game terminates, some garbage gets written on a1, screwing up the score computation
-    //since it is not possible to score on the very last frame, we can safely set the reward to 0.
-    if(m_terminal){
-        m_reward = 0;
-        m_score = old_score;
-    }
-
-
-    // MGB: Also d4-da contain the 'building' status; 05 indicates a destroyed
-    //      building, 00 a live building
+  // MGB: Also d4-da contain the 'building' status; 05 indicates a destroyed
+  //      building, 00 a live building
 }
-
 
 /* is end of game */
-bool AtlantisSettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool AtlantisSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t AtlantisSettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t AtlantisSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool AtlantisSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_LEFTFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool AtlantisSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_LEFTFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void AtlantisSettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
-    m_lives    = 6;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
+  m_lives = 6;
 }
 
-
-
 /* saves the state of the rom settings */
-void AtlantisSettings::saveState(Serializer & ser) {
+void AtlantisSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
@@ -121,7 +98,7 @@ void AtlantisSettings::saveState(Serializer & ser) {
 }
 
 // loads the state of the rom settings
-void AtlantisSettings::loadState(Deserializer & ser) {
+void AtlantisSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();
@@ -130,30 +107,29 @@ void AtlantisSettings::loadState(Deserializer & ser) {
 
 // returns a list of mode that the game can be played in
 ModeVect AtlantisSettings::getAvailableModes() {
-    ModeVect modes(getNumModes());
-    for (unsigned int i = 0; i < modes.size(); i++) {
-        modes[i] = i;
-    }
-    return modes;
+  ModeVect modes(getNumModes());
+  for (unsigned int i = 0; i < modes.size(); i++) {
+    modes[i] = i;
+  }
+  return modes;
 }
 
 // set the mode of the game
 // the given mode must be one returned by the previous function
-void AtlantisSettings::setMode(game_mode_t m, System &system,
-                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
-
-    if(m < getNumModes()) {
-        // read the mode we are currently in
-        unsigned char mode = readRam(&system, 0x8D);
-        // press select until the correct mode is reached
-        while (mode != m) {
-            environment->pressSelect(2);
-            mode = readRam(&system, 0x8D);
-        }
-        //reset the environment to apply changes.
-        environment->softReset();
+void AtlantisSettings::setMode(
+    game_mode_t m, System& system,
+    std::unique_ptr<StellaEnvironmentWrapper> environment) {
+  if (m < getNumModes()) {
+    // read the mode we are currently in
+    unsigned char mode = readRam(&system, 0x8D);
+    // press select until the correct mode is reached
+    while (mode != m) {
+      environment->pressSelect(2);
+      mode = readRam(&system, 0x8D);
     }
-    else {
-        throw std::runtime_error("This mode doesn't currently exist for this game");
-    }
- }
+    //reset the environment to apply changes.
+    environment->softReset();
+  } else {
+    throw std::runtime_error("This mode doesn't currently exist for this game");
+  }
+}

--- a/src/games/supported/Atlantis.hpp
+++ b/src/games/supported/Atlantis.hpp
@@ -29,61 +29,57 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Atlantis settings */
 class AtlantisSettings : public RomSettings {
+ public:
+  AtlantisSettings();
 
-    public:
+  // reset
+  void reset();
 
-        AtlantisSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "atlantis"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // get the available number of modes
+  unsigned int getNumModes() const { return 4; }
 
-        // the rom-name
-        const char* rom() const { return "atlantis"; }
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // get the available number of modes
-        unsigned int getNumModes() const { return 4; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  // returns a list of mode that the game can be played in
+  // in this game, there are 8 available modes
+  ModeVect getAvailableModes();
 
-        virtual int lives() { return isTerminal() ? 0 : m_lives; }
+  // set the mode of the game
+  // the given mode must be one returned by the previous function
+  void setMode(game_mode_t, System& system,
+               std::unique_ptr<StellaEnvironmentWrapper> environment);
 
-        // returns a list of mode that the game can be played in
-        // in this game, there are 8 available modes
-        ModeVect getAvailableModes();
-
-        // set the mode of the game
-        // the given mode must be one returned by the previous function
-        void setMode(game_mode_t, System &system,
-                     std::unique_ptr<StellaEnvironmentWrapper> environment);
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 };
 
-#endif // __ATLANTIS_HPP__
+#endif  // __ATLANTIS_HPP__

--- a/src/games/supported/BankHeist.cpp
+++ b/src/games/supported/BankHeist.cpp
@@ -28,94 +28,72 @@
 
 #include "../RomUtils.hpp"
 
-
-BankHeistSettings::BankHeistSettings() {
-
-    reset();
-}
-
+BankHeistSettings::BankHeistSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* BankHeistSettings::clone() const {
-
-    RomSettings* rval = new BankHeistSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new BankHeistSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void BankHeistSettings::step(const System& system) {
+  // update the reward
+  reward_t score = getDecimalScore(0xDA, 0xD9, 0xD8, &system);
+  m_reward = score - m_score;
+  m_score = score;
 
-    // update the reward
-    reward_t score = getDecimalScore(0xDA, 0xD9, 0xD8, &system);
-    m_reward = score - m_score;
-    m_score = score;
+  // update terminal status
+  int death_timer = readRam(&system, 0xCE);
+  m_lives = readRam(&system, 0xD5);
 
-    // update terminal status
-    int death_timer = readRam(&system, 0xCE);
-    m_lives = readRam(&system, 0xD5);
-
-    m_terminal = (death_timer == 0x01 && m_lives == 0x00);
+  m_terminal = (death_timer == 0x01 && m_lives == 0x00);
 }
-
 
 /* is end of game */
-bool BankHeistSettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool BankHeistSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t BankHeistSettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t BankHeistSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool BankHeistSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_UP:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_DOWN:
-        case PLAYER_A_UPRIGHT:
-        case PLAYER_A_UPLEFT:
-        case PLAYER_A_DOWNRIGHT:
-        case PLAYER_A_DOWNLEFT:
-        case PLAYER_A_UPFIRE:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_LEFTFIRE:
-        case PLAYER_A_DOWNFIRE:
-        case PLAYER_A_UPRIGHTFIRE:
-        case PLAYER_A_UPLEFTFIRE:
-        case PLAYER_A_DOWNRIGHTFIRE:
-        case PLAYER_A_DOWNLEFTFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool BankHeistSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_UP:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_DOWN:
+    case PLAYER_A_UPRIGHT:
+    case PLAYER_A_UPLEFT:
+    case PLAYER_A_DOWNRIGHT:
+    case PLAYER_A_DOWNLEFT:
+    case PLAYER_A_UPFIRE:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_LEFTFIRE:
+    case PLAYER_A_DOWNFIRE:
+    case PLAYER_A_UPRIGHTFIRE:
+    case PLAYER_A_UPLEFTFIRE:
+    case PLAYER_A_DOWNRIGHTFIRE:
+    case PLAYER_A_DOWNLEFTFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void BankHeistSettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
-    m_lives    = 5;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
+  m_lives = 5;
 }
 
-
-
 /* saves the state of the rom settings */
-void BankHeistSettings::saveState(Serializer & ser) {
+void BankHeistSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
@@ -123,7 +101,7 @@ void BankHeistSettings::saveState(Serializer & ser) {
 }
 
 // loads the state of the rom settings
-void BankHeistSettings::loadState(Deserializer & ser) {
+void BankHeistSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();
@@ -132,36 +110,35 @@ void BankHeistSettings::loadState(Deserializer & ser) {
 
 // returns a list of mode that the game can be played in
 ModeVect BankHeistSettings::getAvailableModes() {
-    ModeVect modes(getNumModes());
-    for (unsigned int i = 0; i < modes.size(); i++) {
-        modes[i] = i * 4;
-    }
-    return modes;
+  ModeVect modes(getNumModes());
+  for (unsigned int i = 0; i < modes.size(); i++) {
+    modes[i] = i * 4;
+  }
+  return modes;
 }
 
 // set the mode of the game
 // the given mode must be one returned by the previous function
-void BankHeistSettings::setMode(game_mode_t m, System &system,
-                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
-
-    if(m <= 28 && m % 4 == 0) {
-        // read the mode we are currently in
-        unsigned char mode = readRam(&system, 0x80);
-        // press select until the correct mode is reached
-        while (mode != m) {
-            // hold select button for 10 frames
-            environment->pressSelect();
-            mode = readRam(&system, 0x80);
-        }
-        //reset the environment to apply changes.
-        environment->softReset();
+void BankHeistSettings::setMode(
+    game_mode_t m, System& system,
+    std::unique_ptr<StellaEnvironmentWrapper> environment) {
+  if (m <= 28 && m % 4 == 0) {
+    // read the mode we are currently in
+    unsigned char mode = readRam(&system, 0x80);
+    // press select until the correct mode is reached
+    while (mode != m) {
+      // hold select button for 10 frames
+      environment->pressSelect();
+      mode = readRam(&system, 0x80);
     }
-    else {
-        throw std::runtime_error("This mode doesn't currently exist for this game");
-    }
- }
+    //reset the environment to apply changes.
+    environment->softReset();
+  } else {
+    throw std::runtime_error("This mode doesn't currently exist for this game");
+  }
+}
 
 DifficultyVect BankHeistSettings::getAvailableDifficulties() {
-    DifficultyVect diff = {0, 1, 2, 3};
-    return diff;
+  DifficultyVect diff = {0, 1, 2, 3};
+  return diff;
 }

--- a/src/games/supported/BankHeist.hpp
+++ b/src/games/supported/BankHeist.hpp
@@ -29,65 +29,61 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for BankHeist settings */
 class BankHeistSettings : public RomSettings {
+ public:
+  BankHeistSettings();
 
-    public:
+  // reset
+  void reset();
 
-        BankHeistSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "bank_heist"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // get the available number of modes
+  unsigned int getNumModes() const { return 8; }
 
-        // the rom-name
-        const char* rom() const { return "bank_heist"; }
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // get the available number of modes
-        unsigned int getNumModes() const { return 8; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  // returns a list of mode that the game can be played in
+  // in this game, there are 8 available modes
+  ModeVect getAvailableModes();
 
-        virtual int lives() { return isTerminal() ? 0 : m_lives; }
+  // set the mode of the game
+  // the given mode must be one returned by the previous function
+  void setMode(game_mode_t, System& system,
+               std::unique_ptr<StellaEnvironmentWrapper> environment);
 
-        // returns a list of mode that the game can be played in
-        // in this game, there are 8 available modes
-        ModeVect getAvailableModes();
+  // returns a list of difficulties that the game can be played in
+  // in this game, there are 2 available difficulties
+  DifficultyVect getAvailableDifficulties();
 
-        // set the mode of the game
-        // the given mode must be one returned by the previous function
-        void setMode(game_mode_t, System &system,
-                     std::unique_ptr<StellaEnvironmentWrapper> environment);
-
-        // returns a list of difficulties that the game can be played in
-        // in this game, there are 2 available difficulties
-        DifficultyVect getAvailableDifficulties();
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 };
 
-#endif // __BANKHEIST_HPP__
+#endif  // __BANKHEIST_HPP__

--- a/src/games/supported/BattleZone.cpp
+++ b/src/games/supported/BattleZone.cpp
@@ -28,107 +28,88 @@
 
 #include "../RomUtils.hpp"
 
-
-BattleZoneSettings::BattleZoneSettings() {
-
-    reset();
-}
-
+BattleZoneSettings::BattleZoneSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* BattleZoneSettings::clone() const {
-
-    RomSettings* rval = new BattleZoneSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new BattleZoneSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void BattleZoneSettings::step(const System& system) {
+  // update the reward
+  int first_val = readRam(&system, 0x9D);
+  int first_right_digit = first_val & 15;
+  int first_left_digit = (first_val - first_right_digit) >> 4;
+  if (first_left_digit == 10)
+    first_left_digit = 0;
 
-    // update the reward
-    int first_val = readRam(&system, 0x9D);
-    int first_right_digit = first_val & 15;
-    int first_left_digit = (first_val - first_right_digit) >> 4;
-    if (first_left_digit == 10) first_left_digit = 0;
+  int second_val = readRam(&system, 0x9E);
+  int second_right_digit = second_val & 15;
+  int second_left_digit = (second_val - second_right_digit) >> 4;
+  if (second_right_digit == 10)
+    second_right_digit = 0;
+  if (second_left_digit == 10)
+    second_left_digit = 0;
 
-    int second_val = readRam(&system, 0x9E);
-    int second_right_digit = second_val & 15;
-    int second_left_digit = (second_val - second_right_digit) >> 4;
-    if (second_right_digit == 10) second_right_digit = 0;
-    if (second_left_digit == 10) second_left_digit = 0;
+  reward_t score = 0;
+  score += first_left_digit;
+  score += 10 * second_right_digit;
+  score += 100 * second_left_digit;
+  score *= 1000;
+  m_reward = score - m_score;
+  m_score = score;
 
-    reward_t score = 0;
-    score += first_left_digit;
-    score += 10 * second_right_digit;
-    score += 100 * second_left_digit;
-    score *= 1000;
-    m_reward = score - m_score;
-    m_score = score;
-
-    // update terminal status
-    m_lives = readRam(&system, 0xBA) & 0xF;
-    m_terminal = (m_lives == 0);
+  // update terminal status
+  m_lives = readRam(&system, 0xBA) & 0xF;
+  m_terminal = (m_lives == 0);
 }
-
 
 /* is end of game */
-bool BattleZoneSettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool BattleZoneSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t BattleZoneSettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t BattleZoneSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool BattleZoneSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_UP:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_DOWN:
-        case PLAYER_A_UPRIGHT:
-        case PLAYER_A_UPLEFT:
-        case PLAYER_A_DOWNRIGHT:
-        case PLAYER_A_DOWNLEFT:
-        case PLAYER_A_UPFIRE:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_LEFTFIRE:
-        case PLAYER_A_DOWNFIRE:
-        case PLAYER_A_UPRIGHTFIRE:
-        case PLAYER_A_UPLEFTFIRE:
-        case PLAYER_A_DOWNRIGHTFIRE:
-        case PLAYER_A_DOWNLEFTFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool BattleZoneSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_UP:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_DOWN:
+    case PLAYER_A_UPRIGHT:
+    case PLAYER_A_UPLEFT:
+    case PLAYER_A_DOWNRIGHT:
+    case PLAYER_A_DOWNLEFT:
+    case PLAYER_A_UPFIRE:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_LEFTFIRE:
+    case PLAYER_A_DOWNFIRE:
+    case PLAYER_A_UPRIGHTFIRE:
+    case PLAYER_A_UPLEFTFIRE:
+    case PLAYER_A_DOWNRIGHTFIRE:
+    case PLAYER_A_DOWNLEFTFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void BattleZoneSettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
-    m_lives    = 5;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
+  m_lives = 5;
 }
 
-
-
 /* saves the state of the rom settings */
-void BattleZoneSettings::saveState(Serializer & ser) {
+void BattleZoneSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
@@ -136,7 +117,7 @@ void BattleZoneSettings::saveState(Serializer & ser) {
 }
 
 // loads the state of the rom settings
-void BattleZoneSettings::loadState(Deserializer & ser) {
+void BattleZoneSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();
@@ -145,33 +126,32 @@ void BattleZoneSettings::loadState(Deserializer & ser) {
 
 // returns a list of mode that the game can be played in
 ModeVect BattleZoneSettings::getAvailableModes() {
-    ModeVect modes(getNumModes());
-    for (unsigned int i = 0; i < modes.size(); i++) {
-        modes[i] = i + 1;
-    }
-    return modes;
+  ModeVect modes(getNumModes());
+  for (unsigned int i = 0; i < modes.size(); i++) {
+    modes[i] = i + 1;
+  }
+  return modes;
 }
 
 // set the mode of the game
 // the given mode must be one returned by the previous function
-void BattleZoneSettings::setMode(game_mode_t m, System &system,
+void BattleZoneSettings::setMode(
+    game_mode_t m, System& system,
     std::unique_ptr<StellaEnvironmentWrapper> environment) {
-
-    if(m == 0) {
-        m = 1; // the default mode is not valid here
+  if (m == 0) {
+    m = 1; // the default mode is not valid here
+  }
+  if (m >= 1 && m <= 3) {
+    // read the mode we are currently in
+    unsigned char mode = readRam(&system, 0xA1);
+    // press select until the correct mode is reached
+    while (mode != m) {
+      environment->pressSelect(2);
+      mode = readRam(&system, 0xA1);
     }
-    if(m >= 1 && m <= 3) {
-        // read the mode we are currently in
-        unsigned char mode = readRam(&system, 0xA1);
-        // press select until the correct mode is reached
-        while (mode != m) {
-            environment->pressSelect(2);
-            mode = readRam(&system, 0xA1);
-        }
-        //reset the environment to apply changes.
-        environment->softReset();
-    }
-    else {
-        throw std::runtime_error("This mode doesn't currently exist for this game");
-    }
- }
+    //reset the environment to apply changes.
+    environment->softReset();
+  } else {
+    throw std::runtime_error("This mode doesn't currently exist for this game");
+  }
+}

--- a/src/games/supported/BattleZone.hpp
+++ b/src/games/supported/BattleZone.hpp
@@ -29,61 +29,57 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for BattleZone settings */
 class BattleZoneSettings : public RomSettings {
+ public:
+  BattleZoneSettings();
 
-    public:
+  // reset
+  void reset();
 
-        BattleZoneSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "battle_zone"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // get the available number of modes
+  unsigned int getNumModes() const { return 3; }
 
-        // the rom-name
-        const char* rom() const { return "battle_zone"; }
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // get the available number of modes
-        unsigned int getNumModes() const { return 3; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  // returns a list of mode that the game can be played in
+  // in this game, there are 3 available modes
+  ModeVect getAvailableModes();
 
-        virtual int lives() { return isTerminal() ? 0 : m_lives; }
+  // set the mode of the game
+  // the given mode must be one returned by the previous function
+  void setMode(game_mode_t, System& system,
+               std::unique_ptr<StellaEnvironmentWrapper> environment);
 
-        // returns a list of mode that the game can be played in
-        // in this game, there are 3 available modes
-        ModeVect getAvailableModes();
-
-        // set the mode of the game
-        // the given mode must be one returned by the previous function
-        void setMode(game_mode_t, System &system,
-                     std::unique_ptr<StellaEnvironmentWrapper> environment);
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 };
 
-#endif // __BATTLEZONE_HPP__
+#endif  // __BATTLEZONE_HPP__

--- a/src/games/supported/BeamRider.cpp
+++ b/src/games/supported/BeamRider.cpp
@@ -28,94 +28,72 @@
 
 #include "../RomUtils.hpp"
 
-
-BeamRiderSettings::BeamRiderSettings() {
-
-    reset();
-}
-
+BeamRiderSettings::BeamRiderSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* BeamRiderSettings::clone() const {
-
-    RomSettings* rval = new BeamRiderSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new BeamRiderSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void BeamRiderSettings::step(const System& system) {
+  // update the reward
+  int score = getDecimalScore(9, 10, 11, &system);
+  m_reward = score - m_score;
+  m_score = score;
+  int new_lives = readRam(&system, 0x85) + 1;
 
-    // update the reward
-    int score = getDecimalScore(9, 10, 11, &system);
-    m_reward = score - m_score;
-    m_score = score;
-    int new_lives = readRam(&system, 0x85) + 1;
+  // Decrease lives *after* the death animation; this is necessary as the lives counter
+  // blinks during death
+  if (new_lives == m_lives - 1) {
+    if (readRam(&system, 0x8C) == 0x01)
+      m_lives = new_lives;
+  } else
+    m_lives = new_lives;
 
-    // Decrease lives *after* the death animation; this is necessary as the lives counter
-    // blinks during death
-    if (new_lives == m_lives - 1) {
-        if (readRam(&system, 0x8C) == 0x01)
-            m_lives = new_lives;
-    }
-    else
-        m_lives = new_lives;
-
-    // update terminal status
-    int byte_val = readRam(&system, 5);
-    m_terminal = byte_val == 255;
-    byte_val = byte_val & 15;
-    m_terminal = m_terminal || byte_val < 0;
+  // update terminal status
+  int byte_val = readRam(&system, 5);
+  m_terminal = byte_val == 255;
+  byte_val = byte_val & 15;
+  m_terminal = m_terminal || byte_val < 0;
 }
-
 
 /* is end of game */
-bool BeamRiderSettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool BeamRiderSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t BeamRiderSettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t BeamRiderSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool BeamRiderSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_UP:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_UPRIGHT:
-        case PLAYER_A_UPLEFT:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_LEFTFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool BeamRiderSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_UP:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_UPRIGHT:
+    case PLAYER_A_UPLEFT:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_LEFTFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void BeamRiderSettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
-    m_lives    = 3;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
+  m_lives = 3;
 }
 
-
 /* saves the state of the rom settings */
-void BeamRiderSettings::saveState(Serializer & ser) {
+void BeamRiderSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
@@ -123,7 +101,7 @@ void BeamRiderSettings::saveState(Serializer & ser) {
 }
 
 // loads the state of the rom settings
-void BeamRiderSettings::loadState(Deserializer & ser) {
+void BeamRiderSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();
@@ -131,12 +109,12 @@ void BeamRiderSettings::loadState(Deserializer & ser) {
 }
 
 ActionVect BeamRiderSettings::getStartingActions() {
-    ActionVect startingActions;
-    startingActions.push_back(PLAYER_A_RIGHT);
-    return startingActions;
+  ActionVect startingActions;
+  startingActions.push_back(PLAYER_A_RIGHT);
+  return startingActions;
 }
 
 DifficultyVect BeamRiderSettings::getAvailableDifficulties() {
-    DifficultyVect diff = {0, 1};
-    return diff;
+  DifficultyVect diff = {0, 1};
+  return diff;
 }

--- a/src/games/supported/BeamRider.hpp
+++ b/src/games/supported/BeamRider.hpp
@@ -29,55 +29,51 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Beam Rider - best Atari 2600 game ever! */
 class BeamRiderSettings : public RomSettings {
+ public:
+  BeamRiderSettings();
 
-    public:
+  // reset
+  void reset();
 
-        BeamRiderSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "beam_rider"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // the rom-name
-        const char* rom() const { return "beam_rider"; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  ActionVect getStartingActions();
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
-        ActionVect getStartingActions();
+  // returns a list of difficulties that the game can be played in
+  // in this game, there are 2 available difficulties.
+  DifficultyVect getAvailableDifficulties();
 
-        virtual int lives() { return isTerminal() ? 0 : m_lives; }
-
-        // returns a list of difficulties that the game can be played in
-        // in this game, there are 2 available difficulties.
-        DifficultyVect getAvailableDifficulties();
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 };
 
-#endif // __BEAMRIDER_HPP__
+#endif  // __BEAMRIDER_HPP__

--- a/src/games/supported/Berzerk.cpp
+++ b/src/games/supported/Berzerk.cpp
@@ -28,94 +28,72 @@
 
 #include "../RomUtils.hpp"
 
-
-BerzerkSettings::BerzerkSettings() {
-
-    reset();
-}
-
+BerzerkSettings::BerzerkSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* BerzerkSettings::clone() const {
-
-    RomSettings* rval = new BerzerkSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new BerzerkSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void BerzerkSettings::step(const System& system) {
+  // update the reward
+  reward_t score = getDecimalScore(95, 94, 93, &system);
+  m_reward = score - m_score;
+  m_score = score;
 
-    // update the reward
-    reward_t score = getDecimalScore(95, 94, 93, &system);
-    m_reward = score - m_score;
-    m_score = score;
+  // update terminal status
+  int livesByte = readRam(&system, 0xDA);
 
-    // update terminal status
-    int livesByte = readRam(&system, 0xDA);
-
-    m_terminal = (livesByte == 0xFF);
-    m_lives = livesByte + 1;
+  m_terminal = (livesByte == 0xFF);
+  m_lives = livesByte + 1;
 }
-
 
 /* is end of game */
-bool BerzerkSettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool BerzerkSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t BerzerkSettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t BerzerkSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool BerzerkSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_UP:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_DOWN:
-        case PLAYER_A_UPRIGHT:
-        case PLAYER_A_UPLEFT:
-        case PLAYER_A_DOWNRIGHT:
-        case PLAYER_A_DOWNLEFT:
-        case PLAYER_A_UPFIRE:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_LEFTFIRE:
-        case PLAYER_A_DOWNFIRE:
-        case PLAYER_A_UPRIGHTFIRE:
-        case PLAYER_A_UPLEFTFIRE:
-        case PLAYER_A_DOWNRIGHTFIRE:
-        case PLAYER_A_DOWNLEFTFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool BerzerkSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_UP:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_DOWN:
+    case PLAYER_A_UPRIGHT:
+    case PLAYER_A_UPLEFT:
+    case PLAYER_A_DOWNRIGHT:
+    case PLAYER_A_DOWNLEFT:
+    case PLAYER_A_UPFIRE:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_LEFTFIRE:
+    case PLAYER_A_DOWNFIRE:
+    case PLAYER_A_UPRIGHTFIRE:
+    case PLAYER_A_UPLEFTFIRE:
+    case PLAYER_A_DOWNRIGHTFIRE:
+    case PLAYER_A_DOWNLEFTFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void BerzerkSettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
-    m_lives    = 3;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
+  m_lives = 3;
 }
 
-
-
 /* saves the state of the rom settings */
-void BerzerkSettings::saveState(Serializer & ser) {
+void BerzerkSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
@@ -123,7 +101,7 @@ void BerzerkSettings::saveState(Serializer & ser) {
 }
 
 // loads the state of the rom settings
-void BerzerkSettings::loadState(Deserializer & ser) {
+void BerzerkSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();
@@ -132,41 +110,40 @@ void BerzerkSettings::loadState(Deserializer & ser) {
 
 // returns a list of mode that the game can be played in
 ModeVect BerzerkSettings::getAvailableModes() {
-    ModeVect modes(getNumModes() - 3);
-    for (unsigned int i = 0; i < modes.size(); i++) {
-        //this is 1-12 in Atari-decimal (0x01 ... 0x09 0x10 0x11 0x12)
-        modes[i] = i + 1;
-    }
-    modes.push_back(0x10);
-    modes.push_back(0x11);
-    modes.push_back(0x12);
-    return modes;
+  ModeVect modes(getNumModes() - 3);
+  for (unsigned int i = 0; i < modes.size(); i++) {
+    //this is 1-12 in Atari-decimal (0x01 ... 0x09 0x10 0x11 0x12)
+    modes[i] = i + 1;
+  }
+  modes.push_back(0x10);
+  modes.push_back(0x11);
+  modes.push_back(0x12);
+  return modes;
 }
 
 // set the mode of the game
 // the given mode must be one returned by the previous function
-void BerzerkSettings::setMode(game_mode_t m, System &system,
-                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
-
-    if(m == 0) {
-        m = 1; // The mode 0, which is the default, is not available in this game.
+void BerzerkSettings::setMode(
+    game_mode_t m, System& system,
+    std::unique_ptr<StellaEnvironmentWrapper> environment) {
+  if (m == 0) {
+    m = 1; // The mode 0, which is the default, is not available in this game.
+  }
+  if (m >= 1 && (m <= 9 || m == 0x10 || m == 0x11 || m == 0x12)) {
+    // we wait that the game is ready to change mode
+    for (unsigned int i = 0; i < 20; i++) {
+      environment->act(PLAYER_A_NOOP, PLAYER_B_NOOP);
     }
-    if(m >= 1 && (m <= 9 || m == 0x10 || m == 0x11 || m == 0x12)) {
-        // we wait that the game is ready to change mode
-        for(unsigned int i = 0; i < 20; i++) {
-            environment->act(PLAYER_A_NOOP, PLAYER_B_NOOP);
-        }
-        // read the mode we are currently in
-        unsigned char mode = readRam(&system, 0x80);
-        // press select until the correct mode is reached
-        while (mode != m) {
-            environment->pressSelect(2);
-            mode = readRam(&system, 0x80);
-        }
-        //reset the environment to apply changes.
-        environment->softReset();
+    // read the mode we are currently in
+    unsigned char mode = readRam(&system, 0x80);
+    // press select until the correct mode is reached
+    while (mode != m) {
+      environment->pressSelect(2);
+      mode = readRam(&system, 0x80);
     }
-    else {
-        throw std::runtime_error("This mode doesn't currently exist for this game");
-    }
- }
+    //reset the environment to apply changes.
+    environment->softReset();
+  } else {
+    throw std::runtime_error("This mode doesn't currently exist for this game");
+  }
+}

--- a/src/games/supported/Berzerk.hpp
+++ b/src/games/supported/Berzerk.hpp
@@ -29,62 +29,57 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Berzerk! settings */
 class BerzerkSettings : public RomSettings {
+ public:
+  BerzerkSettings();
 
-    public:
+  // reset
+  void reset();
 
-        BerzerkSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "berzerk"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // get the available number of modes
+  unsigned int getNumModes() const { return 12; }
 
-        // the rom-name
-        const char* rom() const { return "berzerk"; }
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // get the available number of modes
-        unsigned int getNumModes() const { return 12; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  // returns a list of mode that the game can be played in
+  // in this game, there are 12 available modes
+  ModeVect getAvailableModes();
 
-        virtual int lives() { return isTerminal() ? 0 : m_lives; }
+  // set the mode of the game
+  // the given mode must be one returned by the previous function
+  void setMode(game_mode_t, System& system,
+               std::unique_ptr<StellaEnvironmentWrapper> environment);
 
-        // returns a list of mode that the game can be played in
-        // in this game, there are 12 available modes
-        ModeVect getAvailableModes();
-
-        // set the mode of the game
-        // the given mode must be one returned by the previous function
-        void setMode(game_mode_t, System &system,
-                     std::unique_ptr<StellaEnvironmentWrapper> environment);
-
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 };
 
-#endif // __BERZERK_HPP__
+#endif  // __BERZERK_HPP__

--- a/src/games/supported/Bowling.cpp
+++ b/src/games/supported/Bowling.cpp
@@ -13,86 +13,64 @@
 
 #include "../RomUtils.hpp"
 
-
-BowlingSettings::BowlingSettings() {
-
-    reset();
-}
-
+BowlingSettings::BowlingSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* BowlingSettings::clone() const {
-
-    RomSettings* rval = new BowlingSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new BowlingSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void BowlingSettings::step(const System& system) {
+  // update the reward
+  reward_t score = getDecimalScore(0xA1, 0xA6, &system);
+  m_reward = score - m_score;
+  m_score = score;
 
-    // update the reward
-    reward_t score = getDecimalScore(0xA1, 0xA6, &system);
-    m_reward = score - m_score;
-    m_score = score;
-
-    // update terminal status
-    int round = readRam(&system, 0xA4);
-    m_terminal = round > 0x10;
+  // update terminal status
+  int round = readRam(&system, 0xA4);
+  m_terminal = round > 0x10;
 }
-
 
 /* is end of game */
-bool BowlingSettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool BowlingSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t BowlingSettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t BowlingSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool BowlingSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_UP:
-        case PLAYER_A_DOWN:
-        case PLAYER_A_UPFIRE:
-        case PLAYER_A_DOWNFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool BowlingSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_UP:
+    case PLAYER_A_DOWN:
+    case PLAYER_A_UPFIRE:
+    case PLAYER_A_DOWNFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void BowlingSettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
 }
 
-
-
 /* saves the state of the rom settings */
-void BowlingSettings::saveState(Serializer & ser) {
+void BowlingSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
 }
 
 // loads the state of the rom settings
-void BowlingSettings::loadState(Deserializer & ser) {
+void BowlingSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();
@@ -100,32 +78,31 @@ void BowlingSettings::loadState(Deserializer & ser) {
 
 // returns a list of mode that the game can be played in
 ModeVect BowlingSettings::getAvailableModes() {
-    ModeVect modes = {0, 2, 4};
-    return modes;
+  ModeVect modes = {0, 2, 4};
+  return modes;
 }
 
 // set the mode of the game
 // the given mode must be one returned by the previous function
-void BowlingSettings::setMode(game_mode_t m, System &system,
-                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
-
-    if(m == 0 || m == 2 || m == 4) {
-        // read the mode we are currently in
-        unsigned char mode = readRam(&system, 2);
-        // press select until the correct mode is reached
-        while (mode != m) {
-            environment->pressSelect(2);
-            mode = readRam(&system, 2);
-        }
-        //reset the environment to apply changes.
-        environment->softReset();
+void BowlingSettings::setMode(
+    game_mode_t m, System& system,
+    std::unique_ptr<StellaEnvironmentWrapper> environment) {
+  if (m == 0 || m == 2 || m == 4) {
+    // read the mode we are currently in
+    unsigned char mode = readRam(&system, 2);
+    // press select until the correct mode is reached
+    while (mode != m) {
+      environment->pressSelect(2);
+      mode = readRam(&system, 2);
     }
-    else {
-        throw std::runtime_error("This mode doesn't currently exist for this game");
-    }
- }
+    //reset the environment to apply changes.
+    environment->softReset();
+  } else {
+    throw std::runtime_error("This mode doesn't currently exist for this game");
+  }
+}
 
 DifficultyVect BowlingSettings::getAvailableDifficulties() {
-    DifficultyVect diff = {0, 1};
-    return diff;
+  DifficultyVect diff = {0, 1};
+  return diff;
 }

--- a/src/games/supported/Bowling.hpp
+++ b/src/games/supported/Bowling.hpp
@@ -29,65 +29,61 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Bowling settings */
 class BowlingSettings : public RomSettings {
+ public:
+  BowlingSettings();
 
-    public:
+  // reset
+  void reset();
 
-        BowlingSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "bowling"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // get the available number of modes
+  unsigned int getNumModes() const { return 3; }
 
-        // the rom-name
-        const char* rom() const { return "bowling"; }
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // get the available number of modes
-        unsigned int getNumModes() const { return 3; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  // No lives in bowling!
+  virtual int lives() { return 0; }
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  // returns a list of mode that the game can be played in
+  // in this game, there are 3 available modes
+  ModeVect getAvailableModes();
 
-        // No lives in bowling!
-        virtual int lives() { return 0; }
+  // set the mode of the game
+  // the given mode must be one returned by the previous function
+  void setMode(game_mode_t, System& system,
+               std::unique_ptr<StellaEnvironmentWrapper> environment);
 
-        // returns a list of mode that the game can be played in
-        // in this game, there are 3 available modes
-        ModeVect getAvailableModes();
+  // returns a list of difficulties that the game can be played in
+  // in this game, there are 2 available difficulties
+  DifficultyVect getAvailableDifficulties();
 
-        // set the mode of the game
-        // the given mode must be one returned by the previous function
-        void setMode(game_mode_t, System &system,
-                     std::unique_ptr<StellaEnvironmentWrapper> environment);
-
-        // returns a list of difficulties that the game can be played in
-        // in this game, there are 2 available difficulties
-        DifficultyVect getAvailableDifficulties();
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
 };
 
-#endif // __BOWLING_HPP__
+#endif  // __BOWLING_HPP__

--- a/src/games/supported/Boxing.cpp
+++ b/src/games/supported/Boxing.cpp
@@ -13,117 +13,97 @@
 
 #include "../RomUtils.hpp"
 
-
-BoxingSettings::BoxingSettings() {
-
-    reset();
-}
-
+BoxingSettings::BoxingSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* BoxingSettings::clone() const {
-
-    RomSettings* rval = new BoxingSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new BoxingSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void BoxingSettings::step(const System& system) {
+  // update the reward
+  int my_score = getDecimalScore(0x92, &system);
+  int oppt_score = getDecimalScore(0x93, &system);
 
-    // update the reward
-    int my_score   = getDecimalScore(0x92, &system);
-    int oppt_score = getDecimalScore(0x93, &system);
+  // handle KO
+  if (readRam(&system, 0x92) == 0xC0)
+    my_score = 100;
+  if (readRam(&system, 0x93) == 0xC0)
+    oppt_score = 100;
+  reward_t score = my_score - oppt_score;
+  m_reward = score - m_score;
+  m_score = score;
 
-    // handle KO
-    if (readRam(&system, 0x92) == 0xC0) my_score   = 100;
-    if (readRam(&system, 0x93) == 0xC0) oppt_score = 100;
-    reward_t score = my_score - oppt_score;
-    m_reward = score - m_score;
-    m_score = score;
-
-    // update terminal status
-    // if either is KO, the game is over
-    if (my_score == 100 || oppt_score == 100) {
-        m_terminal = true;
-    } else {  // otherwise check to see if out of time
-        int minutes = readRam(&system, 0x90) >> 4;
-        int seconds = (readRam(&system, 0x91) & 0xF) +
-                      (readRam(&system, 0x91) >> 4) * 10;
-        m_terminal = minutes == 0 && seconds == 0;
-    }
+  // update terminal status
+  // if either is KO, the game is over
+  if (my_score == 100 || oppt_score == 100) {
+    m_terminal = true;
+  } else { // otherwise check to see if out of time
+    int minutes = readRam(&system, 0x90) >> 4;
+    int seconds =
+        (readRam(&system, 0x91) & 0xF) + (readRam(&system, 0x91) >> 4) * 10;
+    m_terminal = minutes == 0 && seconds == 0;
+  }
 }
-
 
 /* is end of game */
-bool BoxingSettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool BoxingSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t BoxingSettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t BoxingSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool BoxingSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_UP:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_DOWN:
-        case PLAYER_A_UPRIGHT:
-        case PLAYER_A_UPLEFT:
-        case PLAYER_A_DOWNRIGHT:
-        case PLAYER_A_DOWNLEFT:
-        case PLAYER_A_UPFIRE:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_LEFTFIRE:
-        case PLAYER_A_DOWNFIRE:
-        case PLAYER_A_UPRIGHTFIRE:
-        case PLAYER_A_UPLEFTFIRE:
-        case PLAYER_A_DOWNRIGHTFIRE:
-        case PLAYER_A_DOWNLEFTFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool BoxingSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_UP:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_DOWN:
+    case PLAYER_A_UPRIGHT:
+    case PLAYER_A_UPLEFT:
+    case PLAYER_A_DOWNRIGHT:
+    case PLAYER_A_DOWNLEFT:
+    case PLAYER_A_UPFIRE:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_LEFTFIRE:
+    case PLAYER_A_DOWNFIRE:
+    case PLAYER_A_UPRIGHTFIRE:
+    case PLAYER_A_UPLEFTFIRE:
+    case PLAYER_A_DOWNRIGHTFIRE:
+    case PLAYER_A_DOWNLEFTFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void BoxingSettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
 }
 
-
-
 /* saves the state of the rom settings */
-void BoxingSettings::saveState(Serializer & ser) {
+void BoxingSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
 }
 
 // loads the state of the rom settings
-void BoxingSettings::loadState(Deserializer & ser) {
+void BoxingSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();
 }
 
 DifficultyVect BoxingSettings::getAvailableDifficulties() {
-    DifficultyVect diff = {0, 1, 2, 3};
-    return diff;
+  DifficultyVect diff = {0, 1, 2, 3};
+  return diff;
 }

--- a/src/games/supported/Boxing.hpp
+++ b/src/games/supported/Boxing.hpp
@@ -29,52 +29,48 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Boxing settings */
 class BoxingSettings : public RomSettings {
+ public:
+  BoxingSettings();
 
-    public:
+  // reset
+  void reset();
 
-        BoxingSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "boxing"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // the rom-name
-        const char* rom() const { return "boxing"; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  virtual int lives() { return 0; }
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  // returns a list of difficulties that the game can be played in
+  // in this game, there are 4 available difficulties
+  DifficultyVect getAvailableDifficulties();
 
-        virtual int lives() { return 0; }
-
-        // returns a list of difficulties that the game can be played in
-        // in this game, there are 4 available difficulties
-        DifficultyVect getAvailableDifficulties();
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
 };
 
-#endif // __BOXING_HPP__
+#endif  // __BOXING_HPP__

--- a/src/games/supported/Breakout.cpp
+++ b/src/games/supported/Breakout.cpp
@@ -28,82 +28,63 @@
 
 #include "../RomUtils.hpp"
 
-
-BreakoutSettings::BreakoutSettings() {
-
-    reset();
-}
-
+BreakoutSettings::BreakoutSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* BreakoutSettings::clone() const {
-
-    RomSettings* rval = new BreakoutSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new BreakoutSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void BreakoutSettings::step(const System& system) {
+  // update the reward
+  int x = readRam(&system, 77);
+  int y = readRam(&system, 76);
+  reward_t score =
+      1 * (x & 0x000F) + 10 * ((x & 0x00F0) >> 4) + 100 * (y & 0x000F);
+  m_reward = score - m_score;
+  m_score = score;
 
-    // update the reward
-    int x = readRam(&system, 77);
-    int y = readRam(&system, 76);
-    reward_t score = 1 * (x & 0x000F) + 10 * ((x & 0x00F0) >> 4) + 100 * (y & 0x000F);
-    m_reward = score - m_score;
-    m_score = score;
-
-    // update terminal status
-    int byte_val = readRam(&system, 57);
-    if (!m_started && byte_val == 5) m_started = true;
-    m_terminal = m_started && byte_val == 0;
-    m_lives = byte_val;
+  // update terminal status
+  int byte_val = readRam(&system, 57);
+  if (!m_started && byte_val == 5)
+    m_started = true;
+  m_terminal = m_started && byte_val == 0;
+  m_lives = byte_val;
 }
-
 
 /* is end of game */
-bool BreakoutSettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool BreakoutSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t BreakoutSettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t BreakoutSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool BreakoutSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-            return true;
-        default:
-            return false;
-    }
+bool BreakoutSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void BreakoutSettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 0;
-    m_lives    = 5;
-    m_terminal = false;
-    m_started  = false;
+  m_reward = 0;
+  m_score = 0;
+  m_lives = 5;
+  m_terminal = false;
+  m_started = false;
 }
 
-
 /* saves the state of the rom settings */
-void BreakoutSettings::saveState(Serializer & ser) {
+void BreakoutSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
@@ -112,7 +93,7 @@ void BreakoutSettings::saveState(Serializer & ser) {
 }
 
 // loads the state of the rom settings
-void BreakoutSettings::loadState(Deserializer & ser) {
+void BreakoutSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();
@@ -122,36 +103,34 @@ void BreakoutSettings::loadState(Deserializer & ser) {
 
 // returns a list of mode that the game can be played in
 ModeVect BreakoutSettings::getAvailableModes() {
-    ModeVect modes(getNumModes());
-    for (unsigned int i = 0; i < modes.size(); i++) {
-        modes[i] = i * 4;
-    }
-    return modes;
+  ModeVect modes(getNumModes());
+  for (unsigned int i = 0; i < modes.size(); i++) {
+    modes[i] = i * 4;
+  }
+  return modes;
 }
 
 // set the mode of the game
 // the given mode must be one returned by the previous function
-void BreakoutSettings::setMode(game_mode_t m, System &system,
-                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
-
-    if(m < getNumModes() * 4 && m % 4 == 0) {
-        // read the mode we are currently in
-        unsigned char mode = readRam(&system, 0xB2);
-        // press select until the correct mode is reached
-        while (mode != m) {
-            environment->pressSelect();
-            mode = readRam(&system, 0xB2);
-        }
-        //reset the environment to apply changes.
-        environment->softReset();
+void BreakoutSettings::setMode(
+    game_mode_t m, System& system,
+    std::unique_ptr<StellaEnvironmentWrapper> environment) {
+  if (m < getNumModes() * 4 && m % 4 == 0) {
+    // read the mode we are currently in
+    unsigned char mode = readRam(&system, 0xB2);
+    // press select until the correct mode is reached
+    while (mode != m) {
+      environment->pressSelect();
+      mode = readRam(&system, 0xB2);
     }
-    else {
-        throw std::runtime_error("This mode doesn't currently exist for this game");
-    }
- }
-
+    //reset the environment to apply changes.
+    environment->softReset();
+  } else {
+    throw std::runtime_error("This mode doesn't currently exist for this game");
+  }
+}
 
 DifficultyVect BreakoutSettings::getAvailableDifficulties() {
-    DifficultyVect diff = {0, 1};
-    return diff;
+  DifficultyVect diff = {0, 1};
+  return diff;
 }

--- a/src/games/supported/Breakout.hpp
+++ b/src/games/supported/Breakout.hpp
@@ -29,67 +29,63 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Breakout */
 class BreakoutSettings : public RomSettings {
+ public:
+  BreakoutSettings();
 
-    public:
+  // reset
+  void reset();
 
-        BreakoutSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "breakout"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // get the available number of modes
+  unsigned int getNumModes() const { return 12; }
 
-        // the rom-name
-        const char* rom() const { return "breakout"; }
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // get the available number of modes
-        unsigned int getNumModes() const { return 12; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  // remaining lives
+  int lives() { return isTerminal() ? 0 : m_lives; }
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  // returns a list of mode that the game can be played in
+  // in this game, there are 8 available modes
+  ModeVect getAvailableModes();
 
-        // remaining lives
-        int lives() { return isTerminal() ? 0 : m_lives; }
+  // set the mode of the game
+  // the given mode must be one returned by the previous function
+  void setMode(game_mode_t, System& system,
+               std::unique_ptr<StellaEnvironmentWrapper> environment);
 
-        // returns a list of mode that the game can be played in
-        // in this game, there are 8 available modes
-        ModeVect getAvailableModes();
+  // returns a list of difficulties that the game can be played in
+  // in this game, there are 2 available difficulties
+  DifficultyVect getAvailableDifficulties();
 
-        // set the mode of the game
-        // the given mode must be one returned by the previous function
-        void setMode(game_mode_t, System &system,
-                     std::unique_ptr<StellaEnvironmentWrapper> environment);
-
-        // returns a list of difficulties that the game can be played in
-        // in this game, there are 2 available difficulties
-        DifficultyVect getAvailableDifficulties();
-
-    private:
-
-        bool m_terminal;
-        bool m_started;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
+ private:
+  bool m_terminal;
+  bool m_started;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 };
 
-#endif // __BREAKOUT_HPP__
+#endif  // __BREAKOUT_HPP__

--- a/src/games/supported/Carnival.cpp
+++ b/src/games/supported/Carnival.cpp
@@ -13,87 +13,65 @@
 
 #include "../RomUtils.hpp"
 
-
-CarnivalSettings::CarnivalSettings() {
-
-    reset();
-}
-
+CarnivalSettings::CarnivalSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* CarnivalSettings::clone() const {
-
-    RomSettings* rval = new CarnivalSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new CarnivalSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void CarnivalSettings::step(const System& system) {
+  // update the reward
+  reward_t score = getDecimalScore(0xAE, 0xAD, &system);
+  score *= 10;
+  m_reward = score - m_score;
+  m_score = score;
 
-    // update the reward
-    reward_t score = getDecimalScore(0xAE, 0xAD, &system);
-    score *= 10;
-    m_reward = score - m_score;
-    m_score = score;
-
-    // update terminal status
-    int ammo = readRam(&system, 0x83);
-    m_terminal = ammo < 1;
+  // update terminal status
+  int ammo = readRam(&system, 0x83);
+  m_terminal = ammo < 1;
 }
-
 
 /* is end of game */
-bool CarnivalSettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool CarnivalSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t CarnivalSettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t CarnivalSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool CarnivalSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_LEFTFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool CarnivalSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_LEFTFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void CarnivalSettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
 }
 
-
-
 /* saves the state of the rom settings */
-void CarnivalSettings::saveState(Serializer & ser) {
+void CarnivalSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
 }
 
 // loads the state of the rom settings
-void CarnivalSettings::loadState(Deserializer & ser) {
+void CarnivalSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();

--- a/src/games/supported/Carnival.hpp
+++ b/src/games/supported/Carnival.hpp
@@ -29,48 +29,44 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Carnival settings */
 class CarnivalSettings : public RomSettings {
+ public:
+  CarnivalSettings();
 
-    public:
+  // reset
+  void reset();
 
-        CarnivalSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "carnival"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // the rom-name
-        const char* rom() const { return "carnival"; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  virtual int lives() { return 0; }
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
-
-        virtual int lives() { return 0; }
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
 };
 
-#endif // __CARNIVAL_HPP__
+#endif  // __CARNIVAL_HPP__

--- a/src/games/supported/Centipede.hpp
+++ b/src/games/supported/Centipede.hpp
@@ -29,61 +29,57 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Centipede settings */
 class CentipedeSettings : public RomSettings {
+ public:
+  CentipedeSettings();
 
-    public:
+  // reset
+  void reset();
 
-        CentipedeSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "centipede"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // get the available number of modes
+  unsigned int getNumModes() const { return 2; }
 
-        // the rom-name
-        const char* rom() const { return "centipede"; }
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // get the available number of modes
-        unsigned int getNumModes() const { return 2; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  // returns a list of mode that the game can be played in
+  // in this game, there are 8 available modes
+  ModeVect getAvailableModes();
 
-        virtual int lives() { return isTerminal() ? 0 : m_lives; }
+  // set the mode of the game
+  // the given mode must be one returned by the previous function
+  void setMode(game_mode_t, System& system,
+               std::unique_ptr<StellaEnvironmentWrapper> environment);
 
-        // returns a list of mode that the game can be played in
-        // in this game, there are 8 available modes
-        ModeVect getAvailableModes();
-
-        // set the mode of the game
-        // the given mode must be one returned by the previous function
-        void setMode(game_mode_t, System &system,
-                     std::unique_ptr<StellaEnvironmentWrapper> environment);
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 };
 
-#endif // __CENTIPEDE_HPP__
+#endif  // __CENTIPEDE_HPP__

--- a/src/games/supported/ChopperCommand.cpp
+++ b/src/games/supported/ChopperCommand.cpp
@@ -28,95 +28,75 @@
 
 #include "../RomUtils.hpp"
 
-
-ChopperCommandSettings::ChopperCommandSettings() {
-
-    reset();
-}
-
+ChopperCommandSettings::ChopperCommandSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* ChopperCommandSettings::clone() const {
-
-    RomSettings* rval = new ChopperCommandSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new ChopperCommandSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void ChopperCommandSettings::step(const System& system) {
+  // update the reward
+  reward_t score = getDecimalScore(0xEE, 0xEC, &system);
+  score *= 100;
+  m_reward = score - m_score;
+  m_score = score;
 
-    // update the reward
-    reward_t score = getDecimalScore(0xEE, 0xEC, &system);
-    score *= 100;
-    m_reward = score - m_score;
-    m_score = score;
-
-    // update terminal status
-    m_lives = readRam(&system, 0xE4) & 0xF;
-    m_terminal = (m_lives == 0);
-    m_is_started = (readRam(&system, 0xC2) == 1);
+  // update terminal status
+  m_lives = readRam(&system, 0xE4) & 0xF;
+  m_terminal = (m_lives == 0);
+  m_is_started = (readRam(&system, 0xC2) == 1);
 }
-
 
 /* is end of game */
 bool ChopperCommandSettings::isTerminal() const {
-
-    return (m_is_started && m_terminal);
+  return (m_is_started && m_terminal);
 };
 
-
 /* get the most recently observed reward */
-reward_t ChopperCommandSettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t ChopperCommandSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool ChopperCommandSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_UP:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_DOWN:
-        case PLAYER_A_UPRIGHT:
-        case PLAYER_A_UPLEFT:
-        case PLAYER_A_DOWNRIGHT:
-        case PLAYER_A_DOWNLEFT:
-        case PLAYER_A_UPFIRE:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_LEFTFIRE:
-        case PLAYER_A_DOWNFIRE:
-        case PLAYER_A_UPRIGHTFIRE:
-        case PLAYER_A_UPLEFTFIRE:
-        case PLAYER_A_DOWNRIGHTFIRE:
-        case PLAYER_A_DOWNLEFTFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool ChopperCommandSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_UP:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_DOWN:
+    case PLAYER_A_UPRIGHT:
+    case PLAYER_A_UPLEFT:
+    case PLAYER_A_DOWNRIGHT:
+    case PLAYER_A_DOWNLEFT:
+    case PLAYER_A_UPFIRE:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_LEFTFIRE:
+    case PLAYER_A_DOWNFIRE:
+    case PLAYER_A_UPRIGHTFIRE:
+    case PLAYER_A_UPLEFTFIRE:
+    case PLAYER_A_DOWNRIGHTFIRE:
+    case PLAYER_A_DOWNLEFTFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void ChopperCommandSettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
-    m_lives    = 3;
-    m_is_started = false;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
+  m_lives = 3;
+  m_is_started = false;
 }
 
-
-
 /* saves the state of the rom settings */
-void ChopperCommandSettings::saveState(Serializer & ser) {
+void ChopperCommandSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
@@ -124,42 +104,40 @@ void ChopperCommandSettings::saveState(Serializer & ser) {
 }
 
 // loads the state of the rom settings
-void ChopperCommandSettings::loadState(Deserializer & ser) {
+void ChopperCommandSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();
   m_lives = ser.getInt();
 }
 
-
 // returns a list of mode that the game can be played in
 ModeVect ChopperCommandSettings::getAvailableModes() {
-    ModeVect modes = {0, 2};
-    return modes;
+  ModeVect modes = {0, 2};
+  return modes;
 }
 
 // set the mode of the game
 // the given mode must be one returned by the previous function
-void ChopperCommandSettings::setMode(game_mode_t m, System &system,
-                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
-
-    if(m == 0 || m == 2) {
-        // read the mode we are currently in
-        unsigned char mode = readRam(&system, 0xE0);
-        // press select until the correct mode is reached
-        while (mode != m) {
-            environment->pressSelect(2);
-            mode = readRam(&system, 0xE0);
-        }
-        //reset the environment to apply changes.
-        environment->softReset();
+void ChopperCommandSettings::setMode(
+    game_mode_t m, System& system,
+    std::unique_ptr<StellaEnvironmentWrapper> environment) {
+  if (m == 0 || m == 2) {
+    // read the mode we are currently in
+    unsigned char mode = readRam(&system, 0xE0);
+    // press select until the correct mode is reached
+    while (mode != m) {
+      environment->pressSelect(2);
+      mode = readRam(&system, 0xE0);
     }
-    else {
-        throw std::runtime_error("This mode doesn't currently exist for this game");
-    }
- }
+    //reset the environment to apply changes.
+    environment->softReset();
+  } else {
+    throw std::runtime_error("This mode doesn't currently exist for this game");
+  }
+}
 
 DifficultyVect ChopperCommandSettings::getAvailableDifficulties() {
-    DifficultyVect diff = {0, 1};
-    return diff;
+  DifficultyVect diff = {0, 1};
+  return diff;
 }

--- a/src/games/supported/ChopperCommand.hpp
+++ b/src/games/supported/ChopperCommand.hpp
@@ -29,66 +29,62 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Chopper Command settings */
 class ChopperCommandSettings : public RomSettings {
+ public:
+  ChopperCommandSettings();
 
-    public:
+  // reset
+  void reset();
 
-        ChopperCommandSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "chopper_command"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // get the available number of modes
+  unsigned int getNumModes() const { return 2; }
 
-        // the rom-name
-        const char* rom() const { return "chopper_command"; }
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // get the available number of modes
-        unsigned int getNumModes() const { return 2; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  virtual int lives() { return m_lives; }
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  // returns a list of mode that the game can be played in
+  // in this game, there are 2 available modes
+  ModeVect getAvailableModes();
 
-        virtual int lives() { return m_lives; }
+  // set the mode of the game
+  // the given mode must be one returned by the previous function
+  void setMode(game_mode_t, System& system,
+               std::unique_ptr<StellaEnvironmentWrapper> environment);
 
-        // returns a list of mode that the game can be played in
-        // in this game, there are 2 available modes
-        ModeVect getAvailableModes();
+  // returns a list of difficulties that the game can be played in
+  // in this game, there are 2 available difficulties
+  DifficultyVect getAvailableDifficulties();
 
-        // set the mode of the game
-        // the given mode must be one returned by the previous function
-        void setMode(game_mode_t, System &system,
-                     std::unique_ptr<StellaEnvironmentWrapper> environment);
-
-        // returns a list of difficulties that the game can be played in
-        // in this game, there are 2 available difficulties
-        DifficultyVect getAvailableDifficulties();
-
-    private:
-
-        bool m_is_started;
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
+ private:
+  bool m_is_started;
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 };
 
-#endif // __CHOPPERCOMMAND_HPP__
+#endif  // __CHOPPERCOMMAND_HPP__

--- a/src/games/supported/CrazyClimber.hpp
+++ b/src/games/supported/CrazyClimber.hpp
@@ -29,65 +29,61 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Crazy Climber settings */
 class CrazyClimberSettings : public RomSettings {
+ public:
+  CrazyClimberSettings();
 
-    public:
+  // reset
+  void reset();
 
-        CrazyClimberSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "crazy_climber"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // get the available number of modes
+  unsigned int getNumModes() const { return 4; }
 
-        // the rom-name
-        const char* rom() const { return "crazy_climber"; }
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // get the available number of modes
-        unsigned int getNumModes() const { return 4; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  // returns a list of mode that the game can be played in
+  // in this game, there are 4 available modes
+  ModeVect getAvailableModes();
 
-        virtual int lives() { return isTerminal() ? 0 : m_lives; }
+  // set the mode of the game
+  // the given mode must be one returned by the previous function
+  void setMode(game_mode_t, System& system,
+               std::unique_ptr<StellaEnvironmentWrapper> environment);
 
-        // returns a list of mode that the game can be played in
-        // in this game, there are 4 available modes
-        ModeVect getAvailableModes();
+  // returns a list of difficulties that the game can be played in
+  // in this game, there are 2 available difficulties
+  DifficultyVect getAvailableDifficulties();
 
-        // set the mode of the game
-        // the given mode must be one returned by the previous function
-        void setMode(game_mode_t, System &system,
-                     std::unique_ptr<StellaEnvironmentWrapper> environment);
-
-        // returns a list of difficulties that the game can be played in
-        // in this game, there are 2 available difficulties
-        DifficultyVect getAvailableDifficulties();
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 };
 
-#endif // __CRAZYCLIMBER_HPP__
+#endif  // __CRAZYCLIMBER_HPP__

--- a/src/games/supported/Defender.cpp
+++ b/src/games/supported/Defender.cpp
@@ -28,98 +28,78 @@
 
 #include "../RomUtils.hpp"
 
-
-DefenderSettings::DefenderSettings() {
-
-    reset();
-}
-
+DefenderSettings::DefenderSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* DefenderSettings::clone() const {
-
-    RomSettings* rval = new DefenderSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new DefenderSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void DefenderSettings::step(const System& system) {
+  // update the reward
+  int mult = 1, score = 0;
+  for (int digit = 0; digit < 6; digit++) {
+    int v = readRam(&system, 0x9C + digit) & 0xF;
+    // A indicates a 0 which we don't display
+    if (v == 0xA)
+      v = 0;
+    score += v * mult;
+    mult *= 10;
+  }
+  m_reward = score - m_score;
+  m_score = score;
 
-    // update the reward
-    int mult = 1, score = 0;
-    for (int digit = 0; digit < 6; digit++) {
-        int v = readRam(&system, 0x9C + digit) & 0xF;
-        // A indicates a 0 which we don't display
-        if (v == 0xA) v = 0;
-        score += v * mult;
-        mult *= 10;
-    }
-    m_reward = score - m_score;
-    m_score = score;
-
-    // update terminal status
-    m_lives = readRam(&system, 0xC2);
-    m_terminal = (m_lives == 0);
+  // update terminal status
+  m_lives = readRam(&system, 0xC2);
+  m_terminal = (m_lives == 0);
 }
-
 
 /* is end of game */
-bool DefenderSettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool DefenderSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t DefenderSettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t DefenderSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool DefenderSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_UP:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_DOWN:
-        case PLAYER_A_UPRIGHT:
-        case PLAYER_A_UPLEFT:
-        case PLAYER_A_DOWNRIGHT:
-        case PLAYER_A_DOWNLEFT:
-        case PLAYER_A_UPFIRE:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_LEFTFIRE:
-        case PLAYER_A_DOWNFIRE:
-        case PLAYER_A_UPRIGHTFIRE:
-        case PLAYER_A_UPLEFTFIRE:
-        case PLAYER_A_DOWNRIGHTFIRE:
-        case PLAYER_A_DOWNLEFTFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool DefenderSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_UP:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_DOWN:
+    case PLAYER_A_UPRIGHT:
+    case PLAYER_A_UPLEFT:
+    case PLAYER_A_DOWNRIGHT:
+    case PLAYER_A_DOWNLEFT:
+    case PLAYER_A_UPFIRE:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_LEFTFIRE:
+    case PLAYER_A_DOWNFIRE:
+    case PLAYER_A_UPRIGHTFIRE:
+    case PLAYER_A_UPLEFTFIRE:
+    case PLAYER_A_DOWNRIGHTFIRE:
+    case PLAYER_A_DOWNLEFTFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void DefenderSettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
-    m_lives    = 3;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
+  m_lives = 3;
 }
 
-
 /* saves the state of the rom settings */
-void DefenderSettings::saveState(Serializer & ser) {
+void DefenderSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
@@ -127,7 +107,7 @@ void DefenderSettings::saveState(Serializer & ser) {
 }
 
 // loads the state of the rom settings
-void DefenderSettings::loadState(Deserializer & ser) {
+void DefenderSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();
@@ -136,39 +116,38 @@ void DefenderSettings::loadState(Deserializer & ser) {
 
 // returns a list of mode that the game can be played in
 ModeVect DefenderSettings::getAvailableModes() {
-    ModeVect modes(getNumModes() - 1);
-    for (unsigned int i = 0; i < modes.size(); i++) {
-        modes[i] = i + 1;
-    }
-    modes.push_back(16); //easy mode
-    return modes;
+  ModeVect modes(getNumModes() - 1);
+  for (unsigned int i = 0; i < modes.size(); i++) {
+    modes[i] = i + 1;
+  }
+  modes.push_back(16); //easy mode
+  return modes;
 }
 
 // set the mode of the game
 // the given mode must be one returned by the previous function
-void DefenderSettings::setMode(game_mode_t m, System &system,
-                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
-
-    if(m == 0) {
-        m = 1; // The default mode (0) is not valid here.
+void DefenderSettings::setMode(
+    game_mode_t m, System& system,
+    std::unique_ptr<StellaEnvironmentWrapper> environment) {
+  if (m == 0) {
+    m = 1; // The default mode (0) is not valid here.
+  }
+  if (m >= 1 && (m <= 9 || m == 16)) {
+    // read the mode we are currently in
+    unsigned char mode = readRam(&system, 0x9B);
+    // press select until the correct mode is reached
+    while (mode != m) {
+      environment->pressSelect(2);
+      mode = readRam(&system, 0x9B);
     }
-    if(m >= 1 && (m <= 9 || m == 16)) {
-        // read the mode we are currently in
-        unsigned char mode = readRam(&system, 0x9B);
-        // press select until the correct mode is reached
-        while (mode != m) {
-            environment->pressSelect(2);
-            mode = readRam(&system, 0x9B);
-        }
-        //reset the environment to apply changes.
-        environment->softReset();
-    }
-    else {
-        throw std::runtime_error("This mode doesn't currently exist for this game");
-    }
- }
+    //reset the environment to apply changes.
+    environment->softReset();
+  } else {
+    throw std::runtime_error("This mode doesn't currently exist for this game");
+  }
+}
 
 DifficultyVect DefenderSettings::getAvailableDifficulties() {
-    DifficultyVect diff = {0, 1};
-    return diff;
+  DifficultyVect diff = {0, 1};
+  return diff;
 }

--- a/src/games/supported/Defender.hpp
+++ b/src/games/supported/Defender.hpp
@@ -29,65 +29,61 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Defender settings */
 class DefenderSettings : public RomSettings {
+ public:
+  DefenderSettings();
 
-    public:
+  // reset
+  void reset();
 
-        DefenderSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "defender"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // get the available number of modes
+  unsigned int getNumModes() const { return 10; }
 
-        // the rom-name
-        const char* rom() const { return "defender"; }
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // get the available number of modes
-        unsigned int getNumModes() const { return 10; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  // returns a list of mode that the game can be played in
+  // in this game, there are 10 available modes
+  ModeVect getAvailableModes();
 
-        virtual int lives() { return isTerminal() ? 0 : m_lives; }
+  // set the mode of the game
+  // the given mode must be one returned by the previous function
+  void setMode(game_mode_t, System& system,
+               std::unique_ptr<StellaEnvironmentWrapper> environment);
 
-        // returns a list of mode that the game can be played in
-        // in this game, there are 10 available modes
-        ModeVect getAvailableModes();
+  // returns a list of difficulties that the game can be played in
+  // in this game, there are 2 available difficulties
+  DifficultyVect getAvailableDifficulties();
 
-        // set the mode of the game
-        // the given mode must be one returned by the previous function
-        void setMode(game_mode_t, System &system,
-                     std::unique_ptr<StellaEnvironmentWrapper> environment);
-
-        // returns a list of difficulties that the game can be played in
-        // in this game, there are 2 available difficulties
-        DifficultyVect getAvailableDifficulties();
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 };
 
-#endif // __DEFENDER_HPP__
+#endif  // __DEFENDER_HPP__

--- a/src/games/supported/DemonAttack.hpp
+++ b/src/games/supported/DemonAttack.hpp
@@ -29,66 +29,62 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Demon Attack settings */
 class DemonAttackSettings : public RomSettings {
+ public:
+  DemonAttackSettings();
 
-    public:
+  // reset
+  void reset();
 
-        DemonAttackSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "demon_attack"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // get the available number of modes
+  unsigned int getNumModes() const { return 8; }
 
-        // the rom-name
-        const char* rom() const { return "demon_attack"; }
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // get the available number of modes
-        unsigned int getNumModes() const { return 8; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  // returns a list of mode that the game can be played in
+  // in this game, there are 8 available modes
+  ModeVect getAvailableModes();
 
-        virtual int lives() { return isTerminal() ? 0 : m_lives; }
+  // set the mode of the game
+  // the given mode must be one returned by the previous function
+  void setMode(game_mode_t, System& system,
+               std::unique_ptr<StellaEnvironmentWrapper> environment);
 
-        // returns a list of mode that the game can be played in
-        // in this game, there are 8 available modes
-        ModeVect getAvailableModes();
+  // returns a list of difficulties that the game can be played in
+  // in this game, there are 2 available difficulties
+  DifficultyVect getAvailableDifficulties();
 
-        // set the mode of the game
-        // the given mode must be one returned by the previous function
-        void setMode(game_mode_t, System &system,
-                     std::unique_ptr<StellaEnvironmentWrapper> environment);
-
-        // returns a list of difficulties that the game can be played in
-        // in this game, there are 2 available difficulties
-        DifficultyVect getAvailableDifficulties();
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
-        bool m_level_change;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
+  bool m_level_change;
 };
 
-#endif // __DEMONATTACK_HPP__
+#endif  // __DEMONATTACK_HPP__

--- a/src/games/supported/DonkeyKong.cpp
+++ b/src/games/supported/DonkeyKong.cpp
@@ -13,86 +13,73 @@
 
 #include "../RomUtils.hpp"
 
-
-DonkeyKongSettings::DonkeyKongSettings() {
-    reset();
-}
-
+DonkeyKongSettings::DonkeyKongSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* DonkeyKongSettings::clone() const {
-    RomSettings* rval = new DonkeyKongSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new DonkeyKongSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void DonkeyKongSettings::step(const System& system) {
-    // update the reward
-    int score = getDecimalScore(0x88, 0x87, &system);
-    score *= 100;
-    int reward = score - m_score;
-    m_reward = reward;
-    m_score = score;
+  // update the reward
+  int score = getDecimalScore(0x88, 0x87, &system);
+  score *= 100;
+  int reward = score - m_score;
+  m_reward = reward;
+  m_score = score;
 
-    // update lives and terminal status
-    m_lives = readRam(&system, 0xA3);
-    m_terminal = (m_lives == 0)
-		&& readRam(&system, 0x8F) == 0x03
-		&& readRam(&system, 0x8B) == 0x1F;
+  // update lives and terminal status
+  m_lives = readRam(&system, 0xA3);
+  m_terminal = (m_lives == 0) && readRam(&system, 0x8F) == 0x03 &&
+               readRam(&system, 0x8B) == 0x1F;
 }
 
 /* is end of game */
-bool DonkeyKongSettings::isTerminal() const {
-    return m_terminal;
-};
-
+bool DonkeyKongSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t DonkeyKongSettings::getReward() const {
-    return m_reward;
-}
-
+reward_t DonkeyKongSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool DonkeyKongSettings::isMinimal(const Action &a) const {
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_UP:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_DOWN:
-        case PLAYER_A_UPRIGHT:
-        case PLAYER_A_UPLEFT:
-        case PLAYER_A_DOWNRIGHT:
-        case PLAYER_A_DOWNLEFT:
-        case PLAYER_A_UPFIRE:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_LEFTFIRE:
-        case PLAYER_A_DOWNFIRE:
-        case PLAYER_A_UPRIGHTFIRE:
-        case PLAYER_A_UPLEFTFIRE:
-        case PLAYER_A_DOWNRIGHTFIRE:
-        case PLAYER_A_DOWNLEFTFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool DonkeyKongSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_UP:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_DOWN:
+    case PLAYER_A_UPRIGHT:
+    case PLAYER_A_UPLEFT:
+    case PLAYER_A_DOWNRIGHT:
+    case PLAYER_A_DOWNLEFT:
+    case PLAYER_A_UPFIRE:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_LEFTFIRE:
+    case PLAYER_A_DOWNFIRE:
+    case PLAYER_A_UPRIGHTFIRE:
+    case PLAYER_A_UPLEFTFIRE:
+    case PLAYER_A_DOWNRIGHTFIRE:
+    case PLAYER_A_DOWNLEFTFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void DonkeyKongSettings::reset() {
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
-    m_lives    = 2;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
+  m_lives = 2;
 }
 
 /* saves the state of the rom settings */
-void DonkeyKongSettings::saveState(Serializer & ser) {
+void DonkeyKongSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
@@ -100,7 +87,7 @@ void DonkeyKongSettings::saveState(Serializer & ser) {
 }
 
 // loads the state of the rom settings
-void DonkeyKongSettings::loadState(Deserializer & ser) {
+void DonkeyKongSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();

--- a/src/games/supported/DonkeyKong.hpp
+++ b/src/games/supported/DonkeyKong.hpp
@@ -14,49 +14,46 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for DonkeyKong */
 class DonkeyKongSettings : public RomSettings {
+ public:
+  DonkeyKongSettings();
 
-    public:
+  // reset
+  void reset();
 
-        DonkeyKongSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  // MD5 36b20c427975760cb9cf4a47e41369e4
+  const char* rom() const { return "donkey_kong"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // the rom-name
-		// MD5 36b20c427975760cb9cf4a47e41369e4
-        const char* rom() const { return "donkey_kong"; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
-
-        virtual int lives() { return isTerminal() ? 0 : m_lives; }
-
-    private:
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 };
 
-#endif // __DONKEYKONG_HPP__
+#endif  // __DONKEYKONG_HPP__

--- a/src/games/supported/DoubleDunk.cpp
+++ b/src/games/supported/DoubleDunk.cpp
@@ -13,204 +13,184 @@
 
 #include "../RomUtils.hpp"
 
-
-DoubleDunkSettings::DoubleDunkSettings() {
-
-    reset();
-}
-
+DoubleDunkSettings::DoubleDunkSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* DoubleDunkSettings::clone() const {
-
-    RomSettings* rval = new DoubleDunkSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new DoubleDunkSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void DoubleDunkSettings::step(const System& system) {
+  // update the reward
+  int my_score = getDecimalScore(0xF6, &system);
+  int oppt_score = getDecimalScore(0xF7, &system);
+  int score = my_score - oppt_score;
+  m_reward = score - m_score;
+  m_score = score;
 
-    // update the reward
-    int my_score = getDecimalScore(0xF6, &system);
-    int oppt_score = getDecimalScore(0xF7, &system);
-    int score = my_score - oppt_score;
-    m_reward = score - m_score;
-    m_score = score;
-
-    // update terminal status
-    int some_value = readRam(&system, 0xFE);
-    m_terminal = (my_score >= 24 || oppt_score >= 24) && some_value == 0xE7;
+  // update terminal status
+  int some_value = readRam(&system, 0xFE);
+  m_terminal = (my_score >= 24 || oppt_score >= 24) && some_value == 0xE7;
 }
-
 
 /* is end of game */
-bool DoubleDunkSettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool DoubleDunkSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t DoubleDunkSettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t DoubleDunkSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool DoubleDunkSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_UP:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_DOWN:
-        case PLAYER_A_UPRIGHT:
-        case PLAYER_A_UPLEFT:
-        case PLAYER_A_DOWNRIGHT:
-        case PLAYER_A_DOWNLEFT:
-        case PLAYER_A_UPFIRE:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_LEFTFIRE:
-        case PLAYER_A_DOWNFIRE:
-        case PLAYER_A_UPRIGHTFIRE:
-        case PLAYER_A_UPLEFTFIRE:
-        case PLAYER_A_DOWNRIGHTFIRE:
-        case PLAYER_A_DOWNLEFTFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool DoubleDunkSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_UP:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_DOWN:
+    case PLAYER_A_UPRIGHT:
+    case PLAYER_A_UPLEFT:
+    case PLAYER_A_DOWNRIGHT:
+    case PLAYER_A_DOWNLEFT:
+    case PLAYER_A_UPFIRE:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_LEFTFIRE:
+    case PLAYER_A_DOWNFIRE:
+    case PLAYER_A_UPRIGHTFIRE:
+    case PLAYER_A_UPLEFTFIRE:
+    case PLAYER_A_DOWNRIGHTFIRE:
+    case PLAYER_A_DOWNLEFTFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void DoubleDunkSettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
 }
 
-
 /* saves the state of the rom settings */
-void DoubleDunkSettings::saveState(Serializer & ser) {
+void DoubleDunkSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
 }
 
 // loads the state of the rom settings
-void DoubleDunkSettings::loadState(Deserializer & ser) {
+void DoubleDunkSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();
 }
 
 ActionVect DoubleDunkSettings::getStartingActions() {
-    ActionVect startingActions;
-    startingActions.push_back(PLAYER_A_UPFIRE);
-    return startingActions;
+  ActionVect startingActions;
+  startingActions.push_back(PLAYER_A_UPFIRE);
+  return startingActions;
 }
 
 // returns a list of mode that the game can be played in
 ModeVect DoubleDunkSettings::getAvailableModes() {
-    // this game has a menu that allows to define various yes/no options
-    // setting these options define in a way a different mode
-    // there are 4 relevant options, which makes 2^4=16 available modes
-    ModeVect modes(getNumModes());
-    for (unsigned int i = 0; i < modes.size(); i++) {
-        modes[i] = i;
-    }
-    return modes;
+  // this game has a menu that allows to define various yes/no options
+  // setting these options define in a way a different mode
+  // there are 4 relevant options, which makes 2^4=16 available modes
+  ModeVect modes(getNumModes());
+  for (unsigned int i = 0; i < modes.size(); i++) {
+    modes[i] = i;
+  }
+  return modes;
 }
 
-void DoubleDunkSettings::goDown(System &system,
-                            std::unique_ptr<StellaEnvironmentWrapper> &environment) {
-    // this game has a menu that allows to define various yes/no options
-    // this function goes to the next option in the menu
-    unsigned int previousSelection = readRam(&system, 0xB0);
-    while(previousSelection == readRam(&system, 0xB0)){
-        environment->act(PLAYER_A_DOWN, PLAYER_B_NOOP);
-        environment->act(PLAYER_A_NOOP, PLAYER_B_NOOP);
-    }
+void DoubleDunkSettings::goDown(
+    System& system, std::unique_ptr<StellaEnvironmentWrapper>& environment) {
+  // this game has a menu that allows to define various yes/no options
+  // this function goes to the next option in the menu
+  unsigned int previousSelection = readRam(&system, 0xB0);
+  while (previousSelection == readRam(&system, 0xB0)) {
+    environment->act(PLAYER_A_DOWN, PLAYER_B_NOOP);
+    environment->act(PLAYER_A_NOOP, PLAYER_B_NOOP);
+  }
 }
 
-void DoubleDunkSettings::activateOption(System &system, unsigned int bitOfInterest,
-                                    std::unique_ptr<StellaEnvironmentWrapper> &environment) {
-    // once we are at the proper option in the menu,
-    // if we want to enable it all we have to do is to go right
-    while((readRam(&system, 0x80) & bitOfInterest) != bitOfInterest) {
-        environment->act(PLAYER_A_RIGHT, PLAYER_B_NOOP);
-        environment->act(PLAYER_A_NOOP, PLAYER_B_NOOP);
-    }
+void DoubleDunkSettings::activateOption(
+    System& system, unsigned int bitOfInterest,
+    std::unique_ptr<StellaEnvironmentWrapper>& environment) {
+  // once we are at the proper option in the menu,
+  // if we want to enable it all we have to do is to go right
+  while ((readRam(&system, 0x80) & bitOfInterest) != bitOfInterest) {
+    environment->act(PLAYER_A_RIGHT, PLAYER_B_NOOP);
+    environment->act(PLAYER_A_NOOP, PLAYER_B_NOOP);
+  }
 }
 
-void DoubleDunkSettings::deactivateOption(System &system, unsigned int bitOfInterest,
-                                    std::unique_ptr<StellaEnvironmentWrapper> &environment) {
-    // once we are at the proper optio in the menu,
-    // if we want to disable it all we have to do is to go left
-    while((readRam(&system, 0x80) & bitOfInterest) == bitOfInterest) {
-        environment->act(PLAYER_A_LEFT, PLAYER_B_NOOP);
-        environment->act(PLAYER_A_NOOP, PLAYER_B_NOOP);
-    }
+void DoubleDunkSettings::deactivateOption(
+    System& system, unsigned int bitOfInterest,
+    std::unique_ptr<StellaEnvironmentWrapper>& environment) {
+  // once we are at the proper optio in the menu,
+  // if we want to disable it all we have to do is to go left
+  while ((readRam(&system, 0x80) & bitOfInterest) == bitOfInterest) {
+    environment->act(PLAYER_A_LEFT, PLAYER_B_NOOP);
+    environment->act(PLAYER_A_NOOP, PLAYER_B_NOOP);
+  }
 }
 
 // set the mode of the game
 // the given mode must be one returned by the previous function
-void DoubleDunkSettings::setMode(game_mode_t m, System &system,
-                                std::unique_ptr<StellaEnvironmentWrapper> environment) {
+void DoubleDunkSettings::setMode(
+    game_mode_t m, System& system,
+    std::unique_ptr<StellaEnvironmentWrapper> environment) {
+  if (m < getNumModes()) {
+    environment->pressSelect();
 
-    if(m < getNumModes()) {
-        environment->pressSelect();
+    //discard the first two entries (irrelevant)
+    goDown(system, environment);
+    goDown(system, environment);
 
-        //discard the first two entries (irrelevant)
-        goDown(system, environment);
-        goDown(system, environment);
-
-        //deal with the 3 points option
-        if(m & 1) {
-            activateOption(system, 0x08, environment);
-        } else {
-            deactivateOption(system, 0x08, environment);
-        }
-
-        //deal with the 10 seconds option
-        goDown(system, environment);
-        if(m & 2) {
-            activateOption(system, 0x10, environment);
-        } else {
-            deactivateOption(system, 0x10, environment);
-        }
-
-        //deal with the 3 seconds option
-        goDown(system, environment);
-        if(m & 4) {
-            activateOption(system, 0x04, environment);
-        } else {
-            deactivateOption(system, 0x04, environment);
-        }
-
-        //deal with the foul option
-        goDown(system, environment);
-        if(m & 8) {
-            activateOption(system, 0x20, environment);
-        } else {
-            deactivateOption(system, 0x20, environment);
-        }
-
-        //reset the environment to apply changes.
-        environment->softReset();
-        //apply starting action
-        environment->act(PLAYER_A_UPFIRE, PLAYER_B_NOOP);
-        environment->act(PLAYER_A_NOOP, PLAYER_B_NOOP);
-
+    //deal with the 3 points option
+    if (m & 1) {
+      activateOption(system, 0x08, environment);
+    } else {
+      deactivateOption(system, 0x08, environment);
     }
-    else {
-        throw std::runtime_error("This mode doesn't currently exist for this game");
+
+    //deal with the 10 seconds option
+    goDown(system, environment);
+    if (m & 2) {
+      activateOption(system, 0x10, environment);
+    } else {
+      deactivateOption(system, 0x10, environment);
     }
- }
+
+    //deal with the 3 seconds option
+    goDown(system, environment);
+    if (m & 4) {
+      activateOption(system, 0x04, environment);
+    } else {
+      deactivateOption(system, 0x04, environment);
+    }
+
+    //deal with the foul option
+    goDown(system, environment);
+    if (m & 8) {
+      activateOption(system, 0x20, environment);
+    } else {
+      deactivateOption(system, 0x20, environment);
+    }
+
+    //reset the environment to apply changes.
+    environment->softReset();
+    //apply starting action
+    environment->act(PLAYER_A_UPFIRE, PLAYER_B_NOOP);
+    environment->act(PLAYER_A_NOOP, PLAYER_B_NOOP);
+
+  } else {
+    throw std::runtime_error("This mode doesn't currently exist for this game");
+  }
+}

--- a/src/games/supported/DoubleDunk.hpp
+++ b/src/games/supported/DoubleDunk.hpp
@@ -29,78 +29,73 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Double Dunk settings */
 class DoubleDunkSettings : public RomSettings {
+ public:
+  DoubleDunkSettings();
 
-    public:
+  // reset
+  void reset();
 
-        DoubleDunkSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "double_dunk"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // get the available number of modes
+  unsigned int getNumModes() const { return 16; }
 
-        // the rom-name
-        const char* rom() const { return "double_dunk"; }
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // get the available number of modes
-        unsigned int getNumModes() const { return 16; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  ActionVect getStartingActions();
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  virtual int lives() { return 0; }
 
-        ActionVect getStartingActions();
+  // returns a list of mode that the game can be played in
+  // in this game, there are 16 available modes
+  ModeVect getAvailableModes();
 
-        virtual int lives() { return 0; }
+  // set the mode of the game
+  // the given mode must be one returned by the previous function
+  void setMode(game_mode_t, System& system,
+               std::unique_ptr<StellaEnvironmentWrapper> environment);
 
-        // returns a list of mode that the game can be played in
-        // in this game, there are 16 available modes
-        ModeVect getAvailableModes();
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
 
-        // set the mode of the game
-        // the given mode must be one returned by the previous function
-        void setMode(game_mode_t, System &system,
-                     std::unique_ptr<StellaEnvironmentWrapper> environment);
+  // this game has a menu that allows to define various yes/no options
+  // this function goes to the next option in the menu
+  void goDown(System& system,
+              std::unique_ptr<StellaEnvironmentWrapper>& environment);
 
+  // once we are at the proper option in the menu,
+  // if we want to enable it all we have to do is to go right
+  void activateOption(System& system, unsigned int bitOfInterest,
+                      std::unique_ptr<StellaEnvironmentWrapper>& environment);
 
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-
-        // this game has a menu that allows to define various yes/no options
-        // this function goes to the next option in the menu
-        void goDown(System &system,
-            std::unique_ptr<StellaEnvironmentWrapper> &environment);
-
-        // once we are at the proper option in the menu,
-        // if we want to enable it all we have to do is to go right
-        void activateOption(System &system, unsigned int bitOfInterest,
-            std::unique_ptr<StellaEnvironmentWrapper> &environment);
-
-        // once we are at the proper optio in the menu,
-        // if we want to disable it all we have to do is to go left
-        void deactivateOption(System &system, unsigned int bitOfInterest,
-            std::unique_ptr<StellaEnvironmentWrapper> &environment);
+  // once we are at the proper optio in the menu,
+  // if we want to disable it all we have to do is to go left
+  void deactivateOption(System& system, unsigned int bitOfInterest,
+                        std::unique_ptr<StellaEnvironmentWrapper>& environment);
 };
 
-#endif // __DOUBLEDUNK_HPP__
+#endif  // __DOUBLEDUNK_HPP__

--- a/src/games/supported/ElevatorAction.cpp
+++ b/src/games/supported/ElevatorAction.cpp
@@ -28,92 +28,71 @@
 
 #include "../RomUtils.hpp"
 
-
-ElevatorActionSettings::ElevatorActionSettings() {
-
-    reset();
-}
-
+ElevatorActionSettings::ElevatorActionSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* ElevatorActionSettings::clone() const {
-
-    RomSettings* rval = new ElevatorActionSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new ElevatorActionSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void ElevatorActionSettings::step(const System& system) {
+  // update the reward
+  int score = getDecimalScore(0x89, 0x88, 0x87, &system);
+  m_reward = score - m_score;
+  m_score = score;
 
-    // update the reward
-    int score = getDecimalScore(0x89, 0x88, 0x87, &system);
-    m_reward = score - m_score;
-    m_score = score;
-
-    // update terminal status
-    m_lives = readRam(&system, 0x83);
-    int is_start_screen = readRam(&system, 0x81) == 0x00;
-    m_terminal = (m_lives == 0) && !is_start_screen;
+  // update terminal status
+  m_lives = readRam(&system, 0x83);
+  int is_start_screen = readRam(&system, 0x81) == 0x00;
+  m_terminal = (m_lives == 0) && !is_start_screen;
 }
-
 
 /* is end of game */
-bool ElevatorActionSettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool ElevatorActionSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t ElevatorActionSettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t ElevatorActionSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool ElevatorActionSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_UP:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_DOWN:
-        case PLAYER_A_UPRIGHT:
-        case PLAYER_A_UPLEFT:
-        case PLAYER_A_DOWNRIGHT:
-        case PLAYER_A_DOWNLEFT:
-        case PLAYER_A_UPFIRE:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_LEFTFIRE:
-        case PLAYER_A_DOWNFIRE:
-        case PLAYER_A_UPRIGHTFIRE:
-        case PLAYER_A_UPLEFTFIRE:
-        case PLAYER_A_DOWNRIGHTFIRE:
-        case PLAYER_A_DOWNLEFTFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool ElevatorActionSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_UP:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_DOWN:
+    case PLAYER_A_UPRIGHT:
+    case PLAYER_A_UPLEFT:
+    case PLAYER_A_DOWNRIGHT:
+    case PLAYER_A_DOWNLEFT:
+    case PLAYER_A_UPFIRE:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_LEFTFIRE:
+    case PLAYER_A_DOWNFIRE:
+    case PLAYER_A_UPRIGHTFIRE:
+    case PLAYER_A_UPLEFTFIRE:
+    case PLAYER_A_DOWNRIGHTFIRE:
+    case PLAYER_A_DOWNLEFTFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void ElevatorActionSettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
-    m_lives    = 4;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
+  m_lives = 4;
 }
 
-
 /* saves the state of the rom settings */
-void ElevatorActionSettings::saveState(Serializer & ser) {
+void ElevatorActionSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
@@ -121,7 +100,7 @@ void ElevatorActionSettings::saveState(Serializer & ser) {
 }
 
 // loads the state of the rom settings
-void ElevatorActionSettings::loadState(Deserializer & ser) {
+void ElevatorActionSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();
@@ -129,8 +108,8 @@ void ElevatorActionSettings::loadState(Deserializer & ser) {
 }
 
 ActionVect ElevatorActionSettings::getStartingActions() {
-    ActionVect startingActions;
-    for (int i=0; i<16; i++)
-        startingActions.push_back(PLAYER_A_FIRE);
-    return startingActions;
+  ActionVect startingActions;
+  for (int i = 0; i < 16; i++)
+    startingActions.push_back(PLAYER_A_FIRE);
+  return startingActions;
 }

--- a/src/games/supported/ElevatorAction.hpp
+++ b/src/games/supported/ElevatorAction.hpp
@@ -29,51 +29,47 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Elevator Action settings */
 class ElevatorActionSettings : public RomSettings {
+ public:
+  ElevatorActionSettings();
 
-    public:
+  // reset
+  void reset();
 
-        ElevatorActionSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "elevator_action"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // the rom-name
-        const char* rom() const { return "elevator_action"; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  ActionVect getStartingActions();
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
-        ActionVect getStartingActions();
-
-        virtual int lives() { return isTerminal() ? 0 : m_lives; }
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 };
 
-#endif // __ELEVATORACTION_HPP__
+#endif  // __ELEVATORACTION_HPP__

--- a/src/games/supported/Enduro.cpp
+++ b/src/games/supported/Enduro.cpp
@@ -13,112 +13,94 @@
 
 #include "../RomUtils.hpp"
 
-
-EnduroSettings::EnduroSettings() {
-
-    reset();
-}
-
+EnduroSettings::EnduroSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* EnduroSettings::clone() const {
-
-    RomSettings* rval = new EnduroSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new EnduroSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void EnduroSettings::step(const System& system) {
+  // update the reward
+  int score = 0;
+  int level = readRam(&system, 0xAD);
+  if (level != 0) {
+    int cars_passed = getDecimalScore(0xAB, 0xAC, &system);
+    if (level == 1)
+      cars_passed = 200 - cars_passed;
+    else if (level >= 2)
+      cars_passed = 300 - cars_passed;
+    else
+      assert(false);
 
-    // update the reward
-    int score = 0;
-    int level = readRam(&system, 0xAD);
-    if (level != 0) {
-        int cars_passed = getDecimalScore(0xAB, 0xAC, &system);
-        if (level == 1) cars_passed = 200 - cars_passed;
-        else if (level >= 2) cars_passed = 300 - cars_passed;
-        else assert(false);
-
-        // First level has 200 cars
-        if (level >= 2) {
-            score = 200;
-            // For every level after the first, 300 cars
-            score += (level - 2) * 300;
-        }
-        score += cars_passed;
+    // First level has 200 cars
+    if (level >= 2) {
+      score = 200;
+      // For every level after the first, 300 cars
+      score += (level - 2) * 300;
     }
+    score += cars_passed;
+  }
 
-    m_reward = score - m_score;
-    m_score = score;
+  m_reward = score - m_score;
+  m_score = score;
 
-    // update terminal status
-    //int timeLeft = readRam(&system, 0xB1);
-    int deathFlag = readRam(&system, 0xAF);
-    m_terminal = deathFlag == 0xFF;
+  // update terminal status
+  //int timeLeft = readRam(&system, 0xB1);
+  int deathFlag = readRam(&system, 0xAF);
+  m_terminal = deathFlag == 0xFF;
 }
-
 
 /* is end of game */
-bool EnduroSettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool EnduroSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t EnduroSettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t EnduroSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool EnduroSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_DOWN:
-        case PLAYER_A_DOWNRIGHT:
-        case PLAYER_A_DOWNLEFT:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_LEFTFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool EnduroSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_DOWN:
+    case PLAYER_A_DOWNRIGHT:
+    case PLAYER_A_DOWNLEFT:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_LEFTFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void EnduroSettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
 }
 
-
 /* saves the state of the rom settings */
-void EnduroSettings::saveState(Serializer & ser) {
+void EnduroSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
 }
 
 // loads the state of the rom settings
-void EnduroSettings::loadState(Deserializer & ser) {
+void EnduroSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();
 }
 
 ActionVect EnduroSettings::getStartingActions() {
-    ActionVect startingActions;
-    startingActions.push_back(PLAYER_A_FIRE);
-    return startingActions;
+  ActionVect startingActions;
+  startingActions.push_back(PLAYER_A_FIRE);
+  return startingActions;
 }

--- a/src/games/supported/Enduro.hpp
+++ b/src/games/supported/Enduro.hpp
@@ -29,50 +29,46 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Enduro settings */
 class EnduroSettings : public RomSettings {
+ public:
+  EnduroSettings();
 
-    public:
+  // reset
+  void reset();
 
-        EnduroSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "enduro"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // the rom-name
-        const char* rom() const { return "enduro"; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  ActionVect getStartingActions();
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  virtual int lives() { return 0; }
 
-        ActionVect getStartingActions();
-
-        virtual int lives() { return 0; }
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
 };
 
-#endif // __ENDURO_HPP__
+#endif  // __ENDURO_HPP__

--- a/src/games/supported/FishingDerby.cpp
+++ b/src/games/supported/FishingDerby.cpp
@@ -14,107 +14,86 @@
 #include "../RomUtils.hpp"
 using namespace std;
 
-
-FishingDerbySettings::FishingDerbySettings() {
-
-    reset();
-}
-
+FishingDerbySettings::FishingDerbySettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* FishingDerbySettings::clone() const {
-
-    RomSettings* rval = new FishingDerbySettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new FishingDerbySettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void FishingDerbySettings::step(const System& system) {
+  // update the reward
+  int my_score = max(getDecimalScore(0xBD, &system), 0);
+  int oppt_score = max(getDecimalScore(0xBE, &system), 0);
+  int score = my_score - oppt_score;
+  m_reward = score - m_score;
+  m_score = score;
 
-    // update the reward
-    int my_score   = max(getDecimalScore(0xBD, &system), 0);
-    int oppt_score = max(getDecimalScore(0xBE, &system), 0);
-    int score = my_score - oppt_score;
-    m_reward = score - m_score;
-    m_score = score;
+  // update terminal status
+  int my_score_byte = readRam(&system, 0xBD);
+  int my_oppt_score_byte = readRam(&system, 0xBE);
 
-    // update terminal status
-    int my_score_byte      = readRam(&system, 0xBD);
-    int my_oppt_score_byte = readRam(&system, 0xBE);
-
-    m_terminal = my_score_byte == 0x99 || my_oppt_score_byte == 0x99;
+  m_terminal = my_score_byte == 0x99 || my_oppt_score_byte == 0x99;
 }
-
 
 /* is end of game */
-bool FishingDerbySettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool FishingDerbySettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t FishingDerbySettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t FishingDerbySettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool FishingDerbySettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_UP:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_DOWN:
-        case PLAYER_A_UPRIGHT:
-        case PLAYER_A_UPLEFT:
-        case PLAYER_A_DOWNRIGHT:
-        case PLAYER_A_DOWNLEFT:
-        case PLAYER_A_UPFIRE:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_LEFTFIRE:
-        case PLAYER_A_DOWNFIRE:
-        case PLAYER_A_UPRIGHTFIRE:
-        case PLAYER_A_UPLEFTFIRE:
-        case PLAYER_A_DOWNRIGHTFIRE:
-        case PLAYER_A_DOWNLEFTFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool FishingDerbySettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_UP:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_DOWN:
+    case PLAYER_A_UPRIGHT:
+    case PLAYER_A_UPLEFT:
+    case PLAYER_A_DOWNRIGHT:
+    case PLAYER_A_DOWNLEFT:
+    case PLAYER_A_UPFIRE:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_LEFTFIRE:
+    case PLAYER_A_DOWNFIRE:
+    case PLAYER_A_UPRIGHTFIRE:
+    case PLAYER_A_UPLEFTFIRE:
+    case PLAYER_A_DOWNRIGHTFIRE:
+    case PLAYER_A_DOWNLEFTFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void FishingDerbySettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
 }
 
-
 /* saves the state of the rom settings */
-void FishingDerbySettings::saveState(Serializer & ser) {
+void FishingDerbySettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
 }
 
 // loads the state of the rom settings
-void FishingDerbySettings::loadState(Deserializer & ser) {
+void FishingDerbySettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();
 }
 
 DifficultyVect FishingDerbySettings::getAvailableDifficulties() {
-    DifficultyVect diff = {0, 1, 2, 3};
-    return diff;
+  DifficultyVect diff = {0, 1, 2, 3};
+  return diff;
 }

--- a/src/games/supported/FishingDerby.hpp
+++ b/src/games/supported/FishingDerby.hpp
@@ -29,52 +29,48 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Fishing Derby settings */
 class FishingDerbySettings : public RomSettings {
+ public:
+  FishingDerbySettings();
 
-    public:
+  // reset
+  void reset();
 
-        FishingDerbySettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "fishing_derby"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // the rom-name
-        const char* rom() const { return "fishing_derby"; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  virtual int lives() { return 0; }
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  // returns a list of difficulties that the game can be played in
+  // in this game, there are 4 available difficulties
+  DifficultyVect getAvailableDifficulties();
 
-        virtual int lives() { return 0; }
-
-        // returns a list of difficulties that the game can be played in
-        // in this game, there are 4 available difficulties
-        DifficultyVect getAvailableDifficulties();
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
 };
 
-#endif // __FISHINGDERBY_HPP__
+#endif  // __FISHINGDERBY_HPP__

--- a/src/games/supported/Freeway.cpp
+++ b/src/games/supported/Freeway.cpp
@@ -15,84 +15,69 @@
 
 #include "../RomUtils.hpp"
 
-
 FreewaySettings::FreewaySettings() {
-
-    m_reward    = 0;
-    m_score     = 0;
-    m_terminal  = false;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
 }
-
 
 /* create a new instance of the rom */
 RomSettings* FreewaySettings::clone() const {
-
-    RomSettings* rval = new FreewaySettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new FreewaySettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void FreewaySettings::step(const System& system) {
+  // update the reward
+  int score = getDecimalScore(103, -1, &system);
+  int reward = score - m_score;
+  if (reward < 0)
+    reward = 0;
+  if (reward > 1)
+    reward = 1;
+  m_reward = reward;
+  m_score = score;
 
-    // update the reward
-    int score = getDecimalScore(103, -1, &system);
-    int reward = score - m_score;
-    if (reward < 0) reward = 0;
-    if (reward > 1) reward = 1;
-    m_reward = reward;
-    m_score = score;
-
-    // update terminal status
-    m_terminal = readRam(&system, 22) == 1;
+  // update terminal status
+  m_terminal = readRam(&system, 22) == 1;
 }
-
 
 /* is end of game */
-bool FreewaySettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool FreewaySettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t FreewaySettings::getReward() const {
-
-    return m_reward;
-}
+reward_t FreewaySettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool FreewaySettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_UP:
-        case PLAYER_A_DOWN:
-            return true;
-        default:
-            return false;
-    }
+bool FreewaySettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_UP:
+    case PLAYER_A_DOWN:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void FreewaySettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
 }
 
 /* saves the state of the rom settings */
-void FreewaySettings::saveState(Serializer & ser) {
+void FreewaySettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
 }
 
 // loads the state of the rom settings
-void FreewaySettings::loadState(Deserializer & ser) {
+void FreewaySettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();
@@ -100,35 +85,34 @@ void FreewaySettings::loadState(Deserializer & ser) {
 
 // returns a list of mode that the game can be played in
 ModeVect FreewaySettings::getAvailableModes() {
-    ModeVect modes(getNumModes());
-    for (unsigned int i = 0; i < modes.size(); i++) {
-        modes[i] = i;
-    }
-    return modes;
+  ModeVect modes(getNumModes());
+  for (unsigned int i = 0; i < modes.size(); i++) {
+    modes[i] = i;
+  }
+  return modes;
 }
 
 // set the mode of the game
 // the given mode must be one returned by the previous function
-void FreewaySettings::setMode(game_mode_t m, System &system,
-                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
-
-    if(m < getNumModes()) {
-        // read the mode we are currently in
-        unsigned char mode = readRam(&system, 0x80);
-        // press select until the correct mode is reached
-        while (mode != m) {
-            environment->pressSelect();
-            mode = readRam(&system, 0x80);
-        }
-        //reset the environment to apply changes.
-        environment->softReset();
+void FreewaySettings::setMode(
+    game_mode_t m, System& system,
+    std::unique_ptr<StellaEnvironmentWrapper> environment) {
+  if (m < getNumModes()) {
+    // read the mode we are currently in
+    unsigned char mode = readRam(&system, 0x80);
+    // press select until the correct mode is reached
+    while (mode != m) {
+      environment->pressSelect();
+      mode = readRam(&system, 0x80);
     }
-    else {
-        throw std::runtime_error("This mode doesn't currently exist for this game");
-    }
- }
+    //reset the environment to apply changes.
+    environment->softReset();
+  } else {
+    throw std::runtime_error("This mode doesn't currently exist for this game");
+  }
+}
 
 DifficultyVect FreewaySettings::getAvailableDifficulties() {
-    DifficultyVect diff = {0, 1};
-    return diff;
+  DifficultyVect diff = {0, 1};
+  return diff;
 }

--- a/src/games/supported/Freeway.hpp
+++ b/src/games/supported/Freeway.hpp
@@ -30,63 +30,60 @@
 #include "stella_environment_wrapper.hpp"
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Freeway */
 class FreewaySettings : public RomSettings {
+ public:
+  FreewaySettings();
 
-    public:
+  // reset
+  void reset();
 
-        FreewaySettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "freeway"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // get the available number of modes
+  unsigned int getNumModes() const { return 8; }
 
-        // the rom-name
-        const char* rom() const { return "freeway"; }
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // get the available number of modes
-        unsigned int getNumModes() const { return 8; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  virtual int lives() { return 0; }
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  // returns a list of mode that the game can be played in
+  // in this game, there are 8 available modes
+  ModeVect getAvailableModes();
 
-        virtual int lives() { return 0; }
+  // set the mode of the game
+  // the given mode must be one returned by the previous function
+  void setMode(game_mode_t, System& system,
+               std::unique_ptr<StellaEnvironmentWrapper> environment);
 
-        // returns a list of mode that the game can be played in
-        // in this game, there are 8 available modes
-        ModeVect getAvailableModes();
+  // returns a list of difficulties that the game can be played in
+  // in this game, there are 2 available difficulties
+  DifficultyVect getAvailableDifficulties();
 
-        // set the mode of the game
-        // the given mode must be one returned by the previous function
-        void setMode(game_mode_t, System &system,
-                     std::unique_ptr<StellaEnvironmentWrapper> environment);
-
-        // returns a list of difficulties that the game can be played in
-        // in this game, there are 2 available difficulties
-        DifficultyVect getAvailableDifficulties();
-
-    private:
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
 };
 
-#endif // __FREEWAY_HPP__
+#endif  // __FREEWAY_HPP__

--- a/src/games/supported/Frogger.cpp
+++ b/src/games/supported/Frogger.cpp
@@ -13,68 +13,58 @@
 
 #include "../RomUtils.hpp"
 
-FroggerSettings::FroggerSettings() {
-    reset();
-}
+FroggerSettings::FroggerSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* FroggerSettings::clone() const {
-    RomSettings* rval = new FroggerSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new FroggerSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void FroggerSettings::step(const System& system) {
-    // update the reward
-    int score = getDecimalScore(0xCE, 0xCC, &system);
-    int reward = score - m_score;
-    m_reward = reward;
-    m_score = score;
+  // update the reward
+  int score = getDecimalScore(0xCE, 0xCC, &system);
+  int reward = score - m_score;
+  m_reward = reward;
+  m_score = score;
 
-    // update terminal status
-	m_lives = readRam(&system, 0xD0);
-    m_terminal = readRam(&system, 0xD0) == 0xFF;
+  // update terminal status
+  m_lives = readRam(&system, 0xD0);
+  m_terminal = readRam(&system, 0xD0) == 0xFF;
 }
-
 
 /* is end of game */
-bool FroggerSettings::isTerminal() const {
-    return m_terminal;
-};
-
+bool FroggerSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t FroggerSettings::getReward() const {
-    return m_reward;
-}
+reward_t FroggerSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool FroggerSettings::isMinimal(const Action &a) const {
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_UP:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_DOWN:
-            return true;
-        default:
-            return false;
-    }
+bool FroggerSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_UP:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_DOWN:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void FroggerSettings::reset() {
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
-    m_lives    = 4;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
+  m_lives = 4;
 }
 
 /* saves the state of the rom settings */
-void FroggerSettings::saveState(Serializer & ser) {
+void FroggerSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
@@ -82,7 +72,7 @@ void FroggerSettings::saveState(Serializer & ser) {
 }
 
 // loads the state of the rom settings
-void FroggerSettings::loadState(Deserializer & ser) {
+void FroggerSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();
@@ -90,7 +80,7 @@ void FroggerSettings::loadState(Deserializer & ser) {
 }
 
 ActionVect FroggerSettings::getStartingActions() {
-    ActionVect startingActions;
-    startingActions.push_back(RESET);
-    return startingActions;
+  ActionVect startingActions;
+  startingActions.push_back(RESET);
+  return startingActions;
 }

--- a/src/games/supported/Frogger.hpp
+++ b/src/games/supported/Frogger.hpp
@@ -14,50 +14,49 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Frogger */
 class FroggerSettings : public RomSettings {
-    public:
-        FroggerSettings();
+ public:
+  FroggerSettings();
 
-        // reset
-        void reset();
+  // reset
+  void reset();
 
-        // is end of game
-        bool isTerminal() const;
+  // is end of game
+  bool isTerminal() const;
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // the rom-name
-		// MD5 081e2c114c9c20b61acf25fc95c71bf4
-        const char* rom() const { return "frogger"; }
+  // the rom-name
+  // MD5 081e2c114c9c20b61acf25fc95c71bf4
+  const char* rom() const { return "frogger"; }
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // Frogger requires the RESET action to start the game
-        ActionVect getStartingActions();
+  // Frogger requires the RESET action to start the game
+  ActionVect getStartingActions();
 
-        virtual int lives() { return isTerminal() ? 0 : m_lives; }
+  virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
-    private:
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 };
 
-#endif // __FROGGER_HPP__
+#endif  // __FROGGER_HPP__

--- a/src/games/supported/Frostbite.cpp
+++ b/src/games/supported/Frostbite.cpp
@@ -28,97 +28,76 @@
 
 #include "../RomUtils.hpp"
 
-
-FrostbiteSettings::FrostbiteSettings() {
-
-    reset();
-}
-
+FrostbiteSettings::FrostbiteSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* FrostbiteSettings::clone() const {
-
-    RomSettings* rval = new FrostbiteSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new FrostbiteSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void FrostbiteSettings::step(const System& system) {
+  // update the reward
+  int score = getDecimalScore(0xCA, 0xC9, 0xC8, &system);
+  int reward = score - m_score;
+  m_reward = reward;
+  m_score = score;
 
-    // update the reward
-    int score = getDecimalScore(0xCA, 0xC9, 0xC8, &system);
-    int reward = score - m_score;
-    m_reward = reward;
-    m_score = score;
+  // update terminal status
+  // MGB: the maximum achievable life is 9. The system will actually let us set the byte to
+  // higher values & properly decrement, but we do not gain lives beyond 9.
+  int lives_byte = (readRam(&system, 0xCC) & 0xF);
+  int flag = readRam(&system, 0xF1) & 0x80;
+  m_terminal = (lives_byte == 0 && flag != 0);
 
-    // update terminal status
-    // MGB: the maximum achievable life is 9. The system will actually let us set the byte to
-    // higher values & properly decrement, but we do not gain lives beyond 9.
-    int lives_byte = (readRam(&system, 0xCC) & 0xF);
-    int flag  = readRam(&system, 0xF1) & 0x80;
-    m_terminal = (lives_byte == 0 && flag != 0);
-
-    m_lives = lives_byte + 1;
-
+  m_lives = lives_byte + 1;
 }
-
 
 /* is end of game */
-bool FrostbiteSettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool FrostbiteSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t FrostbiteSettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t FrostbiteSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool FrostbiteSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_UP:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_DOWN:
-        case PLAYER_A_UPRIGHT:
-        case PLAYER_A_UPLEFT:
-        case PLAYER_A_DOWNRIGHT:
-        case PLAYER_A_DOWNLEFT:
-        case PLAYER_A_UPFIRE:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_LEFTFIRE:
-        case PLAYER_A_DOWNFIRE:
-        case PLAYER_A_UPRIGHTFIRE:
-        case PLAYER_A_UPLEFTFIRE:
-        case PLAYER_A_DOWNRIGHTFIRE:
-        case PLAYER_A_DOWNLEFTFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool FrostbiteSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_UP:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_DOWN:
+    case PLAYER_A_UPRIGHT:
+    case PLAYER_A_UPLEFT:
+    case PLAYER_A_DOWNRIGHT:
+    case PLAYER_A_DOWNLEFT:
+    case PLAYER_A_UPFIRE:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_LEFTFIRE:
+    case PLAYER_A_DOWNFIRE:
+    case PLAYER_A_UPRIGHTFIRE:
+    case PLAYER_A_UPLEFTFIRE:
+    case PLAYER_A_DOWNRIGHTFIRE:
+    case PLAYER_A_DOWNLEFTFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void FrostbiteSettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
-    m_lives    = 4;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
+  m_lives = 4;
 }
 
 /* saves the state of the rom settings */
-void FrostbiteSettings::saveState(Serializer & ser) {
+void FrostbiteSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
@@ -126,7 +105,7 @@ void FrostbiteSettings::saveState(Serializer & ser) {
 }
 
 // loads the state of the rom settings
-void FrostbiteSettings::loadState(Deserializer & ser) {
+void FrostbiteSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();
@@ -135,27 +114,26 @@ void FrostbiteSettings::loadState(Deserializer & ser) {
 
 // returns a list of mode that the game can be played in
 ModeVect FrostbiteSettings::getAvailableModes() {
-    ModeVect modes = {0, 2};
-    return modes;
+  ModeVect modes = {0, 2};
+  return modes;
 }
 
 // set the mode of the game
 // the given mode must be one returned by the previous function
-void FrostbiteSettings::setMode(game_mode_t m, System &system,
-                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
-
-    if(m == 0 || m == 2) {
-        // read the mode we are currently in
-        unsigned char mode = readRam(&system, 0x80);
-        // press select until the correct mode is reached
-        while (mode != m) {
-            environment->pressSelect(1);
-            mode = readRam(&system, 0x80);
-        }
-        //reset the environment to apply changes.
-        environment->softReset();
+void FrostbiteSettings::setMode(
+    game_mode_t m, System& system,
+    std::unique_ptr<StellaEnvironmentWrapper> environment) {
+  if (m == 0 || m == 2) {
+    // read the mode we are currently in
+    unsigned char mode = readRam(&system, 0x80);
+    // press select until the correct mode is reached
+    while (mode != m) {
+      environment->pressSelect(1);
+      mode = readRam(&system, 0x80);
     }
-    else {
-        throw std::runtime_error("This mode doesn't currently exist for this game");
-    }
- }
+    //reset the environment to apply changes.
+    environment->softReset();
+  } else {
+    throw std::runtime_error("This mode doesn't currently exist for this game");
+  }
+}

--- a/src/games/supported/Frostbite.hpp
+++ b/src/games/supported/Frostbite.hpp
@@ -29,62 +29,57 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Frostbite */
 class FrostbiteSettings : public RomSettings {
+ public:
+  FrostbiteSettings();
 
-    public:
+  // reset
+  void reset();
 
-        FrostbiteSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "frostbite"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // get the available number of modes
+  unsigned int getNumModes() const { return 2; }
 
-        // the rom-name
-        const char* rom() const { return "frostbite"; }
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // get the available number of modes
-        unsigned int getNumModes() const { return 2; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  // returns a list of mode that the game can be played in
+  // in this game, there are 2 available modes
+  ModeVect getAvailableModes();
 
-        virtual int lives() { return isTerminal() ? 0 : m_lives; }
+  // set the mode of the game
+  // the given mode must be one returned by the previous function
+  void setMode(game_mode_t, System& system,
+               std::unique_ptr<StellaEnvironmentWrapper> environment);
 
-        // returns a list of mode that the game can be played in
-        // in this game, there are 2 available modes
-        ModeVect getAvailableModes();
-
-        // set the mode of the game
-        // the given mode must be one returned by the previous function
-        void setMode(game_mode_t, System &system,
-                     std::unique_ptr<StellaEnvironmentWrapper> environment);
-
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 };
 
-#endif // __FROSTBITE_HPP__
+#endif  // __FROSTBITE_HPP__

--- a/src/games/supported/Galaxian.cpp
+++ b/src/games/supported/Galaxian.cpp
@@ -29,85 +29,73 @@
 
 ActionVect GalaxianSettings::actions;
 
-GalaxianSettings::GalaxianSettings() {
-    reset();
-}
-
+GalaxianSettings::GalaxianSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* GalaxianSettings::clone() const {
-    RomSettings* rval = new GalaxianSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new GalaxianSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void GalaxianSettings::step(const System& system) {
-    // update the reward
-    int score = getDecimalScore(0xAE, 0xAD, 0xAC, &system);
-    // reward cannot get negative in this game. When it does, it means that the score has looped
-    // (overflow)
-    m_reward = score - m_score;
-    if(m_reward < 0) {
-        // 1000000 is the highest possible score
-        const int maximumScore = 1000000;
-        m_reward = (maximumScore - m_score) + score;
-    }
-    m_score = score;
+  // update the reward
+  int score = getDecimalScore(0xAE, 0xAD, 0xAC, &system);
+  // reward cannot get negative in this game. When it does, it means that the score has looped
+  // (overflow)
+  m_reward = score - m_score;
+  if (m_reward < 0) {
+    // 1000000 is the highest possible score
+    const int maximumScore = 1000000;
+    m_reward = (maximumScore - m_score) + score;
+  }
+  m_score = score;
 
-    // update terminal and lives
-    // If bit 0x80 is on, then game is over
-    int some_byte = readRam(&system, 0xBF);
-    m_terminal = (some_byte & 0x80);
-    if (m_terminal) {
-        // Force lives to zero when the game is over since otherwise it would be left as 1
-        m_lives = 0;
-    } else {
-        m_lives = readRam(&system, 0xB9) + 1;  // 0xB9 keeps the number of lives shown below the screen
-    }
+  // update terminal and lives
+  // If bit 0x80 is on, then game is over
+  int some_byte = readRam(&system, 0xBF);
+  m_terminal = (some_byte & 0x80);
+  if (m_terminal) {
+    // Force lives to zero when the game is over since otherwise it would be left as 1
+    m_lives = 0;
+  } else {
+    m_lives = readRam(&system, 0xB9) +
+              1; // 0xB9 keeps the number of lives shown below the screen
+  }
 }
-
 
 /* is end of game */
-bool GalaxianSettings::isTerminal() const {
-    return m_terminal;
-};
-
+bool GalaxianSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t GalaxianSettings::getReward() const {
-    return m_reward;
-}
-
+reward_t GalaxianSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool GalaxianSettings::isMinimal(const Action &a) const {
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_LEFTFIRE:
-        case PLAYER_A_RIGHTFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool GalaxianSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_LEFTFIRE:
+    case PLAYER_A_RIGHTFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void GalaxianSettings::reset() {
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
-    m_lives    = 3;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
+  m_lives = 3;
 }
 
-
 /* saves the state of the rom settings */
-void GalaxianSettings::saveState(Serializer & ser) {
+void GalaxianSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
@@ -115,7 +103,7 @@ void GalaxianSettings::saveState(Serializer & ser) {
 }
 
 // loads the state of the rom settings
-void GalaxianSettings::loadState(Deserializer & ser) {
+void GalaxianSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();
@@ -124,27 +112,26 @@ void GalaxianSettings::loadState(Deserializer & ser) {
 
 // returns a list of mode that the game can be played in
 ModeVect GalaxianSettings::getAvailableModes() {
-    ModeVect modes = { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
-    return modes;
+  ModeVect modes = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+  return modes;
 }
 
 // set the mode of the game
 // the given mode must be one returned by the previous function
-void GalaxianSettings::setMode(game_mode_t mode, System &system,
-                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
+void GalaxianSettings::setMode(
+    game_mode_t mode, System& system,
+    std::unique_ptr<StellaEnvironmentWrapper> environment) {
+  if (mode == 0)
+    mode = 1;
 
-    if (mode == 0)
-        mode = 1;
-
-    if (mode >= 1 && mode <= 9) {
-        // press select until the correct mode is reached
-        while (mode != static_cast<unsigned>(readRam(&system, 0xB3))) {
-            environment->pressSelect();
-        }
-        //reset the environment to apply changes.
-        environment->softReset();
-    } else
-    {
-        throw std::runtime_error("This mode doesn't currently exist for this game");
+  if (mode >= 1 && mode <= 9) {
+    // press select until the correct mode is reached
+    while (mode != static_cast<unsigned>(readRam(&system, 0xB3))) {
+      environment->pressSelect();
     }
+    //reset the environment to apply changes.
+    environment->softReset();
+  } else {
+    throw std::runtime_error("This mode doesn't currently exist for this game");
+  }
 }

--- a/src/games/supported/Galaxian.hpp
+++ b/src/games/supported/Galaxian.hpp
@@ -28,67 +28,62 @@
 
 #include "../RomSettings.hpp"
 
-
 // RL wrapper for Galaxian
 class GalaxianSettings : public RomSettings {
+ public:
+  GalaxianSettings();
 
-    public:
+  // reset
+  void reset();
 
-        GalaxianSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "galaxian"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // the rom-name
-        const char* rom() const { return "galaxian"; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  // get the available number of modes
+  unsigned int getNumModes() const { return 9; }
 
-        virtual int lives() { return isTerminal() ? 0 : m_lives; }
+  // returns a list of mode that the game can be played in
+  ModeVect getAvailableModes();
 
-        // get the available number of modes
-        unsigned int getNumModes() const { return 9; }
+  // set the mode of the game
+  // the given mode must be one returned by the previous function
+  void setMode(game_mode_t mode, System& system,
+               std::unique_ptr<StellaEnvironmentWrapper> environment);
 
-        // returns a list of mode that the game can be played in
-        ModeVect getAvailableModes();
+  // Returns a list of difficulties that the game can be played in.
+  // 2 difficulties: 0 is left B, 1 is left A
+  DifficultyVect getAvailableDifficulties() { return {0, 1}; }
 
-        // set the mode of the game
-        // the given mode must be one returned by the previous function
-        void setMode(game_mode_t mode, System &system,
-                     std::unique_ptr<StellaEnvironmentWrapper> environment);
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 
-        // Returns a list of difficulties that the game can be played in.
-        // 2 difficulties: 0 is left B, 1 is left A
-        DifficultyVect getAvailableDifficulties() { return { 0, 1}; }
-
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
-
-        static ActionVect actions;
+  static ActionVect actions;
 };
 
-#endif // __GALAXIAN_HPP__
+#endif  // __GALAXIAN_HPP__

--- a/src/games/supported/Gopher.hpp
+++ b/src/games/supported/Gopher.hpp
@@ -29,68 +29,64 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Gopher */
 class GopherSettings : public RomSettings {
+ public:
+  GopherSettings();
 
-    public:
+  // reset
+  void reset();
 
-        GopherSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "gopher"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // get the available number of modes
+  unsigned int getNumModes() const { return 2; }
 
-        // the rom-name
-        const char* rom() const { return "gopher"; }
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // get the available number of modes
-        unsigned int getNumModes() const { return 2; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  // Gopher requires the fire action to start the game
+  ActionVect getStartingActions();
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
-        // Gopher requires the fire action to start the game
-        ActionVect getStartingActions();
+  // returns a list of mode that the game can be played in
+  // in this game, there are 8 available modes
+  ModeVect getAvailableModes();
 
-        virtual int lives() { return isTerminal() ? 0 : m_lives; }
+  // set the mode of the game
+  // the given mode must be one returned by the previous function
+  void setMode(game_mode_t, System& system,
+               std::unique_ptr<StellaEnvironmentWrapper> environment);
 
-        // returns a list of mode that the game can be played in
-        // in this game, there are 8 available modes
-        ModeVect getAvailableModes();
+  // returns a list of difficulties that the game can be played in
+  // in this game, there are 2 available difficulties
+  DifficultyVect getAvailableDifficulties();
 
-        // set the mode of the game
-        // the given mode must be one returned by the previous function
-        void setMode(game_mode_t, System &system,
-                     std::unique_ptr<StellaEnvironmentWrapper> environment);
-
-        // returns a list of difficulties that the game can be played in
-        // in this game, there are 2 available difficulties
-        DifficultyVect getAvailableDifficulties();
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 };
 
-#endif // __GOPHER_HPP__
+#endif  // __GOPHER_HPP__

--- a/src/games/supported/Gravitar.cpp
+++ b/src/games/supported/Gravitar.cpp
@@ -28,97 +28,76 @@
 
 #include "../RomUtils.hpp"
 
-
-GravitarSettings::GravitarSettings() {
-
-    reset();
-}
-
+GravitarSettings::GravitarSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* GravitarSettings::clone() const {
-
-    RomSettings* rval = new GravitarSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new GravitarSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void GravitarSettings::step(const System& system) {
+  // update the reward
+  int score = getDecimalScore(9, 8, 7, &system);
+  int reward = score - m_score;
+  m_reward = reward;
+  m_score = score;
 
-    // update the reward
-    int score = getDecimalScore(9, 8, 7, &system);
-    int reward = score - m_score;
-    m_reward = reward;
-    m_score = score;
+  // Byte 0x81 contains information about the current screen
+  int screen_byte = readRam(&system, 0x81);
 
-    // Byte 0x81 contains information about the current screen
-    int screen_byte = readRam(&system, 0x81);
+  // update terminal status
+  m_terminal = screen_byte == 0x01;
 
-    // update terminal status
-    m_terminal = screen_byte == 0x01;
-
-    // On the starting screen, we set our lives total to 6; otherwise read it from data
-    m_lives = screen_byte == 0x0? 6 : (readRam(&system, 0x84) + 1);
+  // On the starting screen, we set our lives total to 6; otherwise read it from data
+  m_lives = screen_byte == 0x0 ? 6 : (readRam(&system, 0x84) + 1);
 }
-
 
 /* is end of game */
-bool GravitarSettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool GravitarSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t GravitarSettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t GravitarSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool GravitarSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_UP:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_DOWN:
-        case PLAYER_A_UPRIGHT:
-        case PLAYER_A_UPLEFT:
-        case PLAYER_A_DOWNRIGHT:
-        case PLAYER_A_DOWNLEFT:
-        case PLAYER_A_UPFIRE:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_LEFTFIRE:
-        case PLAYER_A_DOWNFIRE:
-        case PLAYER_A_UPRIGHTFIRE:
-        case PLAYER_A_UPLEFTFIRE:
-        case PLAYER_A_DOWNRIGHTFIRE:
-        case PLAYER_A_DOWNLEFTFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool GravitarSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_UP:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_DOWN:
+    case PLAYER_A_UPRIGHT:
+    case PLAYER_A_UPLEFT:
+    case PLAYER_A_DOWNRIGHT:
+    case PLAYER_A_DOWNLEFT:
+    case PLAYER_A_UPFIRE:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_LEFTFIRE:
+    case PLAYER_A_DOWNFIRE:
+    case PLAYER_A_UPRIGHTFIRE:
+    case PLAYER_A_UPLEFTFIRE:
+    case PLAYER_A_DOWNRIGHTFIRE:
+    case PLAYER_A_DOWNLEFTFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void GravitarSettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
-    m_lives    = 6;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
+  m_lives = 6;
 }
 
-
 /* saves the state of the rom settings */
-void GravitarSettings::saveState(Serializer & ser) {
+void GravitarSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
@@ -126,7 +105,7 @@ void GravitarSettings::saveState(Serializer & ser) {
 }
 
 // loads the state of the rom settings
-void GravitarSettings::loadState(Deserializer & ser) {
+void GravitarSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();
@@ -134,56 +113,55 @@ void GravitarSettings::loadState(Deserializer & ser) {
 }
 
 ActionVect GravitarSettings::getStartingActions() {
-    ActionVect startingActions;
-    for (int i=0; i<16; i++)
-        startingActions.push_back(PLAYER_A_FIRE);
-    return startingActions;
+  ActionVect startingActions;
+  for (int i = 0; i < 16; i++)
+    startingActions.push_back(PLAYER_A_FIRE);
+  return startingActions;
 }
 
 // returns a list of mode that the game can be played in
 ModeVect GravitarSettings::getAvailableModes() {
-    ModeVect modes(getNumModes());
-    for (unsigned int i = 0; i < modes.size(); i++) {
-        modes[i] = i;
-    }
-    return modes;
+  ModeVect modes(getNumModes());
+  for (unsigned int i = 0; i < modes.size(); i++) {
+    modes[i] = i;
+  }
+  return modes;
 }
 
 // set the mode of the game
 // the given mode must be one returned by the previous function
-void GravitarSettings::setMode(game_mode_t m, System &system,
-                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
-
-    if(m < getNumModes()) {
-        // read the mode we are currently in
-        unsigned char mode = readRam(&system, 0x80);
-        // press select until the correct mode is reached
-        while (mode != m) {
-            // hold select button for 10 frames
-            environment->pressSelect(10);
-            mode = readRam(&system, 0x80);
-        }
-
-        //update the number of lives
-        switch(m){
-            case 0:
-            case 2:
-                m_lives = 6;
-                break;
-            case 1:
-                m_lives = 15;
-                break;
-            case 3:
-                m_lives = 100;
-                break;
-            case 4:
-                m_lives = 25;
-                break;
-        }
-        //reset the environment to apply changes.
-        environment->softReset();
+void GravitarSettings::setMode(
+    game_mode_t m, System& system,
+    std::unique_ptr<StellaEnvironmentWrapper> environment) {
+  if (m < getNumModes()) {
+    // read the mode we are currently in
+    unsigned char mode = readRam(&system, 0x80);
+    // press select until the correct mode is reached
+    while (mode != m) {
+      // hold select button for 10 frames
+      environment->pressSelect(10);
+      mode = readRam(&system, 0x80);
     }
-    else {
-        throw std::runtime_error("This mode doesn't currently exist for this game");
+
+    //update the number of lives
+    switch (m) {
+      case 0:
+      case 2:
+        m_lives = 6;
+        break;
+      case 1:
+        m_lives = 15;
+        break;
+      case 3:
+        m_lives = 100;
+        break;
+      case 4:
+        m_lives = 25;
+        break;
     }
- }
+    //reset the environment to apply changes.
+    environment->softReset();
+  } else {
+    throw std::runtime_error("This mode doesn't currently exist for this game");
+  }
+}

--- a/src/games/supported/Gravitar.hpp
+++ b/src/games/supported/Gravitar.hpp
@@ -29,64 +29,60 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Gravitar */
 class GravitarSettings : public RomSettings {
+ public:
+  GravitarSettings();
 
-    public:
+  // reset
+  void reset();
 
-        GravitarSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "gravitar"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // get the available number of modes
+  unsigned int getNumModes() const { return 5; }
 
-        // the rom-name
-        const char* rom() const { return "gravitar"; }
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // get the available number of modes
-        unsigned int getNumModes() const { return 5; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  // Gravitar requires the fire action to start the game
+  ActionVect getStartingActions();
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
-        // Gravitar requires the fire action to start the game
-        ActionVect getStartingActions();
+  // returns a list of mode that the game can be played in
+  // in this game, there are 5 available modes
+  ModeVect getAvailableModes();
 
-        virtual int lives() { return isTerminal() ? 0 : m_lives; }
+  // set the mode of the game
+  // the given mode must be one returned by the previous function
+  void setMode(game_mode_t, System& system,
+               std::unique_ptr<StellaEnvironmentWrapper> environment);
 
-        // returns a list of mode that the game can be played in
-        // in this game, there are 5 available modes
-        ModeVect getAvailableModes();
-
-        // set the mode of the game
-        // the given mode must be one returned by the previous function
-        void setMode(game_mode_t, System &system,
-                     std::unique_ptr<StellaEnvironmentWrapper> environment);
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 };
 
-#endif // __GRAVITAR_HPP__
+#endif  // __GRAVITAR_HPP__

--- a/src/games/supported/Hero.cpp
+++ b/src/games/supported/Hero.cpp
@@ -28,93 +28,71 @@
 
 #include "../RomUtils.hpp"
 
-
-HeroSettings::HeroSettings() {
-
-    reset();
-}
-
+HeroSettings::HeroSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* HeroSettings::clone() const {
-
-    RomSettings* rval = new HeroSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new HeroSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void HeroSettings::step(const System& system) {
+  // update the reward
+  int score = getDecimalScore(0xB9, 0xB8, 0xB7, &system);
+  int reward = score - m_score;
+  m_reward = reward;
+  m_score = score;
 
-    // update the reward
-    int score = getDecimalScore(0xB9, 0xB8, 0xB7, &system);
-    int reward = score - m_score;
-    m_reward = reward;
-    m_score = score;
-
-    // update terminal status
-    m_lives = readRam(&system, 0xB3);
-    m_terminal = (m_lives == 0);
+  // update terminal status
+  m_lives = readRam(&system, 0xB3);
+  m_terminal = (m_lives == 0);
 }
-
 
 /* is end of game */
-bool HeroSettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool HeroSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t HeroSettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t HeroSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool HeroSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_UP:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_DOWN:
-        case PLAYER_A_UPRIGHT:
-        case PLAYER_A_UPLEFT:
-        case PLAYER_A_DOWNRIGHT:
-        case PLAYER_A_DOWNLEFT:
-        case PLAYER_A_UPFIRE:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_LEFTFIRE:
-        case PLAYER_A_DOWNFIRE:
-        case PLAYER_A_UPRIGHTFIRE:
-        case PLAYER_A_UPLEFTFIRE:
-        case PLAYER_A_DOWNRIGHTFIRE:
-        case PLAYER_A_DOWNLEFTFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool HeroSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_UP:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_DOWN:
+    case PLAYER_A_UPRIGHT:
+    case PLAYER_A_UPLEFT:
+    case PLAYER_A_DOWNRIGHT:
+    case PLAYER_A_DOWNLEFT:
+    case PLAYER_A_UPFIRE:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_LEFTFIRE:
+    case PLAYER_A_DOWNFIRE:
+    case PLAYER_A_UPRIGHTFIRE:
+    case PLAYER_A_UPLEFTFIRE:
+    case PLAYER_A_DOWNRIGHTFIRE:
+    case PLAYER_A_DOWNLEFTFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void HeroSettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
-    m_lives    = 4;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
+  m_lives = 4;
 }
 
-
-
 /* saves the state of the rom settings */
-void HeroSettings::saveState(Serializer & ser) {
+void HeroSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
@@ -122,7 +100,7 @@ void HeroSettings::saveState(Serializer & ser) {
 }
 
 // loads the state of the rom settings
-void HeroSettings::loadState(Deserializer & ser) {
+void HeroSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();
@@ -131,30 +109,29 @@ void HeroSettings::loadState(Deserializer & ser) {
 
 // returns a list of mode that the game can be played in
 ModeVect HeroSettings::getAvailableModes() {
-    ModeVect modes(getNumModes());
-    for (unsigned int i = 0; i < modes.size(); i++) {
-        modes[i] = i;
-    }
-    return modes;
+  ModeVect modes(getNumModes());
+  for (unsigned int i = 0; i < modes.size(); i++) {
+    modes[i] = i;
+  }
+  return modes;
 }
 
 // set the mode of the game
 // the given mode must be one returned by the previous function
-void HeroSettings::setMode(game_mode_t m, System &system,
-                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
-
-    if(m < getNumModes()) {
-        // read the mode we are currently in
-        unsigned char mode = readRam(&system, 0x80);
-        // press select until the correct mode is reached
-        while (mode != m) {
-            environment->pressSelect();
-            mode = readRam(&system, 0x80);
-        }
-        //reset the environment to apply changes.
-        environment->softReset();
+void HeroSettings::setMode(
+    game_mode_t m, System& system,
+    std::unique_ptr<StellaEnvironmentWrapper> environment) {
+  if (m < getNumModes()) {
+    // read the mode we are currently in
+    unsigned char mode = readRam(&system, 0x80);
+    // press select until the correct mode is reached
+    while (mode != m) {
+      environment->pressSelect();
+      mode = readRam(&system, 0x80);
     }
-    else {
-        throw std::runtime_error("This mode doesn't currently exist for this game");
-    }
- }
+    //reset the environment to apply changes.
+    environment->softReset();
+  } else {
+    throw std::runtime_error("This mode doesn't currently exist for this game");
+  }
+}

--- a/src/games/supported/Hero.hpp
+++ b/src/games/supported/Hero.hpp
@@ -29,61 +29,57 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Hero */
 class HeroSettings : public RomSettings {
+ public:
+  HeroSettings();
 
-    public:
+  // reset
+  void reset();
 
-        HeroSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "hero"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // get the available number of modes
+  unsigned int getNumModes() const { return 5; }
 
-        // the rom-name
-        const char* rom() const { return "hero"; }
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // get the available number of modes
-        unsigned int getNumModes() const { return 5; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  // returns a list of mode that the game can be played in
+  // in this game, there are 8 available modes
+  ModeVect getAvailableModes();
 
-        virtual int lives() { return isTerminal() ? 0 : m_lives; }
+  // set the mode of the game
+  // the given mode must be one returned by the previous function
+  void setMode(game_mode_t, System& system,
+               std::unique_ptr<StellaEnvironmentWrapper> environment);
 
-        // returns a list of mode that the game can be played in
-        // in this game, there are 8 available modes
-        ModeVect getAvailableModes();
-
-        // set the mode of the game
-        // the given mode must be one returned by the previous function
-        void setMode(game_mode_t, System &system,
-                     std::unique_ptr<StellaEnvironmentWrapper> environment);
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 };
 
-#endif // __HERO_HPP__
+#endif  // __HERO_HPP__

--- a/src/games/supported/IceHockey.cpp
+++ b/src/games/supported/IceHockey.cpp
@@ -14,102 +14,81 @@
 #include "../RomUtils.hpp"
 using namespace std;
 
-
-IceHockeySettings::IceHockeySettings() {
-
-    reset();
-}
-
+IceHockeySettings::IceHockeySettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* IceHockeySettings::clone() const {
-
-    RomSettings* rval = new IceHockeySettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new IceHockeySettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void IceHockeySettings::step(const System& system) {
+  // update the reward
+  int my_score = max(getDecimalScore(0x8A, &system), 0);
+  int oppt_score = max(getDecimalScore(0x8B, &system), 0);
+  int score = my_score - oppt_score;
+  int reward = min(score - m_score, 1);
+  m_reward = reward;
+  m_score = score;
 
-    // update the reward
-    int my_score = max(getDecimalScore(0x8A, &system), 0);
-    int oppt_score = max(getDecimalScore(0x8B, &system), 0);
-    int score = my_score - oppt_score;
-    int reward = min(score - m_score, 1);
-    m_reward = reward;
-    m_score = score;
-
-    // update terminal status
-    int minutes = readRam(&system, 0x87);
-    int seconds = readRam(&system, 0x86);
-    // end of game when out of time
-    m_terminal = minutes == 0 && seconds == 0;
+  // update terminal status
+  int minutes = readRam(&system, 0x87);
+  int seconds = readRam(&system, 0x86);
+  // end of game when out of time
+  m_terminal = minutes == 0 && seconds == 0;
 }
-
 
 /* is end of game */
-bool IceHockeySettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool IceHockeySettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t IceHockeySettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t IceHockeySettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool IceHockeySettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_UP:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_DOWN:
-        case PLAYER_A_UPRIGHT:
-        case PLAYER_A_UPLEFT:
-        case PLAYER_A_DOWNRIGHT:
-        case PLAYER_A_DOWNLEFT:
-        case PLAYER_A_UPFIRE:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_LEFTFIRE:
-        case PLAYER_A_DOWNFIRE:
-        case PLAYER_A_UPRIGHTFIRE:
-        case PLAYER_A_UPLEFTFIRE:
-        case PLAYER_A_DOWNRIGHTFIRE:
-        case PLAYER_A_DOWNLEFTFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool IceHockeySettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_UP:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_DOWN:
+    case PLAYER_A_UPRIGHT:
+    case PLAYER_A_UPLEFT:
+    case PLAYER_A_DOWNRIGHT:
+    case PLAYER_A_DOWNLEFT:
+    case PLAYER_A_UPFIRE:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_LEFTFIRE:
+    case PLAYER_A_DOWNFIRE:
+    case PLAYER_A_UPRIGHTFIRE:
+    case PLAYER_A_UPLEFTFIRE:
+    case PLAYER_A_DOWNRIGHTFIRE:
+    case PLAYER_A_DOWNLEFTFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void IceHockeySettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
 }
 
-
 /* saves the state of the rom settings */
-void IceHockeySettings::saveState(Serializer & ser) {
+void IceHockeySettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
 }
 
 // loads the state of the rom settings
-void IceHockeySettings::loadState(Deserializer & ser) {
+void IceHockeySettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();
@@ -117,32 +96,31 @@ void IceHockeySettings::loadState(Deserializer & ser) {
 
 // returns a list of mode that the game can be played in
 ModeVect IceHockeySettings::getAvailableModes() {
-    ModeVect modes = {0, 2};
-    return modes;
+  ModeVect modes = {0, 2};
+  return modes;
 }
 
 // set the mode of the game
 // the given mode must be one returned by the previous function
-void IceHockeySettings::setMode(game_mode_t m, System &system,
-                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
-
-    if(m == 0 || m == 2) {
-        // read the mode we are currently in
-        unsigned char mode = readRam(&system, 0x80);
-        // press select until the correct mode is reached
-        while (mode != m) {
-            environment->pressSelect(2);
-            mode = readRam(&system, 0x80);
-        }
-        //reset the environment to apply changes.
-        environment->softReset();
+void IceHockeySettings::setMode(
+    game_mode_t m, System& system,
+    std::unique_ptr<StellaEnvironmentWrapper> environment) {
+  if (m == 0 || m == 2) {
+    // read the mode we are currently in
+    unsigned char mode = readRam(&system, 0x80);
+    // press select until the correct mode is reached
+    while (mode != m) {
+      environment->pressSelect(2);
+      mode = readRam(&system, 0x80);
     }
-    else {
-        throw std::runtime_error("This mode doesn't currently exist for this game");
-    }
- }
+    //reset the environment to apply changes.
+    environment->softReset();
+  } else {
+    throw std::runtime_error("This mode doesn't currently exist for this game");
+  }
+}
 
 DifficultyVect IceHockeySettings::getAvailableDifficulties() {
-    DifficultyVect diff = {0, 1, 2, 3};
-    return diff;
+  DifficultyVect diff = {0, 1, 2, 3};
+  return diff;
 }

--- a/src/games/supported/IceHockey.hpp
+++ b/src/games/supported/IceHockey.hpp
@@ -29,64 +29,60 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Ice Hockey */
 class IceHockeySettings : public RomSettings {
+ public:
+  IceHockeySettings();
 
-    public:
+  // reset
+  void reset();
 
-        IceHockeySettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "ice_hockey"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // get the available number of modes
+  unsigned int getNumModes() const { return 2; }
 
-        // the rom-name
-        const char* rom() const { return "ice_hockey"; }
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // get the available number of modes
-        unsigned int getNumModes() const { return 2; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  virtual int lives() { return 0; }
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  // returns a list of mode that the game can be played in
+  // in this game, there are 2 available modes
+  ModeVect getAvailableModes();
 
-        virtual int lives() { return 0; }
+  // set the mode of the game
+  // the given mode must be one returned by the previous function
+  void setMode(game_mode_t, System& system,
+               std::unique_ptr<StellaEnvironmentWrapper> environment);
 
-        // returns a list of mode that the game can be played in
-        // in this game, there are 2 available modes
-        ModeVect getAvailableModes();
+  // returns a list of difficulties that the game can be played in
+  // in this game, there are 4 available difficulties
+  DifficultyVect getAvailableDifficulties();
 
-        // set the mode of the game
-        // the given mode must be one returned by the previous function
-        void setMode(game_mode_t, System &system,
-                     std::unique_ptr<StellaEnvironmentWrapper> environment);
-
-        // returns a list of difficulties that the game can be played in
-        // in this game, there are 4 available difficulties
-        DifficultyVect getAvailableDifficulties();
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
 };
 
-#endif // __ICEHOCKEY_HPP__
+#endif  // __ICEHOCKEY_HPP__

--- a/src/games/supported/JamesBond.cpp
+++ b/src/games/supported/JamesBond.cpp
@@ -28,98 +28,77 @@
 
 #include "../RomUtils.hpp"
 
-
-JamesBondSettings::JamesBondSettings() {
-
-    reset();
-}
-
+JamesBondSettings::JamesBondSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* JamesBondSettings::clone() const {
-
-    RomSettings* rval = new JamesBondSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new JamesBondSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void JamesBondSettings::step(const System& system) {
+  // update the reward
+  int score = getDecimalScore(0xDC, 0xDD, 0xDE, &system);
+  int reward = score - m_score;
+  m_reward = reward;
+  m_score = score;
 
-    // update the reward
-    int score = getDecimalScore(0xDC, 0xDD, 0xDE, &system);
-    int reward = score - m_score;
-    m_reward = reward;
-    m_score = score;
+  // update terminal status
+  int lives_byte = readRam(&system, 0x86) & 0xF;
+  int screen_byte = readRam(&system, 0x8C);
 
-    // update terminal status
-    int lives_byte = readRam(&system, 0x86) & 0xF;
-    int screen_byte = readRam(&system, 0x8C);
-
-    // byte 0x8C is 0x68 when we die; it does not remain so forever, as
-    // the system loops back to start state after a while (where fire will
-    // start a new game)
-    m_terminal = (lives_byte == 0 && screen_byte == 0x68);
-    m_lives = lives_byte + 1;
+  // byte 0x8C is 0x68 when we die; it does not remain so forever, as
+  // the system loops back to start state after a while (where fire will
+  // start a new game)
+  m_terminal = (lives_byte == 0 && screen_byte == 0x68);
+  m_lives = lives_byte + 1;
 }
-
 
 /* is end of game */
-bool JamesBondSettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool JamesBondSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t JamesBondSettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t JamesBondSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool JamesBondSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_UP:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_DOWN:
-        case PLAYER_A_UPRIGHT:
-        case PLAYER_A_UPLEFT:
-        case PLAYER_A_DOWNRIGHT:
-        case PLAYER_A_DOWNLEFT:
-        case PLAYER_A_UPFIRE:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_LEFTFIRE:
-        case PLAYER_A_DOWNFIRE:
-        case PLAYER_A_UPRIGHTFIRE:
-        case PLAYER_A_UPLEFTFIRE:
-        case PLAYER_A_DOWNRIGHTFIRE:
-        case PLAYER_A_DOWNLEFTFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool JamesBondSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_UP:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_DOWN:
+    case PLAYER_A_UPRIGHT:
+    case PLAYER_A_UPLEFT:
+    case PLAYER_A_DOWNRIGHT:
+    case PLAYER_A_DOWNLEFT:
+    case PLAYER_A_UPFIRE:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_LEFTFIRE:
+    case PLAYER_A_DOWNFIRE:
+    case PLAYER_A_UPRIGHTFIRE:
+    case PLAYER_A_UPLEFTFIRE:
+    case PLAYER_A_DOWNRIGHTFIRE:
+    case PLAYER_A_DOWNLEFTFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void JamesBondSettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
-    m_lives    = 6; // Yes, that's right, 6
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
+  m_lives = 6; // Yes, that's right, 6
 }
 
-
 /* saves the state of the rom settings */
-void JamesBondSettings::saveState(Serializer & ser) {
+void JamesBondSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
@@ -127,41 +106,39 @@ void JamesBondSettings::saveState(Serializer & ser) {
 }
 
 // loads the state of the rom settings
-void JamesBondSettings::loadState(Deserializer & ser) {
+void JamesBondSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();
   m_lives = ser.getInt();
 }
 
-
 // returns a list of mode that the game can be played in
 ModeVect JamesBondSettings::getAvailableModes() {
-    ModeVect modes(getNumModes());
-    for (unsigned int i = 0; i < modes.size(); i++) {
-        modes[i] = i;
-    }
-    return modes;
+  ModeVect modes(getNumModes());
+  for (unsigned int i = 0; i < modes.size(); i++) {
+    modes[i] = i;
+  }
+  return modes;
 }
 
 // set the mode of the game
 // the given mode must be one returned by the previous function
-void JamesBondSettings::setMode(game_mode_t m, System &system,
-                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
-
-    if(m == 0 || m == 1) {
-        // read the mode we are currently in
-        unsigned char mode = readRam(&system, 0x8C);
-        // press select until the correct mode is reached
-        // in the welcome screen, the value of the mode is increased by 0x48
-        while (mode != m && mode != m + 0x48) {
-            environment->pressSelect(20);
-            mode = readRam(&system, 0x8C);
-        }
-        //reset the environment to apply changes.
-        environment->softReset();
+void JamesBondSettings::setMode(
+    game_mode_t m, System& system,
+    std::unique_ptr<StellaEnvironmentWrapper> environment) {
+  if (m == 0 || m == 1) {
+    // read the mode we are currently in
+    unsigned char mode = readRam(&system, 0x8C);
+    // press select until the correct mode is reached
+    // in the welcome screen, the value of the mode is increased by 0x48
+    while (mode != m && mode != m + 0x48) {
+      environment->pressSelect(20);
+      mode = readRam(&system, 0x8C);
     }
-    else {
-        throw std::runtime_error("This mode doesn't currently exist for this game");
-    }
- }
+    //reset the environment to apply changes.
+    environment->softReset();
+  } else {
+    throw std::runtime_error("This mode doesn't currently exist for this game");
+  }
+}

--- a/src/games/supported/JamesBond.hpp
+++ b/src/games/supported/JamesBond.hpp
@@ -29,61 +29,57 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for James Bond */
 class JamesBondSettings : public RomSettings {
+ public:
+  JamesBondSettings();
 
-    public:
+  // reset
+  void reset();
 
-        JamesBondSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "jamesbond"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // get the available number of modes
+  unsigned int getNumModes() const { return 2; }
 
-        // the rom-name
-        const char* rom() const { return "jamesbond"; }
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // get the available number of modes
-        unsigned int getNumModes() const { return 2; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  // returns a list of mode that the game can be played in
+  // in this game, there are 2 available modes
+  ModeVect getAvailableModes();
 
-        virtual int lives() { return isTerminal() ? 0 : m_lives; }
+  // set the mode of the game
+  // the given mode must be one returned by the previous function
+  void setMode(game_mode_t, System& system,
+               std::unique_ptr<StellaEnvironmentWrapper> environment);
 
-        // returns a list of mode that the game can be played in
-        // in this game, there are 2 available modes
-        ModeVect getAvailableModes();
-
-        // set the mode of the game
-        // the given mode must be one returned by the previous function
-        void setMode(game_mode_t, System &system,
-                     std::unique_ptr<StellaEnvironmentWrapper> environment);
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 };
 
-#endif // __JAMESBOND_HPP__
+#endif  // __JAMESBOND_HPP__

--- a/src/games/supported/JourneyEscape.cpp
+++ b/src/games/supported/JourneyEscape.cpp
@@ -15,110 +15,90 @@
 
 #include "../RomUtils.hpp"
 
-
-JourneyEscapeSettings::JourneyEscapeSettings() {
-
-    reset();
-}
-
+JourneyEscapeSettings::JourneyEscapeSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* JourneyEscapeSettings::clone() const {
-
-    RomSettings* rval = new JourneyEscapeSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new JourneyEscapeSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void JourneyEscapeSettings::step(const System& system) {
+  // update the reward
+  int score = getDecimalScore(0x92, 0x91, 0x90, &system);
+  int reward = score - m_score;
+  if (reward == 50000)
+    reward = 0; // HACK: ignoring starting cash
+  m_reward = reward;
+  m_score = score;
 
-    // update the reward
-    int score = getDecimalScore(0x92, 0x91, 0x90, &system);
-    int reward = score - m_score;
-    if (reward == 50000) reward = 0;  // HACK: ignoring starting cash
-    m_reward = reward;
-    m_score = score;
-
-    // update terminal status
-    int minutes = readRam(&system, 0x95);
-    int seconds = readRam(&system, 0x96);
-    m_terminal = minutes == 0 && seconds == 0;
+  // update terminal status
+  int minutes = readRam(&system, 0x95);
+  int seconds = readRam(&system, 0x96);
+  m_terminal = minutes == 0 && seconds == 0;
 }
-
 
 /* is end of game */
-bool JourneyEscapeSettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool JourneyEscapeSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t JourneyEscapeSettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t JourneyEscapeSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool JourneyEscapeSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_UP:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_DOWN:
-        case PLAYER_A_UPRIGHT:
-        case PLAYER_A_UPLEFT:
-        case PLAYER_A_DOWNRIGHT:
-        case PLAYER_A_DOWNLEFT:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_LEFTFIRE:
-        case PLAYER_A_DOWNFIRE:
-        case PLAYER_A_UPRIGHTFIRE:
-        case PLAYER_A_UPLEFTFIRE:
-        case PLAYER_A_DOWNRIGHTFIRE:
-        case PLAYER_A_DOWNLEFTFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool JourneyEscapeSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_UP:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_DOWN:
+    case PLAYER_A_UPRIGHT:
+    case PLAYER_A_UPLEFT:
+    case PLAYER_A_DOWNRIGHT:
+    case PLAYER_A_DOWNLEFT:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_LEFTFIRE:
+    case PLAYER_A_DOWNFIRE:
+    case PLAYER_A_UPRIGHTFIRE:
+    case PLAYER_A_UPLEFTFIRE:
+    case PLAYER_A_DOWNRIGHTFIRE:
+    case PLAYER_A_DOWNLEFTFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void JourneyEscapeSettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
 }
 
-
 /* saves the state of the rom settings */
-void JourneyEscapeSettings::saveState(Serializer & ser) {
+void JourneyEscapeSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
 }
 
 // loads the state of the rom settings
-void JourneyEscapeSettings::loadState(Deserializer & ser) {
+void JourneyEscapeSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();
 }
 
 ActionVect JourneyEscapeSettings::getStartingActions() {
-    ActionVect startingActions;
-    startingActions.push_back(PLAYER_A_FIRE);
-    return startingActions;
+  ActionVect startingActions;
+  startingActions.push_back(PLAYER_A_FIRE);
+  return startingActions;
 }
 
 DifficultyVect JourneyEscapeSettings::getAvailableDifficulties() {
-    DifficultyVect diff = {0, 1};
-    return diff;
+  DifficultyVect diff = {0, 1};
+  return diff;
 }

--- a/src/games/supported/JourneyEscape.hpp
+++ b/src/games/supported/JourneyEscape.hpp
@@ -29,55 +29,51 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Journey Escape */
 class JourneyEscapeSettings : public RomSettings {
+ public:
+  JourneyEscapeSettings();
 
-    public:
+  // reset
+  void reset();
 
-        JourneyEscapeSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "journey_escape"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // the rom-name
-        const char* rom() const { return "journey_escape"; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  // Journey Escape requires the fire action to start the game
+  ActionVect getStartingActions();
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  virtual int lives() { return 0; }
 
-        // Journey Escape requires the fire action to start the game
-        ActionVect getStartingActions();
+  // returns a list of difficulties that the game can be played in
+  // in this game, there are 2 available difficulties
+  DifficultyVect getAvailableDifficulties();
 
-        virtual int lives() { return 0; }
-
-        // returns a list of difficulties that the game can be played in
-        // in this game, there are 2 available difficulties
-        DifficultyVect getAvailableDifficulties();
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
 };
 
-#endif // __JOURNEYESCAPE_HPP__
+#endif  // __JOURNEYESCAPE_HPP__

--- a/src/games/supported/Kaboom.cpp
+++ b/src/games/supported/Kaboom.cpp
@@ -14,86 +14,69 @@
 #include "../RomUtils.hpp"
 #include <iostream>
 
-KaboomSettings::KaboomSettings() {
-    reset();
-}
-
+KaboomSettings::KaboomSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* KaboomSettings::clone() const {
-
-    RomSettings* rval = new KaboomSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new KaboomSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void KaboomSettings::step(const System& system) {
+  // update the reward
+  reward_t score = getDecimalScore(0xA5, 0xA4, 0xA3, &system);
+  m_reward = score - m_score;
+  m_score = score;
 
-    // update the reward
-    reward_t score = getDecimalScore(0xA5, 0xA4, 0xA3, &system);
-    m_reward = score - m_score;
-    m_score = score;
-
-    // update terminal status
-    int lives = readRam(&system, 0xA1);
-    m_terminal = lives == 0x0 || m_score == 999999;
+  // update terminal status
+  int lives = readRam(&system, 0xA1);
+  m_terminal = lives == 0x0 || m_score == 999999;
 }
-
 
 /* is end of game */
-bool KaboomSettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool KaboomSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t KaboomSettings::getReward() const {
-     return m_reward;
-}
-
+reward_t KaboomSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool KaboomSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-             return true;
-        default:
-            return false;
-    }
+bool KaboomSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void KaboomSettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
 }
 
 /* saves the state of the rom settings */
-void KaboomSettings::saveState(Serializer & ser) {
+void KaboomSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
 }
 
 // loads the state of the rom settings
-void KaboomSettings::loadState(Deserializer & ser) {
+void KaboomSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();
 }
 
 ActionVect KaboomSettings::getStartingActions() {
-    ActionVect startingActions;
-    startingActions.push_back(PLAYER_A_FIRE);
-    return startingActions;
+  ActionVect startingActions;
+  startingActions.push_back(PLAYER_A_FIRE);
+  return startingActions;
 }

--- a/src/games/supported/Kaboom.hpp
+++ b/src/games/supported/Kaboom.hpp
@@ -15,11 +15,8 @@
 #include "../RomSettings.hpp"
 
 /* RL wrapper for Kaboom settings */
-class KaboomSettings: public RomSettings
-{
-
-public:
-
+class KaboomSettings : public RomSettings {
+ public:
   KaboomSettings();
 
   // reset
@@ -32,10 +29,7 @@ public:
   reward_t getReward() const;
 
   // the rom-name
-  const char* rom() const
-  {
-    return "kaboom";
-  }
+  const char* rom() const { return "kaboom"; }
 
   // create a new instance of the rom
   RomSettings* clone() const;
@@ -47,18 +41,17 @@ public:
   void step(const System& system);
 
   // saves the state of the rom settings
-  void saveState(Serializer & ser);
+  void saveState(Serializer& ser);
 
   // loads the state of the rom settings
-  void loadState(Deserializer & ser);
+  void loadState(Deserializer& ser);
 
   ActionVect getStartingActions();
 
-private:
-
+ private:
   bool m_terminal;
   reward_t m_reward;
   reward_t m_score;
 };
 
-#endif // __KABOOM__
+#endif  // __KABOOM__

--- a/src/games/supported/Kangaroo.cpp
+++ b/src/games/supported/Kangaroo.cpp
@@ -28,95 +28,73 @@
 
 #include "../RomUtils.hpp"
 
-
-KangarooSettings::KangarooSettings() {
-
-    reset();
-}
-
+KangarooSettings::KangarooSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* KangarooSettings::clone() const {
-
-    RomSettings* rval = new KangarooSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new KangarooSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void KangarooSettings::step(const System& system) {
+  // update the reward
+  int score = getDecimalScore(0xA8, 0xA7, &system);
+  score *= 100;
+  int reward = score - m_score;
+  m_reward = reward;
+  m_score = score;
 
-    // update the reward
-    int score = getDecimalScore(0xA8, 0xA7, &system);
-    score *= 100;
-    int reward = score - m_score;
-    m_reward = reward;
-    m_score = score;
-
-    // update terminal status
-    int lives_byte = readRam(&system, 0xAD);
-    m_terminal = (lives_byte == 0xFF);
-    m_lives = (lives_byte & 0x7) + 1;
+  // update terminal status
+  int lives_byte = readRam(&system, 0xAD);
+  m_terminal = (lives_byte == 0xFF);
+  m_lives = (lives_byte & 0x7) + 1;
 }
-
 
 /* is end of game */
-bool KangarooSettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool KangarooSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t KangarooSettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t KangarooSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool KangarooSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_UP:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_DOWN:
-        case PLAYER_A_UPRIGHT:
-        case PLAYER_A_UPLEFT:
-        case PLAYER_A_DOWNRIGHT:
-        case PLAYER_A_DOWNLEFT:
-        case PLAYER_A_UPFIRE:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_LEFTFIRE:
-        case PLAYER_A_DOWNFIRE:
-        case PLAYER_A_UPRIGHTFIRE:
-        case PLAYER_A_UPLEFTFIRE:
-        case PLAYER_A_DOWNRIGHTFIRE:
-        case PLAYER_A_DOWNLEFTFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool KangarooSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_UP:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_DOWN:
+    case PLAYER_A_UPRIGHT:
+    case PLAYER_A_UPLEFT:
+    case PLAYER_A_DOWNRIGHT:
+    case PLAYER_A_DOWNLEFT:
+    case PLAYER_A_UPFIRE:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_LEFTFIRE:
+    case PLAYER_A_DOWNFIRE:
+    case PLAYER_A_UPRIGHTFIRE:
+    case PLAYER_A_UPLEFTFIRE:
+    case PLAYER_A_DOWNRIGHTFIRE:
+    case PLAYER_A_DOWNLEFTFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void KangarooSettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
-    m_lives    = 3;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
+  m_lives = 3;
 }
 
-
-
 /* saves the state of the rom settings */
-void KangarooSettings::saveState(Serializer & ser) {
+void KangarooSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
@@ -124,7 +102,7 @@ void KangarooSettings::saveState(Serializer & ser) {
 }
 
 // loads the state of the rom settings
-void KangarooSettings::loadState(Deserializer & ser) {
+void KangarooSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();
@@ -133,28 +111,27 @@ void KangarooSettings::loadState(Deserializer & ser) {
 
 // returns a list of mode that the game can be played in
 ModeVect KangarooSettings::getAvailableModes() {
-    ModeVect modes = {0, 1};
-    return modes;
+  ModeVect modes = {0, 1};
+  return modes;
 }
 
 // set the mode of the game
 // the given mode must be one returned by the previous function
-void KangarooSettings::setMode(game_mode_t m, System &system,
-                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
-
-    if( m == 0 || m == 1){
-        // read the mode we are currently in
-        unsigned char mode = readRam(&system, 0xBA);
-        // press select until the correct mode is reached
-        //in the welcome screen, the value of the mode is increased by 0x80
-        while(mode != m && mode != m + 0x80) {
-            environment->pressSelect(2);
-            mode = readRam(&system, 0xBA);
-        }
-        //reset the environment to apply changes.
-        environment->softReset();
+void KangarooSettings::setMode(
+    game_mode_t m, System& system,
+    std::unique_ptr<StellaEnvironmentWrapper> environment) {
+  if (m == 0 || m == 1) {
+    // read the mode we are currently in
+    unsigned char mode = readRam(&system, 0xBA);
+    // press select until the correct mode is reached
+    //in the welcome screen, the value of the mode is increased by 0x80
+    while (mode != m && mode != m + 0x80) {
+      environment->pressSelect(2);
+      mode = readRam(&system, 0xBA);
     }
-    else {
-        throw std::runtime_error("This mode doesn't currently exist for this game");
-    }
- }
+    //reset the environment to apply changes.
+    environment->softReset();
+  } else {
+    throw std::runtime_error("This mode doesn't currently exist for this game");
+  }
+}

--- a/src/games/supported/Kangaroo.hpp
+++ b/src/games/supported/Kangaroo.hpp
@@ -29,61 +29,57 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Kangaroo */
 class KangarooSettings : public RomSettings {
+ public:
+  KangarooSettings();
 
-    public:
+  // reset
+  void reset();
 
-        KangarooSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "kangaroo"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // get the available number of modes
+  unsigned int getNumModes() const { return 2; }
 
-        // the rom-name
-        const char* rom() const { return "kangaroo"; }
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // get the available number of modes
-        unsigned int getNumModes() const { return 2; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  // returns a list of mode that the game can be played in
+  // in this game, there are 8 available modes
+  ModeVect getAvailableModes();
 
-        virtual int lives() { return isTerminal() ? 0 : m_lives; }
+  // set the mode of the game
+  // the given mode must be one returned by the previous function
+  void setMode(game_mode_t, System& system,
+               std::unique_ptr<StellaEnvironmentWrapper> environment);
 
-        // returns a list of mode that the game can be played in
-        // in this game, there are 8 available modes
-        ModeVect getAvailableModes();
-
-        // set the mode of the game
-        // the given mode must be one returned by the previous function
-        void setMode(game_mode_t, System &system,
-                     std::unique_ptr<StellaEnvironmentWrapper> environment);
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 };
 
-#endif // __KANGAROO_HPP__
+#endif  // __KANGAROO_HPP__

--- a/src/games/supported/KeystoneKapers.cpp
+++ b/src/games/supported/KeystoneKapers.cpp
@@ -13,79 +13,66 @@
 
 #include "../RomUtils.hpp"
 
-
-KeystoneKapersSettings::KeystoneKapersSettings() {
-    reset();
-}
-
+KeystoneKapersSettings::KeystoneKapersSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* KeystoneKapersSettings::clone() const {
-    RomSettings* rval = new KeystoneKapersSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new KeystoneKapersSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void KeystoneKapersSettings::step(const System& system) {
-    // update the reward
-    int score = getDecimalScore(0x9C, 0x9B, &system);
-    int reward = score - m_score;
-    m_reward = reward;
-    m_score = score;
+  // update the reward
+  int score = getDecimalScore(0x9C, 0x9B, &system);
+  int reward = score - m_score;
+  m_reward = reward;
+  m_score = score;
 
-    m_lives = readRam(&system, 0x96);
-    m_terminal = (m_lives == 0) && readRam(&system, 0x88) == 0x00;
+  m_lives = readRam(&system, 0x96);
+  m_terminal = (m_lives == 0) && readRam(&system, 0x88) == 0x00;
 }
-
 
 /* is end of game */
-bool KeystoneKapersSettings::isTerminal() const {
-    return m_terminal;
-};
-
+bool KeystoneKapersSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t KeystoneKapersSettings::getReward() const {
-    return m_reward;
-}
-
+reward_t KeystoneKapersSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool KeystoneKapersSettings::isMinimal(const Action &a) const {
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_UP:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_DOWN:
-        case PLAYER_A_UPRIGHT:
-        case PLAYER_A_UPLEFT:
-        case PLAYER_A_DOWNRIGHT:
-        case PLAYER_A_DOWNLEFT:
-        case PLAYER_A_UPFIRE:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_LEFTFIRE:
-        case PLAYER_A_DOWNFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool KeystoneKapersSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_UP:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_DOWN:
+    case PLAYER_A_UPRIGHT:
+    case PLAYER_A_UPLEFT:
+    case PLAYER_A_DOWNRIGHT:
+    case PLAYER_A_DOWNLEFT:
+    case PLAYER_A_UPFIRE:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_LEFTFIRE:
+    case PLAYER_A_DOWNFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void KeystoneKapersSettings::reset() {
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
-    m_lives    = 3;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
+  m_lives = 3;
 }
 
 /* saves the state of the rom settings */
-void KeystoneKapersSettings::saveState(Serializer & ser) {
+void KeystoneKapersSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
@@ -93,7 +80,7 @@ void KeystoneKapersSettings::saveState(Serializer & ser) {
 }
 
 // loads the state of the rom settings
-void KeystoneKapersSettings::loadState(Deserializer & ser) {
+void KeystoneKapersSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();
@@ -101,7 +88,7 @@ void KeystoneKapersSettings::loadState(Deserializer & ser) {
 }
 
 ActionVect KeystoneKapersSettings::getStartingActions() {
-    ActionVect startingActions;
-    startingActions.push_back(RESET);
-    return startingActions;
+  ActionVect startingActions;
+  startingActions.push_back(RESET);
+  return startingActions;
 }

--- a/src/games/supported/KeystoneKapers.hpp
+++ b/src/games/supported/KeystoneKapers.hpp
@@ -14,51 +14,49 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for KeystoneKapers */
 class KeystoneKapersSettings : public RomSettings {
+ public:
+  KeystoneKapersSettings();
 
-    public:
-        KeystoneKapersSettings();
+  // reset
+  void reset();
 
-        // reset
-        void reset();
+  // is end of game
+  bool isTerminal() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // the rom-name
+  // MD5 be929419902e21bd7830a7a7d746195d
+  const char* rom() const { return "keystone_kapers"; }
 
-        // the rom-name
-		// MD5 be929419902e21bd7830a7a7d746195d
-        const char* rom() const { return "keystone_kapers"; }
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  // Keystone Kapers requires the reset button to start the game
+  ActionVect getStartingActions();
 
-        // Keystone Kapers requires the reset button to start the game
-        ActionVect getStartingActions();
+  virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
-        virtual int lives() { return isTerminal() ? 0 : m_lives; }
-
-    private:
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 };
 
-#endif // __KEYSTONEKAPERS_HPP__
+#endif  // __KEYSTONEKAPERS_HPP__

--- a/src/games/supported/Kingkong.cpp
+++ b/src/games/supported/Kingkong.cpp
@@ -28,68 +28,59 @@
 
 #include "../RomUtils.hpp"
 
-KingkongSettings::KingkongSettings() {
-    reset();
-}
+KingkongSettings::KingkongSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* KingkongSettings::clone() const {
-    RomSettings* rval = new KingkongSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new KingkongSettings();
+  *rval = *this;
+  return rval;
 }
 
 /* process the latest information from ALE */
 void KingkongSettings::step(const System& system) {
-    // update the reward
-    int score = getDecimalScore(0x83, 0x82, &system);
-    int reward = score - m_score;
-    m_reward = reward;
-    m_score = score;
+  // update the reward
+  int score = getDecimalScore(0x83, 0x82, &system);
+  int reward = score - m_score;
+  m_reward = reward;
+  m_score = score;
 
-    // update terminal status
-    m_lives = readRam(&system, 0xEE);
-    m_terminal = (m_lives == 0);
+  // update terminal status
+  m_lives = readRam(&system, 0xEE);
+  m_terminal = (m_lives == 0);
 }
 
 /* is end of game */
-bool KingkongSettings::isTerminal() const {
-    return m_terminal;
-};
-
+bool KingkongSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t KingkongSettings::getReward() const {
-    return m_reward;
-}
-
+reward_t KingkongSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool KingkongSettings::isMinimal(const Action &a) const {
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_UP:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_DOWN:
-            return true;
-        default:
-            return false;
-    }
+bool KingkongSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_UP:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_DOWN:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void KingkongSettings::reset() {
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
-    m_lives    = 3;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
+  m_lives = 3;
 }
 
 /* saves the state of the rom settings */
-void KingkongSettings::saveState(Serializer & ser) {
+void KingkongSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
@@ -97,7 +88,7 @@ void KingkongSettings::saveState(Serializer & ser) {
 }
 
 // loads the state of the rom settings
-void KingkongSettings::loadState(Deserializer & ser) {
+void KingkongSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();
@@ -105,7 +96,7 @@ void KingkongSettings::loadState(Deserializer & ser) {
 }
 
 ActionVect KingkongSettings::getStartingActions() {
-    ActionVect startingActions;
-    startingActions.push_back(RESET);
-    return startingActions;
+  ActionVect startingActions;
+  startingActions.push_back(RESET);
+  return startingActions;
 }

--- a/src/games/supported/Kingkong.hpp
+++ b/src/games/supported/Kingkong.hpp
@@ -31,46 +31,46 @@
 
 /* RL wrapper for Kingkong */
 class KingkongSettings : public RomSettings {
-    public:
-        KingkongSettings();
+ public:
+  KingkongSettings();
 
-        // reset
-        void reset();
+  // reset
+  void reset();
 
-        // is end of game
-        bool isTerminal() const;
+  // is end of game
+  bool isTerminal() const;
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // the rom-name
-        const char* rom() const { return "king_kong"; }
+  // the rom-name
+  const char* rom() const { return "king_kong"; }
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // Kingkong requires the fire action to start the game
-        ActionVect getStartingActions();
+  // Kingkong requires the fire action to start the game
+  ActionVect getStartingActions();
 
-        virtual int lives() { return isTerminal() ? 0 : m_lives; }
+  virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
-    private:
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 };
 
-#endif // __KINGKONG_HPP__
+#endif  // __KINGKONG_HPP__

--- a/src/games/supported/Koolaid.cpp
+++ b/src/games/supported/Koolaid.cpp
@@ -13,87 +13,67 @@
 
 #include "../RomUtils.hpp"
 
-
-KoolaidSettings::KoolaidSettings() {
-
-    reset();
-}
-
+KoolaidSettings::KoolaidSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* KoolaidSettings::clone() const {
-
-    RomSettings* rval = new KoolaidSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new KoolaidSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void KoolaidSettings::step(const System& system) {
+  // update the reward
+  int score = getDecimalScore(0x81, 0x80, &system);
+  score *= 100;
+  int reward = score - m_score;
+  m_reward = reward;
+  m_score = score;
 
-    // update the reward
-    int score = getDecimalScore(0x81, 0x80, &system);
-    score *= 100;
-    int reward = score - m_score;
-    m_reward = reward;
-    m_score = score;
-
-    m_terminal = readRam(&system, 0xD1) == 0x80;
+  m_terminal = readRam(&system, 0xD1) == 0x80;
 }
-
 
 /* is end of game */
-bool KoolaidSettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool KoolaidSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t KoolaidSettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t KoolaidSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool KoolaidSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_UP:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_DOWN:
-        case PLAYER_A_UPRIGHT:
-        case PLAYER_A_UPLEFT:
-        case PLAYER_A_DOWNRIGHT:
-        case PLAYER_A_DOWNLEFT:
-            return true;
-        default:
-            return false;
-    }
+bool KoolaidSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_UP:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_DOWN:
+    case PLAYER_A_UPRIGHT:
+    case PLAYER_A_UPLEFT:
+    case PLAYER_A_DOWNRIGHT:
+    case PLAYER_A_DOWNLEFT:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void KoolaidSettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
 }
 
 /* saves the state of the rom settings */
-void KoolaidSettings::saveState(Serializer & ser) {
+void KoolaidSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
 }
 
 // loads the state of the rom settings
-void KoolaidSettings::loadState(Deserializer & ser) {
+void KoolaidSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();

--- a/src/games/supported/Koolaid.hpp
+++ b/src/games/supported/Koolaid.hpp
@@ -14,48 +14,44 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Koolaid */
 class KoolaidSettings : public RomSettings {
+ public:
+  KoolaidSettings();
 
-    public:
+  // reset
+  void reset();
 
-        KoolaidSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "koolaid"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // the rom-name
-        const char* rom() const { return "koolaid"; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  virtual int lives() { return 0; }
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
-
-        virtual int lives() { return 0; }
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
 };
 
-#endif // __KOOLAID_HPP__
+#endif  // __KOOLAID_HPP__

--- a/src/games/supported/Krull.cpp
+++ b/src/games/supported/Krull.cpp
@@ -28,95 +28,74 @@
 
 #include "../RomUtils.hpp"
 
-
-KrullSettings::KrullSettings() {
-
-    reset();
-}
-
+KrullSettings::KrullSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* KrullSettings::clone() const {
-
-    RomSettings* rval = new KrullSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new KrullSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void KrullSettings::step(const System& system) {
+  // update the reward
+  int score = getDecimalScore(0x9E, 0x9D, 0x9C, &system);
+  int reward = score - m_score;
+  m_reward = reward;
+  m_score = score;
 
-    // update the reward
-    int score = getDecimalScore(0x9E, 0x9D, 0x9C, &system);
-    int reward = score - m_score;
-    m_reward = reward;
-    m_score = score;
-
-    // update terminal status
-    int lives = readRam(&system, 0x9F);
-    int byte1 = readRam(&system, 0xA2);
-    int byte2 = readRam(&system, 0x80);
-    m_terminal = lives == 0 && byte1 == 0x03 && byte2 == 0x80;
-    m_lives = (lives & 0x7) + 1;
+  // update terminal status
+  int lives = readRam(&system, 0x9F);
+  int byte1 = readRam(&system, 0xA2);
+  int byte2 = readRam(&system, 0x80);
+  m_terminal = lives == 0 && byte1 == 0x03 && byte2 == 0x80;
+  m_lives = (lives & 0x7) + 1;
 }
-
 
 /* is end of game */
-bool KrullSettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool KrullSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t KrullSettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t KrullSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool KrullSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_UP:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_DOWN:
-        case PLAYER_A_UPRIGHT:
-        case PLAYER_A_UPLEFT:
-        case PLAYER_A_DOWNRIGHT:
-        case PLAYER_A_DOWNLEFT:
-        case PLAYER_A_UPFIRE:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_LEFTFIRE:
-        case PLAYER_A_DOWNFIRE:
-        case PLAYER_A_UPRIGHTFIRE:
-        case PLAYER_A_UPLEFTFIRE:
-        case PLAYER_A_DOWNRIGHTFIRE:
-        case PLAYER_A_DOWNLEFTFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool KrullSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_UP:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_DOWN:
+    case PLAYER_A_UPRIGHT:
+    case PLAYER_A_UPLEFT:
+    case PLAYER_A_DOWNRIGHT:
+    case PLAYER_A_DOWNLEFT:
+    case PLAYER_A_UPFIRE:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_LEFTFIRE:
+    case PLAYER_A_DOWNFIRE:
+    case PLAYER_A_UPRIGHTFIRE:
+    case PLAYER_A_UPLEFTFIRE:
+    case PLAYER_A_DOWNRIGHTFIRE:
+    case PLAYER_A_DOWNLEFTFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void KrullSettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
-    m_lives    = 3;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
+  m_lives = 3;
 }
 
-
 /* saves the state of the rom settings */
-void KrullSettings::saveState(Serializer & ser) {
+void KrullSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
@@ -124,7 +103,7 @@ void KrullSettings::saveState(Serializer & ser) {
 }
 
 // loads the state of the rom settings
-void KrullSettings::loadState(Deserializer & ser) {
+void KrullSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();

--- a/src/games/supported/Krull.hpp
+++ b/src/games/supported/Krull.hpp
@@ -29,49 +29,45 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Krull */
 class KrullSettings : public RomSettings {
+ public:
+  KrullSettings();
 
-    public:
+  // reset
+  void reset();
 
-        KrullSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "krull"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // the rom-name
-        const char* rom() const { return "krull"; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
-
-        virtual int lives() { return isTerminal() ? 0 : m_lives; }
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 };
 
-#endif // __KRULL_HPP__
+#endif  // __KRULL_HPP__

--- a/src/games/supported/KungFuMaster.cpp
+++ b/src/games/supported/KungFuMaster.cpp
@@ -28,90 +28,68 @@
 
 #include "../RomUtils.hpp"
 
-
-KungFuMasterSettings::KungFuMasterSettings() {
-
-    reset();
-}
-
+KungFuMasterSettings::KungFuMasterSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* KungFuMasterSettings::clone() const {
-
-    RomSettings* rval = new KungFuMasterSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new KungFuMasterSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void KungFuMasterSettings::step(const System& system) {
+  // update the reward
+  int score = getDecimalScore(0x9A, 0x99, 0x98, &system);
+  int reward = score - m_score;
+  m_reward = reward;
+  m_score = score;
 
-    // update the reward
-    int score = getDecimalScore(0x9A, 0x99, 0x98, &system);
-    int reward = score - m_score;
-    m_reward = reward;
-    m_score = score;
-
-    // update terminal status
-    int lives_byte = readRam(&system, 0x9D);
-    m_terminal = lives_byte == 0xFF;
-    m_lives = (lives_byte & 0x7) + 1;
+  // update terminal status
+  int lives_byte = readRam(&system, 0x9D);
+  m_terminal = lives_byte == 0xFF;
+  m_lives = (lives_byte & 0x7) + 1;
 }
-
 
 /* is end of game */
-bool KungFuMasterSettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool KungFuMasterSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t KungFuMasterSettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t KungFuMasterSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool KungFuMasterSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_UP:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_DOWN:
-        case PLAYER_A_DOWNRIGHT:
-        case PLAYER_A_DOWNLEFT:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_LEFTFIRE:
-        case PLAYER_A_DOWNFIRE:
-        case PLAYER_A_UPRIGHTFIRE:
-        case PLAYER_A_UPLEFTFIRE:
-        case PLAYER_A_DOWNRIGHTFIRE:
-        case PLAYER_A_DOWNLEFTFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool KungFuMasterSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_UP:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_DOWN:
+    case PLAYER_A_DOWNRIGHT:
+    case PLAYER_A_DOWNLEFT:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_LEFTFIRE:
+    case PLAYER_A_DOWNFIRE:
+    case PLAYER_A_UPRIGHTFIRE:
+    case PLAYER_A_UPLEFTFIRE:
+    case PLAYER_A_DOWNRIGHTFIRE:
+    case PLAYER_A_DOWNLEFTFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void KungFuMasterSettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
-    m_lives    = 4;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
+  m_lives = 4;
 }
 
-
-
 /* saves the state of the rom settings */
-void KungFuMasterSettings::saveState(Serializer & ser) {
+void KungFuMasterSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
@@ -119,7 +97,7 @@ void KungFuMasterSettings::saveState(Serializer & ser) {
 }
 
 // loads the state of the rom settings
-void KungFuMasterSettings::loadState(Deserializer & ser) {
+void KungFuMasterSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();

--- a/src/games/supported/KungFuMaster.hpp
+++ b/src/games/supported/KungFuMaster.hpp
@@ -29,49 +29,45 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Kung Fu Master */
 class KungFuMasterSettings : public RomSettings {
+ public:
+  KungFuMasterSettings();
 
-    public:
+  // reset
+  void reset();
 
-        KungFuMasterSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "kung_fu_master"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // the rom-name
-        const char* rom() const { return "kung_fu_master"; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
-
-        virtual int lives() { return isTerminal() ? 0 : m_lives; }
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 };
 
-#endif // __KUNGFUMASTER_HPP__
+#endif  // __KUNGFUMASTER_HPP__

--- a/src/games/supported/LaserGates.cpp
+++ b/src/games/supported/LaserGates.cpp
@@ -13,95 +13,83 @@
 
 #include "../RomUtils.hpp"
 
-LaserGatesSettings::LaserGatesSettings() {
-    reset();
-}
-
+LaserGatesSettings::LaserGatesSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* LaserGatesSettings::clone() const {
-    RomSettings* rval = new LaserGatesSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new LaserGatesSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void LaserGatesSettings::step(const System& system) {
-    // update the reward
-    int score = getDecimalScore(0x82, 0x81, 0x80, &system);
-    int reward = score - m_score;
-    m_reward = reward;
-    m_score = score;
+  // update the reward
+  int score = getDecimalScore(0x82, 0x81, 0x80, &system);
+  int reward = score - m_score;
+  m_reward = reward;
+  m_score = score;
 
-    // update terminal status
-    m_terminal = readRam(&system, 0x83) == 0x00;
+  // update terminal status
+  m_terminal = readRam(&system, 0x83) == 0x00;
 }
-
 
 /* is end of game */
-bool LaserGatesSettings::isTerminal() const {
-    return m_terminal;
-};
-
+bool LaserGatesSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t LaserGatesSettings::getReward() const {
-    return m_reward;
-}
-
+reward_t LaserGatesSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool LaserGatesSettings::isMinimal(const Action &a) const {
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_UP:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_DOWN:
-        case PLAYER_A_UPRIGHT:
-        case PLAYER_A_UPLEFT:
-        case PLAYER_A_DOWNRIGHT:
-        case PLAYER_A_DOWNLEFT:
-        case PLAYER_A_UPFIRE:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_LEFTFIRE:
-        case PLAYER_A_DOWNFIRE:
-        case PLAYER_A_UPRIGHTFIRE:
-        case PLAYER_A_UPLEFTFIRE:
-        case PLAYER_A_DOWNRIGHTFIRE:
-        case PLAYER_A_DOWNLEFTFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool LaserGatesSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_UP:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_DOWN:
+    case PLAYER_A_UPRIGHT:
+    case PLAYER_A_UPLEFT:
+    case PLAYER_A_DOWNRIGHT:
+    case PLAYER_A_DOWNLEFT:
+    case PLAYER_A_UPFIRE:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_LEFTFIRE:
+    case PLAYER_A_DOWNFIRE:
+    case PLAYER_A_UPRIGHTFIRE:
+    case PLAYER_A_UPLEFTFIRE:
+    case PLAYER_A_DOWNRIGHTFIRE:
+    case PLAYER_A_DOWNLEFTFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void LaserGatesSettings::reset() {
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
 }
 
 /* saves the state of the rom settings */
-void LaserGatesSettings::saveState(Serializer & ser) {
+void LaserGatesSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
 }
 
 // loads the state of the rom settings
-void LaserGatesSettings::loadState(Deserializer & ser) {
+void LaserGatesSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();
 }
 
 ActionVect LaserGatesSettings::getStartingActions() {
-    ActionVect startingActions;
-    startingActions.push_back(RESET);
-    return startingActions;
+  ActionVect startingActions;
+  startingActions.push_back(RESET);
+  return startingActions;
 }

--- a/src/games/supported/LaserGates.hpp
+++ b/src/games/supported/LaserGates.hpp
@@ -14,49 +14,48 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Laser Gates */
 class LaserGatesSettings : public RomSettings {
-    public:
-        LaserGatesSettings();
+ public:
+  LaserGatesSettings();
 
-        // reset
-        void reset();
+  // reset
+  void reset();
 
-        // is end of game
-        bool isTerminal() const;
+  // is end of game
+  bool isTerminal() const;
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // the rom-name
-		// MD5 1fa58679d4a39052bd9db059e8cda4ad
-        const char* rom() const { return "laser_gates"; }
+  // the rom-name
+  // MD5 1fa58679d4a39052bd9db059e8cda4ad
+  const char* rom() const { return "laser_gates"; }
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // LaserGates requires the fire action to start the game
-        ActionVect getStartingActions();
+  // LaserGates requires the fire action to start the game
+  ActionVect getStartingActions();
 
-        virtual int lives() { return 0; }
+  virtual int lives() { return 0; }
 
-    private:
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
 };
 
-#endif // __LASERGATES_HPP__
+#endif  // __LASERGATES_HPP__

--- a/src/games/supported/LostLuggage.cpp
+++ b/src/games/supported/LostLuggage.cpp
@@ -13,64 +13,54 @@
 
 #include "../RomUtils.hpp"
 
-LostLuggageSettings::LostLuggageSettings() {
-    reset();
-}
+LostLuggageSettings::LostLuggageSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* LostLuggageSettings::clone() const {
-    RomSettings* rval = new LostLuggageSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new LostLuggageSettings();
+  *rval = *this;
+  return rval;
 }
 
 /* process the latest information from ALE */
 void LostLuggageSettings::step(const System& system) {
-    // update the reward
-    int score = getDecimalScore(0x96, 0x95, 0x94, &system);
-    int reward = score - m_score;
-    m_reward = reward;
-    m_score = score;
+  // update the reward
+  int score = getDecimalScore(0x96, 0x95, 0x94, &system);
+  int reward = score - m_score;
+  m_reward = reward;
+  m_score = score;
 
-    // update terminal status
-    m_lives = readRam(&system, 0xCA);
-    m_terminal = (m_lives == 0)
-        && readRam(&system, 0xC8) == 0x0A
-        && readRam(&system, 0xA5) == 0x00
-        && readRam(&system, 0xA9) == 0x00;
+  // update terminal status
+  m_lives = readRam(&system, 0xCA);
+  m_terminal = (m_lives == 0) && readRam(&system, 0xC8) == 0x0A &&
+               readRam(&system, 0xA5) == 0x00 && readRam(&system, 0xA9) == 0x00;
 }
 
 /* is end of game */
-bool LostLuggageSettings::isTerminal() const {
-    return m_terminal;
-};
-
+bool LostLuggageSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t LostLuggageSettings::getReward() const {
-    return m_reward;
-}
-
+reward_t LostLuggageSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool LostLuggageSettings::isMinimal(const Action &a) const {
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_UP:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_DOWN:
-        case PLAYER_A_UPRIGHT:
-        case PLAYER_A_UPLEFT:
-        case PLAYER_A_DOWNRIGHT:
-        case PLAYER_A_DOWNLEFT:
-            return true;
-        default:
-            return false;
-    }
+bool LostLuggageSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_UP:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_DOWN:
+    case PLAYER_A_UPRIGHT:
+    case PLAYER_A_UPLEFT:
+    case PLAYER_A_DOWNRIGHT:
+    case PLAYER_A_DOWNLEFT:
+      return true;
+    default:
+      return false;
+  }
 }
 
-bool LostLuggageSettings::isLegal(const Action &a) const {
+bool LostLuggageSettings::isLegal(const Action& a) const {
   switch (a) {
     // Don't allow pressing 'fire'
     case PLAYER_A_FIRE:
@@ -90,14 +80,14 @@ bool LostLuggageSettings::isLegal(const Action &a) const {
 
 /* reset the state of the game */
 void LostLuggageSettings::reset() {
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
-    m_lives    = 3;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
+  m_lives = 3;
 }
 
 /* saves the state of the rom settings */
-void LostLuggageSettings::saveState(Serializer & ser) {
+void LostLuggageSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
@@ -105,7 +95,7 @@ void LostLuggageSettings::saveState(Serializer & ser) {
 }
 
 // loads the state of the rom settings
-void LostLuggageSettings::loadState(Deserializer & ser) {
+void LostLuggageSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();
@@ -113,7 +103,7 @@ void LostLuggageSettings::loadState(Deserializer & ser) {
 }
 
 ActionVect LostLuggageSettings::getStartingActions() {
-    ActionVect startingActions;
-    startingActions.push_back(RESET);
-    return startingActions;
+  ActionVect startingActions;
+  startingActions.push_back(RESET);
+  return startingActions;
 }

--- a/src/games/supported/LostLuggage.hpp
+++ b/src/games/supported/LostLuggage.hpp
@@ -16,50 +16,50 @@
 
 /* RL wrapper for Lost Luggage */
 class LostLuggageSettings : public RomSettings {
-    public:
-        LostLuggageSettings();
+ public:
+  LostLuggageSettings();
 
-        // reset
-        void reset();
+  // reset
+  void reset();
 
-        // is end of game
-        bool isTerminal() const;
+  // is end of game
+  bool isTerminal() const;
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // the rom-name
-		// MD5 7c00e7a205d3fda98eb20da7c9c50a55
-        const char* rom() const { return "lost_luggage"; }
+  // the rom-name
+  // MD5 7c00e7a205d3fda98eb20da7c9c50a55
+  const char* rom() const { return "lost_luggage"; }
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-		// FIRE resets the game, prevent this
-        bool isLegal(const Action& a) const;
+  // FIRE resets the game, prevent this
+  bool isLegal(const Action& a) const;
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // LostLuggage requires the fire action to start the game
-        ActionVect getStartingActions();
+  // LostLuggage requires the fire action to start the game
+  ActionVect getStartingActions();
 
-        virtual int lives() { return isTerminal() ? 0 : m_lives; }
+  virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
-    private:
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 };
 
-#endif // __LOSTLUGGAGE_HPP__
+#endif  // __LOSTLUGGAGE_HPP__

--- a/src/games/supported/MontezumaRevenge.cpp
+++ b/src/games/supported/MontezumaRevenge.cpp
@@ -28,97 +28,75 @@
 
 #include "../RomUtils.hpp"
 
-
-MontezumaRevengeSettings::MontezumaRevengeSettings() {
-
-    reset();
-}
-
+MontezumaRevengeSettings::MontezumaRevengeSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* MontezumaRevengeSettings::clone() const {
-
-    RomSettings* rval = new MontezumaRevengeSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new MontezumaRevengeSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void MontezumaRevengeSettings::step(const System& system) {
+  // update the reward
+  int score = getDecimalScore(0x95, 0x94, 0x93, &system);
+  int reward = score - m_score;
+  m_reward = reward;
+  m_score = score;
 
-    // update the reward
-    int score = getDecimalScore(0x95, 0x94, 0x93, &system);
-    int reward = score - m_score;
-    m_reward = reward;
-    m_score = score;
+  // update terminal status
+  int new_lives = readRam(&system, 0xBA);
+  int some_byte = readRam(&system, 0xFE);
+  m_terminal = new_lives == 0 && some_byte == 0x60;
 
-    // update terminal status
-    int new_lives = readRam(&system, 0xBA);
-    int some_byte = readRam(&system, 0xFE);
-    m_terminal = new_lives == 0 && some_byte == 0x60;
-
-    // Actually does not go up to 8, but that's alright
-    m_lives = (new_lives & 0x7) + 1;
+  // Actually does not go up to 8, but that's alright
+  m_lives = (new_lives & 0x7) + 1;
 }
-
 
 /* is end of game */
-bool MontezumaRevengeSettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool MontezumaRevengeSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t MontezumaRevengeSettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t MontezumaRevengeSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool MontezumaRevengeSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_UP:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_DOWN:
-        case PLAYER_A_UPRIGHT:
-        case PLAYER_A_UPLEFT:
-        case PLAYER_A_DOWNRIGHT:
-        case PLAYER_A_DOWNLEFT:
-        case PLAYER_A_UPFIRE:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_LEFTFIRE:
-        case PLAYER_A_DOWNFIRE:
-        case PLAYER_A_UPRIGHTFIRE:
-        case PLAYER_A_UPLEFTFIRE:
-        case PLAYER_A_DOWNRIGHTFIRE:
-        case PLAYER_A_DOWNLEFTFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool MontezumaRevengeSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_UP:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_DOWN:
+    case PLAYER_A_UPRIGHT:
+    case PLAYER_A_UPLEFT:
+    case PLAYER_A_DOWNRIGHT:
+    case PLAYER_A_DOWNLEFT:
+    case PLAYER_A_UPFIRE:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_LEFTFIRE:
+    case PLAYER_A_DOWNFIRE:
+    case PLAYER_A_UPRIGHTFIRE:
+    case PLAYER_A_UPLEFTFIRE:
+    case PLAYER_A_DOWNRIGHTFIRE:
+    case PLAYER_A_DOWNLEFTFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void MontezumaRevengeSettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
-    m_lives    = 6;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
+  m_lives = 6;
 }
 
-
-
 /* saves the state of the rom settings */
-void MontezumaRevengeSettings::saveState(Serializer & ser) {
+void MontezumaRevengeSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
@@ -126,7 +104,7 @@ void MontezumaRevengeSettings::saveState(Serializer & ser) {
 }
 
 // loads the state of the rom settings
-void MontezumaRevengeSettings::loadState(Deserializer & ser) {
+void MontezumaRevengeSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();

--- a/src/games/supported/MontezumaRevenge.hpp
+++ b/src/games/supported/MontezumaRevenge.hpp
@@ -29,49 +29,45 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Montezuma Revenge */
 class MontezumaRevengeSettings : public RomSettings {
+ public:
+  MontezumaRevengeSettings();
 
-    public:
+  // reset
+  void reset();
 
-        MontezumaRevengeSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "montezuma_revenge"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // the rom-name
-        const char* rom() const { return "montezuma_revenge"; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
-
-        virtual int lives() { return isTerminal() ? 0 : m_lives; }
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 };
 
-#endif // __MONTEZUMAREVENGE_HPP__
+#endif  // __MONTEZUMAREVENGE_HPP__

--- a/src/games/supported/MrDo.cpp
+++ b/src/games/supported/MrDo.cpp
@@ -13,82 +13,64 @@
 
 #include "../RomUtils.hpp"
 
-
-MrDoSettings::MrDoSettings() {
-
-    reset();
-}
-
+MrDoSettings::MrDoSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* MrDoSettings::clone() const {
-
-    RomSettings* rval = new MrDoSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new MrDoSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void MrDoSettings::step(const System& system) {
+  // update the reward
+  int score = getDecimalScore(0x82, 0x83, &system);
+  score *= 10;
+  int reward = score - m_score;
+  m_reward = reward;
+  m_score = score;
 
-    // update the reward
-    int score = getDecimalScore(0x82, 0x83, &system);
-    score *= 10;
-    int reward = score - m_score;
-    m_reward = reward;
-    m_score = score;
-
-    // update terminal status
-    m_lives = readRam(&system, 0xDB);
-    m_terminal = readRam(&system, 0xDA) == 0x40;
+  // update terminal status
+  m_lives = readRam(&system, 0xDB);
+  m_terminal = readRam(&system, 0xDA) == 0x40;
 }
-
 
 /* is end of game */
-bool MrDoSettings::isTerminal() const {
-    return m_terminal;
-};
-
+bool MrDoSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t MrDoSettings::getReward() const {
-    return m_reward;
-}
-
+reward_t MrDoSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool MrDoSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_UP:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_DOWN:
-        case PLAYER_A_UPFIRE:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_LEFTFIRE:
-        case PLAYER_A_DOWNFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool MrDoSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_UP:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_DOWN:
+    case PLAYER_A_UPFIRE:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_LEFTFIRE:
+    case PLAYER_A_DOWNFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void MrDoSettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
-    m_lives    = 4;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
+  m_lives = 4;
 }
 
 /* saves the state of the rom settings */
-void MrDoSettings::saveState(Serializer & ser) {
+void MrDoSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
@@ -96,7 +78,7 @@ void MrDoSettings::saveState(Serializer & ser) {
 }
 
 // loads the state of the rom settings
-void MrDoSettings::loadState(Deserializer & ser) {
+void MrDoSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();
@@ -104,7 +86,7 @@ void MrDoSettings::loadState(Deserializer & ser) {
 }
 
 ActionVect MrDoSettings::getStartingActions() {
-    ActionVect startingActions;
-    startingActions.push_back(PLAYER_A_FIRE);
-    return startingActions;
+  ActionVect startingActions;
+  startingActions.push_back(PLAYER_A_FIRE);
+  return startingActions;
 }

--- a/src/games/supported/MrDo.hpp
+++ b/src/games/supported/MrDo.hpp
@@ -14,52 +14,48 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for MrDo */
 class MrDoSettings : public RomSettings {
+ public:
+  MrDoSettings();
 
-    public:
+  // reset
+  void reset();
 
-        MrDoSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "mr_do"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // the rom-name
-        const char* rom() const { return "mr_do"; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  // Mr. Do requires the fire action to start the game
+  ActionVect getStartingActions();
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
-        // Mr. Do requires the fire action to start the game
-        ActionVect getStartingActions();
-
-        virtual int lives() { return isTerminal() ? 0 : m_lives; }
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 };
 
-#endif // __MRDO_HPP__
+#endif  // __MRDO_HPP__

--- a/src/games/supported/MsPacman.cpp
+++ b/src/games/supported/MsPacman.cpp
@@ -28,88 +28,66 @@
 
 #include "../RomUtils.hpp"
 
-
-MsPacmanSettings::MsPacmanSettings() {
-
-    reset();
-}
-
+MsPacmanSettings::MsPacmanSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* MsPacmanSettings::clone() const {
-
-    RomSettings* rval = new MsPacmanSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new MsPacmanSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void MsPacmanSettings::step(const System& system) {
+  // update the reward
+  int score = getDecimalScore(0xF8, 0xF9, 0xFA, &system);
+  int reward = score - m_score;
+  m_reward = reward;
+  m_score = score;
 
-    // update the reward
-    int score = getDecimalScore(0xF8, 0xF9, 0xFA, &system);
-    int reward = score - m_score;
-    m_reward = reward;
-    m_score = score;
+  // update terminal status
+  int lives_byte = readRam(&system, 0xFB) & 0xF;
+  // MGB Did not work int black_screen_byte = readRam(&system, 0x94);
+  int death_timer = readRam(&system, 0xA7);
+  m_terminal = (lives_byte == 0 && death_timer == 0x53);
 
-    // update terminal status
-    int lives_byte = readRam(&system, 0xFB) & 0xF;
-    // MGB Did not work int black_screen_byte = readRam(&system, 0x94);
-    int death_timer = readRam(&system, 0xA7);
-    m_terminal = (lives_byte == 0 && death_timer == 0x53);
-
-    m_lives = (lives_byte & 0x7) + 1;
+  m_lives = (lives_byte & 0x7) + 1;
 }
-
 
 /* is end of game */
-bool MsPacmanSettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool MsPacmanSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t MsPacmanSettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t MsPacmanSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool MsPacmanSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_UP:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_DOWN:
-        case PLAYER_A_UPRIGHT:
-        case PLAYER_A_UPLEFT:
-        case PLAYER_A_DOWNRIGHT:
-        case PLAYER_A_DOWNLEFT:
-            return true;
-        default:
-            return false;
-    }
+bool MsPacmanSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_UP:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_DOWN:
+    case PLAYER_A_UPRIGHT:
+    case PLAYER_A_UPLEFT:
+    case PLAYER_A_DOWNRIGHT:
+    case PLAYER_A_DOWNLEFT:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void MsPacmanSettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
-    m_lives    = 3;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
+  m_lives = 3;
 }
 
-
-
 /* saves the state of the rom settings */
-void MsPacmanSettings::saveState(Serializer & ser) {
+void MsPacmanSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
@@ -117,7 +95,7 @@ void MsPacmanSettings::saveState(Serializer & ser) {
 }
 
 // loads the state of the rom settings
-void MsPacmanSettings::loadState(Deserializer & ser) {
+void MsPacmanSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();
@@ -126,48 +104,47 @@ void MsPacmanSettings::loadState(Deserializer & ser) {
 
 // returns a list of mode that the game can be played in
 ModeVect MsPacmanSettings::getAvailableModes() {
-    ModeVect modes(getNumModes());
-    for (unsigned int i = 0; i < modes.size(); i++) {
-        modes[i] = i;
-    }
-    return modes;
+  ModeVect modes(getNumModes());
+  for (unsigned int i = 0; i < modes.size(); i++) {
+    modes[i] = i;
+  }
+  return modes;
 }
 
 // set the mode of the game
 // the given mode must be one returned by the previous function
-void MsPacmanSettings::setMode(game_mode_t m, System &system,
-                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
-
-    if(m < getNumModes()) {
-        if(m == 0) { //this is the standard variation of the game
-            // read the mode we are currently in
-            unsigned char mode = readRam(&system, 0x99);
-            // read the variation
-            unsigned char var = readRam(&system, 0xA1);
-            // press select until the correct mode is reached
-            while(mode != 1 || var != 1) {
-                // hold select button for 10 frames
-                environment->pressSelect(10);
-                mode = readRam(&system, 0x99);
-                var = readRam(&system, 0xA1);
-            }
-        } else {
-            // read the mode we are currently in
-            unsigned char mode = readRam(&system, 0x99);
-            // read the variation
-            unsigned char var = readRam(&system, 0xA1);
-            // press select until the correct mode is reached
-            while(mode != m || var != 0) {
-                // hold select button for 10 frames
-                environment->pressSelect(10);
-                mode = readRam(&system, 0x99);
-                var = readRam(&system, 0xA1);
-            }
-        }
-        //reset the environment to apply changes.
-        environment->softReset();
+void MsPacmanSettings::setMode(
+    game_mode_t m, System& system,
+    std::unique_ptr<StellaEnvironmentWrapper> environment) {
+  if (m < getNumModes()) {
+    if (m == 0) { //this is the standard variation of the game
+      // read the mode we are currently in
+      unsigned char mode = readRam(&system, 0x99);
+      // read the variation
+      unsigned char var = readRam(&system, 0xA1);
+      // press select until the correct mode is reached
+      while (mode != 1 || var != 1) {
+        // hold select button for 10 frames
+        environment->pressSelect(10);
+        mode = readRam(&system, 0x99);
+        var = readRam(&system, 0xA1);
+      }
+    } else {
+      // read the mode we are currently in
+      unsigned char mode = readRam(&system, 0x99);
+      // read the variation
+      unsigned char var = readRam(&system, 0xA1);
+      // press select until the correct mode is reached
+      while (mode != m || var != 0) {
+        // hold select button for 10 frames
+        environment->pressSelect(10);
+        mode = readRam(&system, 0x99);
+        var = readRam(&system, 0xA1);
+      }
     }
-    else {
-        throw std::runtime_error("This mode doesn't currently exist for this game");
-    }
- }
+    //reset the environment to apply changes.
+    environment->softReset();
+  } else {
+    throw std::runtime_error("This mode doesn't currently exist for this game");
+  }
+}

--- a/src/games/supported/MsPacman.hpp
+++ b/src/games/supported/MsPacman.hpp
@@ -29,61 +29,57 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Ms Pacman */
 class MsPacmanSettings : public RomSettings {
+ public:
+  MsPacmanSettings();
 
-    public:
+  // reset
+  void reset();
 
-        MsPacmanSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "ms_pacman"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // get the available number of modes
+  unsigned int getNumModes() const { return 4; }
 
-        // the rom-name
-        const char* rom() const { return "ms_pacman"; }
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // get the available number of modes
-        unsigned int getNumModes() const { return 4; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  // returns a list of mode that the game can be played in
+  // in this game, there are 8 available modes
+  ModeVect getAvailableModes();
 
-        virtual int lives() { return isTerminal() ? 0 : m_lives; }
+  // set the mode of the game
+  // the given mode must be one returned by the previous function
+  void setMode(game_mode_t, System& system,
+               std::unique_ptr<StellaEnvironmentWrapper> environment);
 
-        // returns a list of mode that the game can be played in
-        // in this game, there are 8 available modes
-        ModeVect getAvailableModes();
-
-        // set the mode of the game
-        // the given mode must be one returned by the previous function
-        void setMode(game_mode_t, System &system,
-                     std::unique_ptr<StellaEnvironmentWrapper> environment);
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 };
 
-#endif // __MSPACMAN_HPP__
+#endif  // __MSPACMAN_HPP__

--- a/src/games/supported/NameThisGame.hpp
+++ b/src/games/supported/NameThisGame.hpp
@@ -29,65 +29,61 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Name This Game */
 class NameThisGameSettings : public RomSettings {
+ public:
+  NameThisGameSettings();
 
-    public:
+  // reset
+  void reset();
 
-        NameThisGameSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "name_this_game"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // get the available number of modes
+  unsigned int getNumModes() const { return 3; }
 
-        // the rom-name
-        const char* rom() const { return "name_this_game"; }
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // get the available number of modes
-        unsigned int getNumModes() const { return 3; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  // returns a list of mode that the game can be played in
+  // in this game, there are 3 available modes
+  ModeVect getAvailableModes();
 
-        virtual int lives() { return isTerminal() ? 0 : m_lives; }
+  // set the mode of the game
+  // the given mode must be one returned by the previous function
+  void setMode(game_mode_t, System& system,
+               std::unique_ptr<StellaEnvironmentWrapper> environment);
 
-        // returns a list of mode that the game can be played in
-        // in this game, there are 3 available modes
-        ModeVect getAvailableModes();
+  // returns a list of difficulties that the game can be played in
+  // in this game, there are 2 available difficulties
+  DifficultyVect getAvailableDifficulties();
 
-        // set the mode of the game
-        // the given mode must be one returned by the previous function
-        void setMode(game_mode_t, System &system,
-                     std::unique_ptr<StellaEnvironmentWrapper> environment);
-
-        // returns a list of difficulties that the game can be played in
-        // in this game, there are 2 available difficulties
-        DifficultyVect getAvailableDifficulties();
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 };
 
-#endif // __NAMETHISGAME_HPP__
+#endif  // __NAMETHISGAME_HPP__

--- a/src/games/supported/Phoenix.cpp
+++ b/src/games/supported/Phoenix.cpp
@@ -28,85 +28,65 @@
 
 #include "../RomUtils.hpp"
 
-
-PhoenixSettings::PhoenixSettings() {
-
-    reset();
-}
-
+PhoenixSettings::PhoenixSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* PhoenixSettings::clone() const {
-
-    RomSettings* rval = new PhoenixSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new PhoenixSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void PhoenixSettings::step(const System& system) {
+  // update the reward
+  int score = getDecimalScore(0xC8, 0xC9, &system) * 10;
+  score += readRam(&system, 0xC7) >> 4;
+  score *= 10;
+  int reward = score - m_score;
+  m_reward = reward;
+  m_score = score;
 
-    // update the reward
-    int score = getDecimalScore(0xC8, 0xC9, &system) * 10;
-    score += readRam(&system, 0xC7) >> 4;
-    score *= 10;
-    int reward = score - m_score;
-    m_reward = reward;
-    m_score = score;
-
-    // update terminal status
-    int state_byte = readRam(&system, 0xCC);
-    m_terminal = state_byte == 0x80;
-    // Technically seems to only go up to 5
-    m_lives = readRam(&system, 0xCB) & 0x7;
+  // update terminal status
+  int state_byte = readRam(&system, 0xCC);
+  m_terminal = state_byte == 0x80;
+  // Technically seems to only go up to 5
+  m_lives = readRam(&system, 0xCB) & 0x7;
 }
-
 
 /* is end of game */
-bool PhoenixSettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool PhoenixSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t PhoenixSettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t PhoenixSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool PhoenixSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_DOWN:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_LEFTFIRE:
-        case PLAYER_A_DOWNFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool PhoenixSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_DOWN:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_LEFTFIRE:
+    case PLAYER_A_DOWNFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void PhoenixSettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
-    m_lives    = 5;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
+  m_lives = 5;
 }
 
 /* saves the state of the rom settings */
-void PhoenixSettings::saveState(Serializer & ser) {
+void PhoenixSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
@@ -114,7 +94,7 @@ void PhoenixSettings::saveState(Serializer & ser) {
 }
 
 // loads the state of the rom settings
-void PhoenixSettings::loadState(Deserializer & ser) {
+void PhoenixSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();

--- a/src/games/supported/Phoenix.hpp
+++ b/src/games/supported/Phoenix.hpp
@@ -29,49 +29,45 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Phoenix */
 class PhoenixSettings : public RomSettings {
+ public:
+  PhoenixSettings();
 
-    public:
+  // reset
+  void reset();
 
-        PhoenixSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "phoenix"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // the rom-name
-        const char* rom() const { return "phoenix"; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
-
-        virtual int lives() { return isTerminal() ? 0 : m_lives; }
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 };
 
-#endif // __PHOENIX_HPP__
+#endif  // __PHOENIX_HPP__

--- a/src/games/supported/Pitfall.cpp
+++ b/src/games/supported/Pitfall.cpp
@@ -28,96 +28,75 @@
 
 #include "../RomUtils.hpp"
 
-
-PitfallSettings::PitfallSettings() {
-
-    reset();
-}
-
+PitfallSettings::PitfallSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* PitfallSettings::clone() const {
-
-    RomSettings* rval = new PitfallSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new PitfallSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void PitfallSettings::step(const System& system) {
+  // update the reward
+  int score = getDecimalScore(0xD7, 0xD6, 0xD5, &system);
+  int reward = score - m_score;
+  m_reward = reward;
+  m_score = score;
 
-    // update the reward
-    int score = getDecimalScore(0xD7, 0xD6, 0xD5, &system);
-    int reward = score - m_score;
-    m_reward = reward;
-    m_score = score;
+  // update terminal status
+  int lives_byte = readRam(&system, 0x80) >> 4;
+  // The value at 09xE will be nonzero if we cannot control the player
+  int logo_timer = readRam(&system, 0x9E);
+  m_terminal = lives_byte == 0 && logo_timer != 0;
 
-    // update terminal status
-    int lives_byte = readRam(&system, 0x80) >> 4;
-    // The value at 09xE will be nonzero if we cannot control the player
-    int logo_timer = readRam(&system, 0x9E);
-    m_terminal = lives_byte == 0 && logo_timer != 0;
-
-    m_lives = (lives_byte == 0xA) ? 3 : ((lives_byte == 0x8) ? 2 : 1);
+  m_lives = (lives_byte == 0xA) ? 3 : ((lives_byte == 0x8) ? 2 : 1);
 }
-
 
 /* is end of game */
-bool PitfallSettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool PitfallSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t PitfallSettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t PitfallSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool PitfallSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_UP:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_DOWN:
-        case PLAYER_A_UPRIGHT:
-        case PLAYER_A_UPLEFT:
-        case PLAYER_A_DOWNRIGHT:
-        case PLAYER_A_DOWNLEFT:
-        case PLAYER_A_UPFIRE:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_LEFTFIRE:
-        case PLAYER_A_DOWNFIRE:
-        case PLAYER_A_UPRIGHTFIRE:
-        case PLAYER_A_UPLEFTFIRE:
-        case PLAYER_A_DOWNRIGHTFIRE:
-        case PLAYER_A_DOWNLEFTFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool PitfallSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_UP:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_DOWN:
+    case PLAYER_A_UPRIGHT:
+    case PLAYER_A_UPLEFT:
+    case PLAYER_A_DOWNRIGHT:
+    case PLAYER_A_DOWNLEFT:
+    case PLAYER_A_UPFIRE:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_LEFTFIRE:
+    case PLAYER_A_DOWNFIRE:
+    case PLAYER_A_UPRIGHTFIRE:
+    case PLAYER_A_UPLEFTFIRE:
+    case PLAYER_A_DOWNRIGHTFIRE:
+    case PLAYER_A_DOWNLEFTFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void PitfallSettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 2000;
-    m_terminal = false;
-    m_lives    = 3;
+  m_reward = 0;
+  m_score = 2000;
+  m_terminal = false;
+  m_lives = 3;
 }
 
 /* saves the state of the rom settings */
-void PitfallSettings::saveState(Serializer & ser) {
+void PitfallSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
@@ -125,7 +104,7 @@ void PitfallSettings::saveState(Serializer & ser) {
 }
 
 // loads the state of the rom settings
-void PitfallSettings::loadState(Deserializer & ser) {
+void PitfallSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();
@@ -133,7 +112,7 @@ void PitfallSettings::loadState(Deserializer & ser) {
 }
 
 ActionVect PitfallSettings::getStartingActions() {
-    ActionVect startingActions;
-    startingActions.push_back(PLAYER_A_UP);
-    return startingActions;
+  ActionVect startingActions;
+  startingActions.push_back(PLAYER_A_UP);
+  return startingActions;
 }

--- a/src/games/supported/Pitfall.hpp
+++ b/src/games/supported/Pitfall.hpp
@@ -29,51 +29,47 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Phoenix */
 class PitfallSettings : public RomSettings {
+ public:
+  PitfallSettings();
 
-    public:
+  // reset
+  void reset();
 
-        PitfallSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "pitfall"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // the rom-name
-        const char* rom() const { return "pitfall"; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  ActionVect getStartingActions();
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
-        ActionVect getStartingActions();
-
-        virtual int lives() { return isTerminal() ? 0 : m_lives; }
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 };
 
-#endif // __PITFALL_HPP__
+#endif  // __PITFALL_HPP__

--- a/src/games/supported/Pong.cpp
+++ b/src/games/supported/Pong.cpp
@@ -13,87 +13,66 @@
 
 #include "../RomUtils.hpp"
 
-
-PongSettings::PongSettings() {
-
-    reset();
-}
-
+PongSettings::PongSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* PongSettings::clone() const {
-
-    RomSettings* rval = new PongSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new PongSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void PongSettings::step(const System& system) {
+  // update the reward
+  int x = readRam(&system, 13); // cpu score
+  int y = readRam(&system, 14); // player score
+  reward_t score = y - x;
+  m_reward = score - m_score;
+  m_score = score;
 
-    // update the reward
-    int x = readRam(&system, 13); // cpu score
-    int y = readRam(&system, 14); // player score
-    reward_t score = y - x;
-    m_reward = score - m_score;
-    m_score = score;
-
-    // update terminal status
-    // (game over when a player reaches 21)
-    m_terminal = x == 21 || y == 21;
+  // update terminal status
+  // (game over when a player reaches 21)
+  m_terminal = x == 21 || y == 21;
 }
-
 
 /* is end of game */
-bool PongSettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool PongSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t PongSettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t PongSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool PongSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_LEFTFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool PongSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_LEFTFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void PongSettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
 }
 
-
 /* saves the state of the rom settings */
-void PongSettings::saveState(Serializer & ser) {
+void PongSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
 }
 
 // loads the state of the rom settings
-void PongSettings::loadState(Deserializer & ser) {
+void PongSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();
@@ -101,35 +80,34 @@ void PongSettings::loadState(Deserializer & ser) {
 
 // returns a list of mode that the game can be played in
 ModeVect PongSettings::getAvailableModes() {
-    ModeVect modes(getNumModes());
-    for (unsigned int i = 0; i < modes.size(); i++) {
-        modes[i] = i;
-    }
-    return modes;
+  ModeVect modes(getNumModes());
+  for (unsigned int i = 0; i < modes.size(); i++) {
+    modes[i] = i;
+  }
+  return modes;
 }
 
 // set the mode of the game
 // the given mode must be one returned by the previous function
-void PongSettings::setMode(game_mode_t m, System &system,
-                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
-
-    if(m < getNumModes()) {
-        // read the mode we are currently in
-        unsigned char mode = readRam(&system, 0x96);
-        // press select until the correct mode is reached
-        while (mode != m) {
-            environment->pressSelect(2);
-            mode = readRam(&system, 0x96);
-        }
-        //reset the environment to apply changes.
-        environment->softReset();
+void PongSettings::setMode(
+    game_mode_t m, System& system,
+    std::unique_ptr<StellaEnvironmentWrapper> environment) {
+  if (m < getNumModes()) {
+    // read the mode we are currently in
+    unsigned char mode = readRam(&system, 0x96);
+    // press select until the correct mode is reached
+    while (mode != m) {
+      environment->pressSelect(2);
+      mode = readRam(&system, 0x96);
     }
-    else {
-        throw std::runtime_error("This mode doesn't currently exist for this game");
-    }
- }
+    //reset the environment to apply changes.
+    environment->softReset();
+  } else {
+    throw std::runtime_error("This mode doesn't currently exist for this game");
+  }
+}
 
 DifficultyVect PongSettings::getAvailableDifficulties() {
-    DifficultyVect diff = {0, 1};
-    return diff;
+  DifficultyVect diff = {0, 1};
+  return diff;
 }

--- a/src/games/supported/Pong.hpp
+++ b/src/games/supported/Pong.hpp
@@ -29,64 +29,60 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Pong */
 class PongSettings : public RomSettings {
+ public:
+  PongSettings();
 
-    public:
+  // reset
+  void reset();
 
-        PongSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "pong"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // get the available number of modes
+  unsigned int getNumModes() const { return 2; }
 
-        // the rom-name
-        const char* rom() const { return "pong"; }
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // get the available number of modes
-        unsigned int getNumModes() const { return 2; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  virtual int lives() { return 0; }
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  // returns a list of difficulties that the game can be played in
+  // in this game, there are 2 available difficulties
+  DifficultyVect getAvailableDifficulties();
 
-        virtual int lives() { return 0; }
+  // returns a list of mode that the game can be played in
+  // in this game, there are 2 available modes
+  ModeVect getAvailableModes();
 
-        // returns a list of difficulties that the game can be played in
-        // in this game, there are 2 available difficulties
-        DifficultyVect getAvailableDifficulties();
+  // set the mode of the game
+  // the given mode must be one returned by the previous function
+  void setMode(game_mode_t, System& system,
+               std::unique_ptr<StellaEnvironmentWrapper> environment);
 
-        // returns a list of mode that the game can be played in
-        // in this game, there are 2 available modes
-        ModeVect getAvailableModes();
-
-        // set the mode of the game
-        // the given mode must be one returned by the previous function
-        void setMode(game_mode_t, System &system,
-                     std::unique_ptr<StellaEnvironmentWrapper> environment);
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
 };
 
-#endif // __PONG_HPP__
+#endif  // __PONG_HPP__

--- a/src/games/supported/Pooyan.cpp
+++ b/src/games/supported/Pooyan.cpp
@@ -28,82 +28,62 @@
 
 #include "../RomUtils.hpp"
 
-
-PooyanSettings::PooyanSettings() {
-
-    reset();
-}
-
+PooyanSettings::PooyanSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* PooyanSettings::clone() const {
-
-    RomSettings* rval = new PooyanSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new PooyanSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void PooyanSettings::step(const System& system) {
+  // update the reward
+  int score = getDecimalScore(0x8A, 0x89, 0x88, &system);
+  int reward = score - m_score;
+  m_reward = reward;
+  m_score = score;
 
-    // update the reward
-    int score = getDecimalScore(0x8A, 0x89, 0x88, &system);
-    int reward = score - m_score;
-    m_reward = reward;
-    m_score = score;
+  // update terminal status
+  int lives_byte = readRam(&system, 0x96);
+  int some_byte = readRam(&system, 0x98);
+  m_terminal = (lives_byte == 0x0 && some_byte == 0x05);
 
-    // update terminal status
-    int lives_byte = readRam(&system, 0x96);
-    int some_byte  = readRam(&system, 0x98);
-    m_terminal = (lives_byte == 0x0 && some_byte == 0x05);
-
-    m_lives = (lives_byte & 0x7) + 1;
+  m_lives = (lives_byte & 0x7) + 1;
 }
-
 
 /* is end of game */
-bool PooyanSettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool PooyanSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t PooyanSettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t PooyanSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool PooyanSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_UP:
-        case PLAYER_A_DOWN:
-        case PLAYER_A_UPFIRE:
-        case PLAYER_A_DOWNFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool PooyanSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_UP:
+    case PLAYER_A_DOWN:
+    case PLAYER_A_UPFIRE:
+    case PLAYER_A_DOWNFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void PooyanSettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
-    m_lives    = 3;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
+  m_lives = 3;
 }
 
 /* saves the state of the rom settings */
-void PooyanSettings::saveState(Serializer & ser) {
+void PooyanSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
@@ -111,7 +91,7 @@ void PooyanSettings::saveState(Serializer & ser) {
 }
 
 // loads the state of the rom settings
-void PooyanSettings::loadState(Deserializer & ser) {
+void PooyanSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();
@@ -120,32 +100,30 @@ void PooyanSettings::loadState(Deserializer & ser) {
 
 // returns a list of mode that the game can be played in
 ModeVect PooyanSettings::getAvailableModes() {
-    ModeVect modes = {0x0A, 0x1E, 0x32, 0x46};
-    return modes;
+  ModeVect modes = {0x0A, 0x1E, 0x32, 0x46};
+  return modes;
 }
 
 // set the mode of the game
 // the given mode must be one returned by the previous function
-void PooyanSettings::setMode(game_mode_t m, System &system,
-                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
-
-
-    if (m == 0) {
-      m = 0x0A; // The default mode (0) is not valid here.
+void PooyanSettings::setMode(
+    game_mode_t m, System& system,
+    std::unique_ptr<StellaEnvironmentWrapper> environment) {
+  if (m == 0) {
+    m = 0x0A; // The default mode (0) is not valid here.
+  }
+  if (m == 0x0A || m == 0x1E || m == 0x32 || m == 0x46) {
+    environment->pressSelect(2);
+    // read the mode we are currently in
+    unsigned char mode = readRam(&system, 0xBD);
+    // press select until the correct mode is reached
+    while (mode != m) {
+      environment->pressSelect(2);
+      mode = readRam(&system, 0xBD);
     }
-    if(m == 0x0A || m == 0x1E || m == 0x32 || m == 0x46) {
-        environment->pressSelect(2);
-        // read the mode we are currently in
-        unsigned char mode = readRam(&system, 0xBD);
-        // press select until the correct mode is reached
-        while (mode != m) {
-            environment->pressSelect(2);
-            mode = readRam(&system, 0xBD);
-        }
-        //reset the environment to apply changes.
-        environment->softReset();
-    }
-    else {
-        throw std::runtime_error("This mode doesn't currently exist for this game");
-    }
- }
+    //reset the environment to apply changes.
+    environment->softReset();
+  } else {
+    throw std::runtime_error("This mode doesn't currently exist for this game");
+  }
+}

--- a/src/games/supported/Pooyan.hpp
+++ b/src/games/supported/Pooyan.hpp
@@ -29,61 +29,57 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Pooyan */
 class PooyanSettings : public RomSettings {
+ public:
+  PooyanSettings();
 
-    public:
+  // reset
+  void reset();
 
-        PooyanSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "pooyan"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // get the available number of modes
+  unsigned int getNumModes() const { return 4; }
 
-        // the rom-name
-        const char* rom() const { return "pooyan"; }
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // get the available number of modes
-        unsigned int getNumModes() const { return 4; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  // returns a list of mode that the game can be played in
+  // in this game, there are 4 available modes
+  ModeVect getAvailableModes();
 
-        virtual int lives() { return isTerminal() ? 0 : m_lives; }
+  // set the mode of the game
+  // the given mode must be one returned by the previous function
+  void setMode(game_mode_t, System& system,
+               std::unique_ptr<StellaEnvironmentWrapper> environment);
 
-        // returns a list of mode that the game can be played in
-        // in this game, there are 4 available modes
-        ModeVect getAvailableModes();
-
-        // set the mode of the game
-        // the given mode must be one returned by the previous function
-        void setMode(game_mode_t, System &system,
-                     std::unique_ptr<StellaEnvironmentWrapper> environment);
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 };
 
-#endif // __POOYAN_HPP__
+#endif  // __POOYAN_HPP__

--- a/src/games/supported/PrivateEye.cpp
+++ b/src/games/supported/PrivateEye.cpp
@@ -13,141 +13,119 @@
 
 #include "../RomUtils.hpp"
 
-
-PrivateEyeSettings::PrivateEyeSettings() {
-
-    reset();
-}
-
+PrivateEyeSettings::PrivateEyeSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* PrivateEyeSettings::clone() const {
-
-    RomSettings* rval = new PrivateEyeSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new PrivateEyeSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void PrivateEyeSettings::step(const System& system) {
+  // update the reward
+  int score = getDecimalScore(0xCA, 0xC9, 0xC8, &system);
+  int reward = score - m_score;
+  m_reward = reward;
+  m_score = score;
 
-    // update the reward
-    int score = getDecimalScore(0xCA, 0xC9, 0xC8, &system);
-    int reward = score - m_score;
-    m_reward = reward;
-    m_score = score;
-
-    // update terminal status
-    int copyright_timer = readRam(&system, 0xC2);
-    // 00 when the game is running; 01 at start of game.
-    m_terminal = copyright_timer != 0x00 && copyright_timer != 0x01;
+  // update terminal status
+  int copyright_timer = readRam(&system, 0xC2);
+  // 00 when the game is running; 01 at start of game.
+  m_terminal = copyright_timer != 0x00 && copyright_timer != 0x01;
 }
-
 
 /* is end of game */
-bool PrivateEyeSettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool PrivateEyeSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t PrivateEyeSettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t PrivateEyeSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool PrivateEyeSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_UP:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_DOWN:
-        case PLAYER_A_UPRIGHT:
-        case PLAYER_A_UPLEFT:
-        case PLAYER_A_DOWNRIGHT:
-        case PLAYER_A_DOWNLEFT:
-        case PLAYER_A_UPFIRE:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_LEFTFIRE:
-        case PLAYER_A_DOWNFIRE:
-        case PLAYER_A_UPRIGHTFIRE:
-        case PLAYER_A_UPLEFTFIRE:
-        case PLAYER_A_DOWNRIGHTFIRE:
-        case PLAYER_A_DOWNLEFTFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool PrivateEyeSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_UP:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_DOWN:
+    case PLAYER_A_UPRIGHT:
+    case PLAYER_A_UPLEFT:
+    case PLAYER_A_DOWNRIGHT:
+    case PLAYER_A_DOWNLEFT:
+    case PLAYER_A_UPFIRE:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_LEFTFIRE:
+    case PLAYER_A_DOWNFIRE:
+    case PLAYER_A_UPRIGHTFIRE:
+    case PLAYER_A_UPLEFTFIRE:
+    case PLAYER_A_DOWNRIGHTFIRE:
+    case PLAYER_A_DOWNLEFTFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void PrivateEyeSettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 1000;
-    m_terminal = false;
+  m_reward = 0;
+  m_score = 1000;
+  m_terminal = false;
 }
 
 /* saves the state of the rom settings */
-void PrivateEyeSettings::saveState(Serializer & ser) {
+void PrivateEyeSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
 }
 
 // loads the state of the rom settings
-void PrivateEyeSettings::loadState(Deserializer & ser) {
+void PrivateEyeSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();
 }
 
 ActionVect PrivateEyeSettings::getStartingActions() {
-    ActionVect startingActions;
-    startingActions.push_back(PLAYER_A_UP);
-    return startingActions;
+  ActionVect startingActions;
+  startingActions.push_back(PLAYER_A_UP);
+  return startingActions;
 }
 
 // returns a list of mode that the game can be played in
 ModeVect PrivateEyeSettings::getAvailableModes() {
-    ModeVect modes(getNumModes());
-    for (unsigned int i = 0; i < modes.size(); i++) {
-        modes[i] = i;
-    }
-    return modes;
+  ModeVect modes(getNumModes());
+  for (unsigned int i = 0; i < modes.size(); i++) {
+    modes[i] = i;
+  }
+  return modes;
 }
 
 // set the mode of the game
 // the given mode must be one returned by the previous function
-void PrivateEyeSettings::setMode(game_mode_t m, System &system,
-                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
-
-    if(m < getNumModes()) {
-        // read the mode we are currently in
-        unsigned char mode = readRam(&system, 0x80);
-        // press select until the correct mode is reached
-        while (mode != m) {
-            environment->pressSelect(2);
-            mode = readRam(&system, 0x80);
-        }
-        //reset the environment to apply changes.
-        environment->softReset();
+void PrivateEyeSettings::setMode(
+    game_mode_t m, System& system,
+    std::unique_ptr<StellaEnvironmentWrapper> environment) {
+  if (m < getNumModes()) {
+    // read the mode we are currently in
+    unsigned char mode = readRam(&system, 0x80);
+    // press select until the correct mode is reached
+    while (mode != m) {
+      environment->pressSelect(2);
+      mode = readRam(&system, 0x80);
     }
-    else {
-        throw std::runtime_error("This mode doesn't currently exist for this game");
-    }
- }
-
+    //reset the environment to apply changes.
+    environment->softReset();
+  } else {
+    throw std::runtime_error("This mode doesn't currently exist for this game");
+  }
+}
 
 DifficultyVect PrivateEyeSettings::getAvailableDifficulties() {
-    DifficultyVect diff = {0, 1, 2, 3};
-    return diff;
+  DifficultyVect diff = {0, 1, 2, 3};
+  return diff;
 }

--- a/src/games/supported/PrivateEye.hpp
+++ b/src/games/supported/PrivateEye.hpp
@@ -29,66 +29,62 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Private Eye */
 class PrivateEyeSettings : public RomSettings {
+ public:
+  PrivateEyeSettings();
 
-    public:
+  // reset
+  void reset();
 
-        PrivateEyeSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "private_eye"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // get the available number of modes
+  unsigned int getNumModes() const { return 5; }
 
-        // the rom-name
-        const char* rom() const { return "private_eye"; }
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // get the available number of modes
-        unsigned int getNumModes() const { return 5; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  ActionVect getStartingActions();
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  virtual int lives() { return 0; }
 
-        ActionVect getStartingActions();
+  // returns a list of mode that the game can be played in
+  // in this game, there are 5 available modes
+  ModeVect getAvailableModes();
 
-        virtual int lives() { return 0; }
+  // set the mode of the game
+  // the given mode must be one returned by the previous function
+  void setMode(game_mode_t, System& system,
+               std::unique_ptr<StellaEnvironmentWrapper> environment);
 
-        // returns a list of mode that the game can be played in
-        // in this game, there are 5 available modes
-        ModeVect getAvailableModes();
+  // returns a list of difficulties that the game can be played in
+  // in this game, there are 4 available difficulties
+  DifficultyVect getAvailableDifficulties();
 
-        // set the mode of the game
-        // the given mode must be one returned by the previous function
-        void setMode(game_mode_t, System &system,
-                     std::unique_ptr<StellaEnvironmentWrapper> environment);
-
-        // returns a list of difficulties that the game can be played in
-        // in this game, there are 4 available difficulties
-        DifficultyVect getAvailableDifficulties();
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
 };
 
-#endif // __PRIVATEEYE_HPP__
+#endif  // __PRIVATEEYE_HPP__

--- a/src/games/supported/QBert.cpp
+++ b/src/games/supported/QBert.cpp
@@ -28,95 +28,77 @@
 
 #include "../RomUtils.hpp"
 
-
-QBertSettings::QBertSettings() {
-
-    reset();
-}
-
+QBertSettings::QBertSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* QBertSettings::clone() const {
-
-    RomSettings* rval = new QBertSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new QBertSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void QBertSettings::step(const System& system) {
-    // update terminal status
-    int lives_value = readRam(&system, 0x88);
-    // Lives start at 2 (4 lives, 3 displayed) and go down to 0xFE (death)
-    // Alternatively we can die and reset within one frame; we catch this case
-    m_terminal = (lives_value == 0xFE) ||
-      (lives_value == 0x02 && m_last_lives == -1);
+  // update terminal status
+  int lives_value = readRam(&system, 0x88);
+  // Lives start at 2 (4 lives, 3 displayed) and go down to 0xFE (death)
+  // Alternatively we can die and reset within one frame; we catch this case
+  m_terminal =
+      (lives_value == 0xFE) || (lives_value == 0x02 && m_last_lives == -1);
 
-    // Convert char into a signed integer
-    int livesAsChar = static_cast<char>(lives_value);
+  // Convert char into a signed integer
+  int livesAsChar = static_cast<char>(lives_value);
 
-    if (m_last_lives - 1 == livesAsChar) m_lives--;
-    m_last_lives = livesAsChar;
+  if (m_last_lives - 1 == livesAsChar)
+    m_lives--;
+  m_last_lives = livesAsChar;
 
-    // update the reward
-    // Ignore reward if reset the game via the fire button; otherwise the agent
-    //  gets a big negative reward on its last step
-    if (!m_terminal) {
-      int score = getDecimalScore(0xDB, 0xDA, 0xD9, &system);
-      int reward = score - m_score;
-      m_reward = reward;
-      m_score = score;
-    }
-    else {
-      m_reward = 0;
-    }
+  // update the reward
+  // Ignore reward if reset the game via the fire button; otherwise the agent
+  //  gets a big negative reward on its last step
+  if (!m_terminal) {
+    int score = getDecimalScore(0xDB, 0xDA, 0xD9, &system);
+    int reward = score - m_score;
+    m_reward = reward;
+    m_score = score;
+  } else {
+    m_reward = 0;
+  }
 }
-
 
 /* is end of game */
-bool QBertSettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool QBertSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t QBertSettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t QBertSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool QBertSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_UP:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_DOWN:
-            return true;
-        default:
-            return false;
-    }
+bool QBertSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_UP:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_DOWN:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void QBertSettings::reset() {
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
-    // Anything non-0xFF
-    m_last_lives = 2;
-    m_lives    = 4;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
+  // Anything non-0xFF
+  m_last_lives = 2;
+  m_lives = 4;
 }
 
 /* saves the state of the rom settings */
-void QBertSettings::saveState(Serializer & ser) {
+void QBertSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
@@ -125,7 +107,7 @@ void QBertSettings::saveState(Serializer & ser) {
 }
 
 // loads the state of the rom settings
-void QBertSettings::loadState(Deserializer & ser) {
+void QBertSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();
@@ -134,6 +116,6 @@ void QBertSettings::loadState(Deserializer & ser) {
 }
 
 DifficultyVect QBertSettings::getAvailableDifficulties() {
-    DifficultyVect diff = {0, 1};
-    return diff;
+  DifficultyVect diff = {0, 1};
+  return diff;
 }

--- a/src/games/supported/QBert.hpp
+++ b/src/games/supported/QBert.hpp
@@ -29,54 +29,50 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for QBert */
 class QBertSettings : public RomSettings {
+ public:
+  QBertSettings();
 
-    public:
+  // reset
+  void reset();
 
-        QBertSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "qbert"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // the rom-name
-        const char* rom() const { return "qbert"; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  // returns a list of difficulties that the game can be played in
+  // in this game, there are 2 available difficulties
+  DifficultyVect getAvailableDifficulties();
 
-        virtual int lives() { return isTerminal() ? 0 : m_lives; }
-
-        // returns a list of difficulties that the game can be played in
-        // in this game, there are 2 available difficulties
-        DifficultyVect getAvailableDifficulties();
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_last_lives;
-        int m_lives;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_last_lives;
+  int m_lives;
 };
 
-#endif // __QBERT_HPP__
+#endif  // __QBERT_HPP__

--- a/src/games/supported/RiverRaid.cpp
+++ b/src/games/supported/RiverRaid.cpp
@@ -28,124 +28,105 @@
 
 #include "../RomUtils.hpp"
 
-
 RiverRaidSettings::RiverRaidSettings() {
+  m_ram_vals_to_digits[0] = 0;
+  m_ram_vals_to_digits[8] = 1;
+  m_ram_vals_to_digits[16] = 2;
+  m_ram_vals_to_digits[24] = 3;
+  m_ram_vals_to_digits[32] = 4;
+  m_ram_vals_to_digits[40] = 5;
+  m_ram_vals_to_digits[48] = 6;
+  m_ram_vals_to_digits[56] = 7;
+  m_ram_vals_to_digits[64] = 8;
+  m_ram_vals_to_digits[72] = 9;
 
-    m_ram_vals_to_digits[0]  = 0;
-    m_ram_vals_to_digits[8]  = 1;
-    m_ram_vals_to_digits[16] = 2;
-    m_ram_vals_to_digits[24] = 3;
-    m_ram_vals_to_digits[32] = 4;
-    m_ram_vals_to_digits[40] = 5;
-    m_ram_vals_to_digits[48] = 6;
-    m_ram_vals_to_digits[56] = 7;
-    m_ram_vals_to_digits[64] = 8;
-    m_ram_vals_to_digits[72] = 9;
-
-    reset();
+  reset();
 }
-
 
 /* create a new instance of the rom */
 RomSettings* RiverRaidSettings::clone() const {
-
-    RomSettings* rval = new RiverRaidSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new RiverRaidSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void RiverRaidSettings::step(const System& system) {
+  // update the reward
+  int score = 0;
+  int digit = m_ram_vals_to_digits[readRam(&system, 87)];
+  score += digit;
+  digit = m_ram_vals_to_digits[readRam(&system, 85)];
+  score += 10 * digit;
+  digit = m_ram_vals_to_digits[readRam(&system, 83)];
+  score += 100 * digit;
+  digit = m_ram_vals_to_digits[readRam(&system, 81)];
+  score += 1000 * digit;
+  digit = m_ram_vals_to_digits[readRam(&system, 79)];
+  score += 10000 * digit;
+  digit = m_ram_vals_to_digits[readRam(&system, 77)];
+  score += 100000 * digit;
+  m_reward = score - m_score;
+  m_score = score;
 
-    // update the reward
-    int score = 0;
-    int digit = m_ram_vals_to_digits[readRam(&system, 87)];
-    score += digit;
-    digit = m_ram_vals_to_digits[readRam(&system, 85)];
-    score += 10 * digit;
-    digit = m_ram_vals_to_digits[readRam(&system, 83)];
-    score += 100 * digit;
-    digit = m_ram_vals_to_digits[readRam(&system, 81)];
-    score += 1000 * digit;
-    digit = m_ram_vals_to_digits[readRam(&system, 79)];
-    score += 10000 * digit;
-    digit = m_ram_vals_to_digits[readRam(&system, 77)];
-    score += 100000 * digit;
-    m_reward = score - m_score;
-    m_score = score;
-
-    // update terminal status
-    int byte_val = readRam(&system, 0xC0);
-    m_terminal = (byte_val == 0x58 && m_lives_byte == 0x59);
-    m_lives_byte = byte_val;
+  // update terminal status
+  int byte_val = readRam(&system, 0xC0);
+  m_terminal = (byte_val == 0x58 && m_lives_byte == 0x59);
+  m_lives_byte = byte_val;
 }
 
 int RiverRaidSettings::numericLives() const {
-    // The last life, which is effectively empty, is stored as a '0x59'; but initially the
-    // value is 0x58 == 0, which then changes to 0x18 == 3 lives when the ship reaches the
-    // edge of the screen
-    return m_lives_byte == 0x58 ? 4 : // Assume beginning of episode
-           m_lives_byte == 0x59 ? 1 :
-           (m_lives_byte / 8 + 1);
+  // The last life, which is effectively empty, is stored as a '0x59'; but initially the
+  // value is 0x58 == 0, which then changes to 0x18 == 3 lives when the ship reaches the
+  // edge of the screen
+  return m_lives_byte == 0x58 ? 4 : // Assume beginning of episode
+             m_lives_byte == 0x59 ? 1 : (m_lives_byte / 8 + 1);
 }
 
 /* is end of game */
-bool RiverRaidSettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool RiverRaidSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t RiverRaidSettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t RiverRaidSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool RiverRaidSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_UP:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_DOWN:
-        case PLAYER_A_UPRIGHT:
-        case PLAYER_A_UPLEFT:
-        case PLAYER_A_DOWNRIGHT:
-        case PLAYER_A_DOWNLEFT:
-        case PLAYER_A_UPFIRE:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_LEFTFIRE:
-        case PLAYER_A_DOWNFIRE:
-        case PLAYER_A_UPRIGHTFIRE:
-        case PLAYER_A_UPLEFTFIRE:
-        case PLAYER_A_DOWNRIGHTFIRE:
-        case PLAYER_A_DOWNLEFTFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool RiverRaidSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_UP:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_DOWN:
+    case PLAYER_A_UPRIGHT:
+    case PLAYER_A_UPLEFT:
+    case PLAYER_A_DOWNRIGHT:
+    case PLAYER_A_DOWNLEFT:
+    case PLAYER_A_UPFIRE:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_LEFTFIRE:
+    case PLAYER_A_DOWNFIRE:
+    case PLAYER_A_UPRIGHTFIRE:
+    case PLAYER_A_UPLEFTFIRE:
+    case PLAYER_A_DOWNRIGHTFIRE:
+    case PLAYER_A_DOWNLEFTFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void RiverRaidSettings::reset() {
-
-    m_lives      = 0;
-    m_reward     = 0;
-    m_score      = 0;
-    m_terminal   = false;
-    m_lives_byte = 0x58;
+  m_lives = 0;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
+  m_lives_byte = 0x58;
 }
 
-
 /* saves the state of the rom settings */
-void RiverRaidSettings::saveState(Serializer & ser) {
+void RiverRaidSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
@@ -153,7 +134,7 @@ void RiverRaidSettings::saveState(Serializer & ser) {
 }
 
 // loads the state of the rom settings
-void RiverRaidSettings::loadState(Deserializer & ser) {
+void RiverRaidSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();
@@ -161,6 +142,6 @@ void RiverRaidSettings::loadState(Deserializer & ser) {
 }
 
 DifficultyVect RiverRaidSettings::getAvailableDifficulties() {
-    DifficultyVect diff = {0, 1};
-    return diff;
+  DifficultyVect diff = {0, 1};
+  return diff;
 }

--- a/src/games/supported/RiverRaid.hpp
+++ b/src/games/supported/RiverRaid.hpp
@@ -33,55 +33,52 @@
 
 /* RL wrapper for RiverRaid */
 class RiverRaidSettings : public RomSettings {
+ public:
+  RiverRaidSettings();
 
-    public:
+  // reset
+  void reset();
 
-        RiverRaidSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "riverraid"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // the rom-name
-        const char* rom() const { return "riverraid"; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  virtual int lives() { return isTerminal() ? 0 : numericLives(); }
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  // returns a list of difficulties that the game can be played in
+  // in this game, there are 2 available difficulties
+  DifficultyVect getAvailableDifficulties();
 
-        virtual int lives() { return isTerminal() ? 0 : numericLives(); }
+ private:
+  /** Necessary because Riverraid stores its lives in a very strange format */
+  int numericLives() const;
 
-        // returns a list of difficulties that the game can be played in
-        // in this game, there are 2 available difficulties
-        DifficultyVect getAvailableDifficulties();
-
-    private:
-
-        /** Necessary because Riverraid stores its lives in a very strange format */
-        int numericLives() const;
-
-        std::map<int, int> m_ram_vals_to_digits;
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives_byte;
-        int m_lives;
+  std::map<int, int> m_ram_vals_to_digits;
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives_byte;
+  int m_lives;
 };
 
-#endif // __RIVERRAID_HPP__
+#endif  // __RIVERRAID_HPP__

--- a/src/games/supported/RoadRunner.cpp
+++ b/src/games/supported/RoadRunner.cpp
@@ -28,104 +28,85 @@
 
 #include "../RomUtils.hpp"
 
-
-RoadRunnerSettings::RoadRunnerSettings() {
-
-    reset();
-}
-
+RoadRunnerSettings::RoadRunnerSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* RoadRunnerSettings::clone() const {
-
-    RomSettings* rval = new RoadRunnerSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new RoadRunnerSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void RoadRunnerSettings::step(const System& system) {
+  // update the reward
+  int score = 0, mult = 1;
+  for (int digit = 0; digit < 4; digit++) {
+    int value = readRam(&system, 0xC9 + digit) & 0xF;
+    // 0xA represents '0, don't display'
+    if (value == 0xA)
+      value = 0;
+    score += mult * value;
+    mult *= 10;
+  }
+  score *= 100;
+  int reward = score - m_score;
+  m_reward = reward;
+  m_score = score;
 
-    // update the reward
-    int score = 0, mult = 1;
-    for (int digit = 0; digit < 4; digit++) {
-        int value = readRam(&system, 0xC9 + digit) & 0xF;
-        // 0xA represents '0, don't display'
-        if (value == 0xA) value = 0;
-        score += mult * value;
-        mult *= 10;
-    }
-    score *= 100;
-    int reward = score - m_score;
-    m_reward = reward;
-    m_score = score;
+  // update terminal status
+  int lives_byte = readRam(&system, 0xC4) & 0x7;
+  int y_vel = readRam(&system, 0xB9);
+  int x_vel_death = readRam(&system, 0xBD);
 
-    // update terminal status
-    int lives_byte = readRam(&system, 0xC4) & 0x7;
-    int y_vel = readRam(&system, 0xB9);
-    int x_vel_death = readRam(&system, 0xBD);
+  m_terminal = (lives_byte == 0 && (y_vel != 0 || x_vel_death != 0));
 
-    m_terminal = (lives_byte == 0 && (y_vel != 0 || x_vel_death != 0));
-
-    m_lives = lives_byte + 1;
+  m_lives = lives_byte + 1;
 }
-
 
 /* is end of game */
-bool RoadRunnerSettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool RoadRunnerSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t RoadRunnerSettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t RoadRunnerSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool RoadRunnerSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_UP:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_DOWN:
-        case PLAYER_A_UPRIGHT:
-        case PLAYER_A_UPLEFT:
-        case PLAYER_A_DOWNRIGHT:
-        case PLAYER_A_DOWNLEFT:
-        case PLAYER_A_UPFIRE:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_LEFTFIRE:
-        case PLAYER_A_DOWNFIRE:
-        case PLAYER_A_UPRIGHTFIRE:
-        case PLAYER_A_UPLEFTFIRE:
-        case PLAYER_A_DOWNRIGHTFIRE:
-        case PLAYER_A_DOWNLEFTFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool RoadRunnerSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_UP:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_DOWN:
+    case PLAYER_A_UPRIGHT:
+    case PLAYER_A_UPLEFT:
+    case PLAYER_A_DOWNRIGHT:
+    case PLAYER_A_DOWNLEFT:
+    case PLAYER_A_UPFIRE:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_LEFTFIRE:
+    case PLAYER_A_DOWNFIRE:
+    case PLAYER_A_UPRIGHTFIRE:
+    case PLAYER_A_UPLEFTFIRE:
+    case PLAYER_A_DOWNRIGHTFIRE:
+    case PLAYER_A_DOWNLEFTFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void RoadRunnerSettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
-    m_lives    = 3;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
+  m_lives = 3;
 }
 
 /* saves the state of the rom settings */
-void RoadRunnerSettings::saveState(Serializer & ser) {
+void RoadRunnerSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
@@ -133,7 +114,7 @@ void RoadRunnerSettings::saveState(Serializer & ser) {
 }
 
 // loads the state of the rom settings
-void RoadRunnerSettings::loadState(Deserializer & ser) {
+void RoadRunnerSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();

--- a/src/games/supported/RoadRunner.hpp
+++ b/src/games/supported/RoadRunner.hpp
@@ -29,49 +29,45 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Road Runner */
 class RoadRunnerSettings : public RomSettings {
+ public:
+  RoadRunnerSettings();
 
-    public:
+  // reset
+  void reset();
 
-        RoadRunnerSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "road_runner"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // the rom-name
-        const char* rom() const { return "road_runner"; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
-
-        virtual int lives() { return isTerminal() ? 0 : m_lives; }
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 };
 
-#endif // __ROADRUNNER_HPP__
+#endif  // __ROADRUNNER_HPP__

--- a/src/games/supported/RoboTank.cpp
+++ b/src/games/supported/RoboTank.cpp
@@ -28,96 +28,76 @@
 
 #include "../RomUtils.hpp"
 
-
-RoboTankSettings::RoboTankSettings() {
-
-    reset();
-}
-
+RoboTankSettings::RoboTankSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* RoboTankSettings::clone() const {
-
-    RomSettings* rval = new RoboTankSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new RoboTankSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void RoboTankSettings::step(const System& system) {
+  // update the reward
+  int dead_squadrons = readRam(&system, 0xB6);
+  int dead_tanks = readRam(&system, 0xB5);
+  int score = dead_squadrons * 12 + dead_tanks;
+  int reward = score - m_score;
+  m_reward = reward;
+  m_score = score;
 
-    // update the reward
-    int dead_squadrons = readRam(&system, 0xB6);
-    int dead_tanks = readRam(&system, 0xB5);
-    int score = dead_squadrons * 12 + dead_tanks;
-    int reward = score - m_score;
-    m_reward = reward;
-    m_score = score;
+  // update terminal status
+  int termination_flag = readRam(&system, 0xB4);
+  int lives = readRam(&system, 0xA8);
+  m_terminal = lives == 0 && termination_flag == 0xFF;
 
-    // update terminal status
-    int termination_flag = readRam(&system, 0xB4);
-    int lives = readRam(&system, 0xA8);
-    m_terminal = lives == 0 && termination_flag == 0xFF;
-
-    m_lives = (lives & 0xF) + 1;
+  m_lives = (lives & 0xF) + 1;
 }
-
 
 /* is end of game */
-bool RoboTankSettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool RoboTankSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t RoboTankSettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t RoboTankSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool RoboTankSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_UP:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_DOWN:
-        case PLAYER_A_UPRIGHT:
-        case PLAYER_A_UPLEFT:
-        case PLAYER_A_DOWNRIGHT:
-        case PLAYER_A_DOWNLEFT:
-        case PLAYER_A_UPFIRE:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_LEFTFIRE:
-        case PLAYER_A_DOWNFIRE:
-        case PLAYER_A_UPRIGHTFIRE:
-        case PLAYER_A_UPLEFTFIRE:
-        case PLAYER_A_DOWNRIGHTFIRE:
-        case PLAYER_A_DOWNLEFTFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool RoboTankSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_UP:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_DOWN:
+    case PLAYER_A_UPRIGHT:
+    case PLAYER_A_UPLEFT:
+    case PLAYER_A_DOWNRIGHT:
+    case PLAYER_A_DOWNLEFT:
+    case PLAYER_A_UPFIRE:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_LEFTFIRE:
+    case PLAYER_A_DOWNFIRE:
+    case PLAYER_A_UPRIGHTFIRE:
+    case PLAYER_A_UPLEFTFIRE:
+    case PLAYER_A_DOWNRIGHTFIRE:
+    case PLAYER_A_DOWNLEFTFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void RoboTankSettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
-    m_lives    = 4;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
+  m_lives = 4;
 }
 
 /* saves the state of the rom settings */
-void RoboTankSettings::saveState(Serializer & ser) {
+void RoboTankSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
@@ -125,7 +105,7 @@ void RoboTankSettings::saveState(Serializer & ser) {
 }
 
 // loads the state of the rom settings
-void RoboTankSettings::loadState(Deserializer & ser) {
+void RoboTankSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();

--- a/src/games/supported/RoboTank.hpp
+++ b/src/games/supported/RoboTank.hpp
@@ -29,49 +29,45 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for RoboTank */
 class RoboTankSettings : public RomSettings {
+ public:
+  RoboTankSettings();
 
-    public:
+  // reset
+  void reset();
 
-        RoboTankSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "robotank"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // the rom-name
-        const char* rom() const { return "robotank"; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
-
-        virtual int lives() { return isTerminal() ? 0 : m_lives; }
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 };
 
-#endif // __ROBOTANK_HPP__
+#endif  // __ROBOTANK_HPP__

--- a/src/games/supported/Seaquest.cpp
+++ b/src/games/supported/Seaquest.cpp
@@ -28,91 +28,70 @@
 
 #include "../RomUtils.hpp"
 
-
-SeaquestSettings::SeaquestSettings() {
-
-    reset();
-}
-
+SeaquestSettings::SeaquestSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* SeaquestSettings::clone() const {
-
-    RomSettings* rval = new SeaquestSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new SeaquestSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void SeaquestSettings::step(const System& system) {
+  // update the reward
+  reward_t score = getDecimalScore(0xBA, 0xB9, 0xB8, &system);
+  m_reward = score - m_score;
+  m_score = score;
 
-    // update the reward
-    reward_t score = getDecimalScore(0xBA, 0xB9, 0xB8, &system);
-    m_reward = score - m_score;
-    m_score = score;
-
-    // update terminal status
-    m_terminal = readRam(&system, 0xA3) != 0;
-    m_lives = readRam(&system, 0xBB) + 1;
+  // update terminal status
+  m_terminal = readRam(&system, 0xA3) != 0;
+  m_lives = readRam(&system, 0xBB) + 1;
 }
-
 
 /* is end of game */
-bool SeaquestSettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool SeaquestSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t SeaquestSettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t SeaquestSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool SeaquestSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_UP:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_DOWN:
-        case PLAYER_A_UPRIGHT:
-        case PLAYER_A_UPLEFT:
-        case PLAYER_A_DOWNRIGHT:
-        case PLAYER_A_DOWNLEFT:
-        case PLAYER_A_UPFIRE:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_LEFTFIRE:
-        case PLAYER_A_DOWNFIRE:
-        case PLAYER_A_UPRIGHTFIRE:
-        case PLAYER_A_UPLEFTFIRE:
-        case PLAYER_A_DOWNRIGHTFIRE:
-        case PLAYER_A_DOWNLEFTFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool SeaquestSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_UP:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_DOWN:
+    case PLAYER_A_UPRIGHT:
+    case PLAYER_A_UPLEFT:
+    case PLAYER_A_DOWNRIGHT:
+    case PLAYER_A_DOWNLEFT:
+    case PLAYER_A_UPFIRE:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_LEFTFIRE:
+    case PLAYER_A_DOWNFIRE:
+    case PLAYER_A_UPRIGHTFIRE:
+    case PLAYER_A_UPLEFTFIRE:
+    case PLAYER_A_DOWNRIGHTFIRE:
+    case PLAYER_A_DOWNLEFTFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void SeaquestSettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
-    m_lives    = 4;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
+  m_lives = 4;
 }
 
-
 /* saves the state of the rom settings */
-void SeaquestSettings::saveState(Serializer & ser) {
+void SeaquestSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
@@ -120,7 +99,7 @@ void SeaquestSettings::saveState(Serializer & ser) {
 }
 
 // loads the state of the rom settings
-void SeaquestSettings::loadState(Deserializer & ser) {
+void SeaquestSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();
@@ -128,6 +107,6 @@ void SeaquestSettings::loadState(Deserializer & ser) {
 }
 
 DifficultyVect SeaquestSettings::getAvailableDifficulties() {
-    DifficultyVect diff = {0, 1};
-    return diff;
+  DifficultyVect diff = {0, 1};
+  return diff;
 }

--- a/src/games/supported/Seaquest.hpp
+++ b/src/games/supported/Seaquest.hpp
@@ -29,53 +29,49 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Seaquest */
 class SeaquestSettings : public RomSettings {
+ public:
+  SeaquestSettings();
 
-    public:
+  // reset
+  void reset();
 
-        SeaquestSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "seaquest"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // the rom-name
-        const char* rom() const { return "seaquest"; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  // returns a list of difficulties that the game can be played in
+  // in this game, there are 2 available difficulties
+  DifficultyVect getAvailableDifficulties();
 
-        virtual int lives() { return isTerminal() ? 0 : m_lives; }
-
-        // returns a list of difficulties that the game can be played in
-        // in this game, there are 2 available difficulties
-        DifficultyVect getAvailableDifficulties();
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 };
 
-#endif // __SEAQUEST_HPP__
+#endif  // __SEAQUEST_HPP__

--- a/src/games/supported/SirLancelot.cpp
+++ b/src/games/supported/SirLancelot.cpp
@@ -13,72 +13,59 @@
 
 #include "../RomUtils.hpp"
 
-
-SirLancelotSettings::SirLancelotSettings() {
-    reset();
-}
-
+SirLancelotSettings::SirLancelotSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* SirLancelotSettings::clone() const {
-    RomSettings* rval = new SirLancelotSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new SirLancelotSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void SirLancelotSettings::step(const System& system) {
-    // update the reward
-    int score = getDecimalScore(0xA0, 0x9F, 0x9E, &system);
-    int reward = score - m_score;
-    m_reward = reward;
-    m_score = score;
+  // update the reward
+  int score = getDecimalScore(0xA0, 0x9F, 0x9E, &system);
+  int reward = score - m_score;
+  m_reward = reward;
+  m_score = score;
 
-    // update terminal status
-	m_lives = readRam(&system, 0xA9);
-    m_terminal = (m_lives == 0) && readRam(&system, 0xA7) == 0xA0;
+  // update terminal status
+  m_lives = readRam(&system, 0xA9);
+  m_terminal = (m_lives == 0) && readRam(&system, 0xA7) == 0xA0;
 }
-
 
 /* is end of game */
-bool SirLancelotSettings::isTerminal() const {
-    return m_terminal;
-};
-
+bool SirLancelotSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t SirLancelotSettings::getReward() const {
-    return m_reward;
-}
-
+reward_t SirLancelotSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool SirLancelotSettings::isMinimal(const Action &a) const {
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_LEFTFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool SirLancelotSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_LEFTFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void SirLancelotSettings::reset() {
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
-    m_lives    = 3;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
+  m_lives = 3;
 }
 
 /* saves the state of the rom settings */
-void SirLancelotSettings::saveState(Serializer & ser) {
+void SirLancelotSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
@@ -86,7 +73,7 @@ void SirLancelotSettings::saveState(Serializer & ser) {
 }
 
 // loads the state of the rom settings
-void SirLancelotSettings::loadState(Deserializer & ser) {
+void SirLancelotSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();
@@ -94,8 +81,8 @@ void SirLancelotSettings::loadState(Deserializer & ser) {
 }
 
 ActionVect SirLancelotSettings::getStartingActions() {
-    ActionVect startingActions;
-    startingActions.push_back(RESET);
-    startingActions.push_back(PLAYER_A_LEFT);
-    return startingActions;
+  ActionVect startingActions;
+  startingActions.push_back(RESET);
+  startingActions.push_back(PLAYER_A_LEFT);
+  return startingActions;
 }

--- a/src/games/supported/SirLancelot.hpp
+++ b/src/games/supported/SirLancelot.hpp
@@ -14,50 +14,49 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Up N Down */
 class SirLancelotSettings : public RomSettings {
-    public:
-        SirLancelotSettings();
+ public:
+  SirLancelotSettings();
 
-        // reset
-        void reset();
+  // reset
+  void reset();
 
-        // is end of game
-        bool isTerminal() const;
+  // is end of game
+  bool isTerminal() const;
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // the rom-name
-		// MD5 7ead257e8b5a44cac538f5f54c7a0023
-        const char* rom() const { return "sir_lancelot"; }
+  // the rom-name
+  // MD5 7ead257e8b5a44cac538f5f54c7a0023
+  const char* rom() const { return "sir_lancelot"; }
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // SirLancelot requires the reset+left action to start the game
-        ActionVect getStartingActions();
+  // SirLancelot requires the reset+left action to start the game
+  ActionVect getStartingActions();
 
-        virtual int lives() { return isTerminal() ? 0 : m_lives; }
+  virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
-    private:
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 };
 
-#endif // __SIRLANCELOT_HPP__
+#endif  // __SIRLANCELOT_HPP__

--- a/src/games/supported/Skiing.cpp
+++ b/src/games/supported/Skiing.cpp
@@ -13,67 +13,49 @@
 
 #include "../RomUtils.hpp"
 
-
-SkiingSettings::SkiingSettings() {
-
-    reset();
-}
-
+SkiingSettings::SkiingSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* SkiingSettings::clone() const {
-
-    RomSettings* rval = new SkiingSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new SkiingSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void SkiingSettings::step(const System& system) {
+  // update the reward
+  int centiseconds = getDecimalScore(0xEA, 0xE9, &system);
+  int minutes = readRam(&system, 0xE8);
+  int score = minutes * 6000 + centiseconds;
+  int reward = m_score - score; // negative reward for time
+  m_reward = reward;
+  m_score = score;
 
-    // update the reward
-    int centiseconds = getDecimalScore(0xEA, 0xE9, &system);
-    int minutes = readRam(&system, 0xE8);
-    int score = minutes * 6000 + centiseconds;
-    int reward = m_score - score; // negative reward for time
-    m_reward = reward;
-    m_score = score;
-
-    // update terminal status
-    int end_flag = readRam(&system, 0x91);
-    m_terminal = end_flag == 0xFF;
+  // update terminal status
+  int end_flag = readRam(&system, 0x91);
+  m_terminal = end_flag == 0xFF;
 }
-
 
 /* is end of game */
-bool SkiingSettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool SkiingSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t SkiingSettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t SkiingSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool SkiingSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-            return true;
-        default:
-            return false;
-    }
+bool SkiingSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+      return true;
+    default:
+      return false;
+  }
 }
 
-bool SkiingSettings::isLegal(const Action &a) const {
+bool SkiingSettings::isLegal(const Action& a) const {
   switch (a) {
     // Don't allow pressing 'fire'
     case PLAYER_A_FIRE:
@@ -93,29 +75,28 @@ bool SkiingSettings::isLegal(const Action &a) const {
 
 /* reset the state of the game */
 void SkiingSettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
 }
 
 /* saves the state of the rom settings */
-void SkiingSettings::saveState(Serializer & ser) {
+void SkiingSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
 }
 
 // loads the state of the rom settings
-void SkiingSettings::loadState(Deserializer & ser) {
+void SkiingSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();
 }
 
 ActionVect SkiingSettings::getStartingActions() {
-    ActionVect startingActions;
-    for (int i=0; i<16; i++)
-        startingActions.push_back(PLAYER_A_DOWN);
-    return startingActions;
+  ActionVect startingActions;
+  for (int i = 0; i < 16; i++)
+    startingActions.push_back(PLAYER_A_DOWN);
+  return startingActions;
 }

--- a/src/games/supported/Skiing.hpp
+++ b/src/games/supported/Skiing.hpp
@@ -29,52 +29,48 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Skiing */
 class SkiingSettings : public RomSettings {
+ public:
+  SkiingSettings();
 
-    public:
+  // reset
+  void reset();
 
-        SkiingSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "skiing"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // the rom-name
-        const char* rom() const { return "skiing"; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  bool isLegal(const Action& a) const;
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        bool isLegal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  ActionVect getStartingActions();
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  virtual int lives() { return 0; }
 
-        ActionVect getStartingActions();
-
-        virtual int lives() { return 0; }
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
 };
 
-#endif // __SKIING_HPP__
+#endif  // __SKIING_HPP__

--- a/src/games/supported/Solaris.cpp
+++ b/src/games/supported/Solaris.cpp
@@ -28,96 +28,75 @@
 
 #include "../RomUtils.hpp"
 
-
-SolarisSettings::SolarisSettings() {
-
-    reset();
-}
-
+SolarisSettings::SolarisSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* SolarisSettings::clone() const {
-
-    RomSettings* rval = new SolarisSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new SolarisSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void SolarisSettings::step(const System& system) {
+  // update the reward
+  // only 5 digits are displayed but we keep track of 6 digits
+  int score = getDecimalScore(0xDC, 0xDD, 0xDE, &system);
+  score *= 10;
+  int reward = score - m_score;
+  m_reward = reward;
+  m_score = score;
 
-    // update the reward
-    // only 5 digits are displayed but we keep track of 6 digits
-    int score = getDecimalScore(0xDC, 0xDD, 0xDE, &system);
-    score *= 10;
-    int reward = score - m_score;
-    m_reward = reward;
-    m_score = score;
+  // update terminal status
+  int lives_byte = readRam(&system, 0xD9);
+  m_terminal = lives_byte == 0;
 
-    // update terminal status
-    int lives_byte = readRam(&system, 0xD9);
-    m_terminal = lives_byte == 0;
-
-    m_lives = lives_byte & 0xF;
-
+  m_lives = lives_byte & 0xF;
 }
-
 
 /* is end of game */
-bool SolarisSettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool SolarisSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t SolarisSettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t SolarisSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool SolarisSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_UP:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_DOWN:
-        case PLAYER_A_UPRIGHT:
-        case PLAYER_A_UPLEFT:
-        case PLAYER_A_DOWNRIGHT:
-        case PLAYER_A_DOWNLEFT:
-        case PLAYER_A_UPFIRE:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_LEFTFIRE:
-        case PLAYER_A_DOWNFIRE:
-        case PLAYER_A_UPRIGHTFIRE:
-        case PLAYER_A_UPLEFTFIRE:
-        case PLAYER_A_DOWNRIGHTFIRE:
-        case PLAYER_A_DOWNLEFTFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool SolarisSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_UP:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_DOWN:
+    case PLAYER_A_UPRIGHT:
+    case PLAYER_A_UPLEFT:
+    case PLAYER_A_DOWNRIGHT:
+    case PLAYER_A_DOWNLEFT:
+    case PLAYER_A_UPFIRE:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_LEFTFIRE:
+    case PLAYER_A_DOWNFIRE:
+    case PLAYER_A_UPRIGHTFIRE:
+    case PLAYER_A_UPLEFTFIRE:
+    case PLAYER_A_DOWNRIGHTFIRE:
+    case PLAYER_A_DOWNLEFTFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void SolarisSettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
-    m_lives    = 3;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
+  m_lives = 3;
 }
 
 /* saves the state of the rom settings */
-void SolarisSettings::saveState(Serializer & ser) {
+void SolarisSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
@@ -125,7 +104,7 @@ void SolarisSettings::saveState(Serializer & ser) {
 }
 
 // loads the state of the rom settings
-void SolarisSettings::loadState(Deserializer & ser) {
+void SolarisSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();

--- a/src/games/supported/Solaris.hpp
+++ b/src/games/supported/Solaris.hpp
@@ -29,49 +29,45 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Solaris */
 class SolarisSettings : public RomSettings {
+ public:
+  SolarisSettings();
 
-    public:
+  // reset
+  void reset();
 
-        SolarisSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "solaris"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // the rom-name
-        const char* rom() const { return "solaris"; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
-
-        virtual int lives() { return isTerminal() ? 0 : m_lives; }
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 };
 
-#endif // __SOLARIS_HPP__
+#endif  // __SOLARIS_HPP__

--- a/src/games/supported/SpaceInvaders.cpp
+++ b/src/games/supported/SpaceInvaders.cpp
@@ -30,86 +30,67 @@
 
 ActionVect SpaceInvadersSettings::actions;
 
-SpaceInvadersSettings::SpaceInvadersSettings() {
-    reset();
-}
-
+SpaceInvadersSettings::SpaceInvadersSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* SpaceInvadersSettings::clone() const {
-
-    RomSettings* rval = new SpaceInvadersSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new SpaceInvadersSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void SpaceInvadersSettings::step(const System& system) {
+  // update the reward
+  int score = getDecimalScore(0xE8, 0xE6, &system);
+  // reward cannot get negative in this game. When it does, it means that the score has looped
+  // (overflow)
+  m_reward = score - m_score;
+  if (m_reward < 0) {
+    // 10000 is the highest possible score
+    const int maximumScore = 10000;
+    m_reward = (maximumScore - m_score) + score;
+  }
+  m_score = score;
+  m_lives = readRam(&system, 0xC9);
 
-    // update the reward
-    int score = getDecimalScore(0xE8, 0xE6, &system);
-    // reward cannot get negative in this game. When it does, it means that the score has looped
-    // (overflow)
-    m_reward = score - m_score;
-    if(m_reward < 0) {
-        // 10000 is the highest possible score
-        const int maximumScore = 10000;
-        m_reward = (maximumScore - m_score) + score;
-    }
-    m_score = score;
-    m_lives = readRam(&system, 0xC9);
-
-    // update terminal status
-    // If bit 0x80 is on, then game is over
-    int some_byte = readRam(&system, 0x98);
-    m_terminal = (some_byte & 0x80) || m_lives == 0;
+  // update terminal status
+  // If bit 0x80 is on, then game is over
+  int some_byte = readRam(&system, 0x98);
+  m_terminal = (some_byte & 0x80) || m_lives == 0;
 }
-
 
 /* is end of game */
-bool SpaceInvadersSettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool SpaceInvadersSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t SpaceInvadersSettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t SpaceInvadersSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool SpaceInvadersSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_LEFTFIRE:
-        case PLAYER_A_RIGHTFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool SpaceInvadersSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_LEFTFIRE:
+    case PLAYER_A_RIGHTFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void SpaceInvadersSettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
-    m_lives    = 3;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
+  m_lives = 3;
 }
 
-
 /* saves the state of the rom settings */
-void SpaceInvadersSettings::saveState(Serializer & ser) {
+void SpaceInvadersSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
@@ -117,7 +98,7 @@ void SpaceInvadersSettings::saveState(Serializer & ser) {
 }
 
 // loads the state of the rom settings
-void SpaceInvadersSettings::loadState(Deserializer & ser) {
+void SpaceInvadersSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();
@@ -126,35 +107,34 @@ void SpaceInvadersSettings::loadState(Deserializer & ser) {
 
 // returns a list of mode that the game can be played in
 ModeVect SpaceInvadersSettings::getAvailableModes() {
-    ModeVect modes(getNumModes());
-    for (unsigned int i = 0; i < modes.size(); i++) {
-        modes[i] = i;
-    }
-    return modes;
+  ModeVect modes(getNumModes());
+  for (unsigned int i = 0; i < modes.size(); i++) {
+    modes[i] = i;
+  }
+  return modes;
 }
 
 // set the mode of the game
 // the given mode must be one returned by the previous function
-void SpaceInvadersSettings::setMode(game_mode_t m, System &system,
-                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
-
-    if(m < getNumModes()) {
-        // read the mode we are currently in
-        unsigned char mode = readRam(&system, 0xDC);
-        // press select until the correct mode is reached
-        while (mode != m) {
-            environment->pressSelect(2);
-            mode = readRam(&system, 0xDC);
-        }
-        //reset the environment to apply changes.
-        environment->softReset();
+void SpaceInvadersSettings::setMode(
+    game_mode_t m, System& system,
+    std::unique_ptr<StellaEnvironmentWrapper> environment) {
+  if (m < getNumModes()) {
+    // read the mode we are currently in
+    unsigned char mode = readRam(&system, 0xDC);
+    // press select until the correct mode is reached
+    while (mode != m) {
+      environment->pressSelect(2);
+      mode = readRam(&system, 0xDC);
     }
-    else {
-        throw std::runtime_error("This mode doesn't currently exist for this game");
-    }
- }
+    //reset the environment to apply changes.
+    environment->softReset();
+  } else {
+    throw std::runtime_error("This mode doesn't currently exist for this game");
+  }
+}
 
 DifficultyVect SpaceInvadersSettings::getAvailableDifficulties() {
-    DifficultyVect diff = {0, 1};
-    return diff;
+  DifficultyVect diff = {0, 1};
+  return diff;
 }

--- a/src/games/supported/SpaceInvaders.hpp
+++ b/src/games/supported/SpaceInvaders.hpp
@@ -29,68 +29,63 @@
 
 #include "../RomSettings.hpp"
 
-
 // RL wrapper for SpaceInvaders
 class SpaceInvadersSettings : public RomSettings {
+ public:
+  SpaceInvadersSettings();
 
-    public:
+  // reset
+  void reset();
 
-        SpaceInvadersSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "space_invaders"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // get the available number of modes
+  unsigned int getNumModes() const { return 16; }
 
-        // the rom-name
-        const char* rom() const { return "space_invaders"; }
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // get the available number of modes
-        unsigned int getNumModes() const { return 16; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  // returns a list of mode that the game can be played in
+  // in this game, there are 16 available modes
+  ModeVect getAvailableModes();
 
-        virtual int lives() { return isTerminal() ? 0 : m_lives; }
+  // set the mode of the game
+  // the given mode must be one returned by the previous function
+  void setMode(game_mode_t, System& system,
+               std::unique_ptr<StellaEnvironmentWrapper> environment);
 
-        // returns a list of mode that the game can be played in
-        // in this game, there are 16 available modes
-        ModeVect getAvailableModes();
+  // returns a list of difficulties that the game can be played in
+  // in this game, there are 2 available difficulties
+  DifficultyVect getAvailableDifficulties();
 
-        // set the mode of the game
-        // the given mode must be one returned by the previous function
-        void setMode(game_mode_t, System &system,
-                     std::unique_ptr<StellaEnvironmentWrapper> environment);
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 
-        // returns a list of difficulties that the game can be played in
-        // in this game, there are 2 available difficulties
-        DifficultyVect getAvailableDifficulties();
-
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
-
-        static ActionVect actions;
+  static ActionVect actions;
 };
 
-#endif // __SPACEINVADERS_HPP__
+#endif  // __SPACEINVADERS_HPP__

--- a/src/games/supported/StarGunner.hpp
+++ b/src/games/supported/StarGunner.hpp
@@ -29,62 +29,58 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Star Gunner */
 class StarGunnerSettings : public RomSettings {
+ public:
+  StarGunnerSettings();
 
-    public:
+  // reset
+  void reset();
 
-        StarGunnerSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "star_gunner"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // get the available number of modes
+  unsigned int getNumModes() const { return 4; }
 
-        // the rom-name
-        const char* rom() const { return "star_gunner"; }
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // get the available number of modes
-        unsigned int getNumModes() const { return 4; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  // returns a list of mode that the game can be played in
+  // in this game, there are 4 available modes
+  ModeVect getAvailableModes();
 
-        virtual int lives() { return isTerminal() ? 0 : m_lives; }
+  // set the mode of the game
+  // the given mode must be one returned by the previous function
+  void setMode(game_mode_t, System& system,
+               std::unique_ptr<StellaEnvironmentWrapper> environment);
 
-        // returns a list of mode that the game can be played in
-        // in this game, there are 4 available modes
-        ModeVect getAvailableModes();
-
-        // set the mode of the game
-        // the given mode must be one returned by the previous function
-        void setMode(game_mode_t, System &system,
-                     std::unique_ptr<StellaEnvironmentWrapper> environment);
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
-        bool m_game_started;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
+  bool m_game_started;
 };
 
-#endif // __STARGUNNER_HPP__
+#endif  // __STARGUNNER_HPP__

--- a/src/games/supported/Tennis.cpp
+++ b/src/games/supported/Tennis.cpp
@@ -13,106 +13,86 @@
 
 #include "../RomUtils.hpp"
 
-
-TennisSettings::TennisSettings() {
-
-    reset();
-}
-
+TennisSettings::TennisSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* TennisSettings::clone() const {
-
-    RomSettings* rval = new TennisSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new TennisSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void TennisSettings::step(const System& system) {
+  // update the reward
+  int my_score = readRam(&system, 0xC5);
+  int oppt_score = readRam(&system, 0xC6);
+  int my_points = readRam(&system, 0xC7);
+  int oppt_points = readRam(&system, 0xC8);
+  int delta_score = my_score - oppt_score;
+  int delta_points = my_points - oppt_points;
 
-    // update the reward
-    int my_score     = readRam(&system, 0xC5);
-    int oppt_score   = readRam(&system, 0xC6);
-    int my_points    = readRam(&system, 0xC7);
-    int oppt_points  = readRam(&system, 0xC8);
-    int delta_score  = my_score - oppt_score;
-    int delta_points = my_points - oppt_points;
+  // a reward for the game
+  if (m_prev_delta_points != delta_points)
+    m_reward = delta_points - m_prev_delta_points;
+  // a reward for each point
+  else if (m_prev_delta_score != delta_score)
+    m_reward = delta_score - m_prev_delta_score;
+  else
+    m_reward = 0;
 
-    // a reward for the game
-    if (m_prev_delta_points != delta_points)
-        m_reward = delta_points - m_prev_delta_points;
-    // a reward for each point
-    else if (m_prev_delta_score != delta_score)
-        m_reward = delta_score - m_prev_delta_score;
-    else
-      m_reward = 0;
+  m_prev_delta_points = delta_points;
+  m_prev_delta_score = delta_score;
 
-    m_prev_delta_points = delta_points;
-    m_prev_delta_score = delta_score;
-
-    // update terminal status
-    m_terminal = (my_points >= 6 && delta_points >= 2)    ||
-                 (oppt_points >= 6 && -delta_points >= 2) ||
-                 (my_points == 7 || oppt_points == 7);
+  // update terminal status
+  m_terminal = (my_points >= 6 && delta_points >= 2) ||
+               (oppt_points >= 6 && -delta_points >= 2) ||
+               (my_points == 7 || oppt_points == 7);
 }
-
 
 /* is end of game */
-bool TennisSettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool TennisSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t TennisSettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t TennisSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool TennisSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_UP:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_DOWN:
-        case PLAYER_A_UPRIGHT:
-        case PLAYER_A_UPLEFT:
-        case PLAYER_A_DOWNRIGHT:
-        case PLAYER_A_DOWNLEFT:
-        case PLAYER_A_UPFIRE:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_LEFTFIRE:
-        case PLAYER_A_DOWNFIRE:
-        case PLAYER_A_UPRIGHTFIRE:
-        case PLAYER_A_UPLEFTFIRE:
-        case PLAYER_A_DOWNRIGHTFIRE:
-        case PLAYER_A_DOWNLEFTFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool TennisSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_UP:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_DOWN:
+    case PLAYER_A_UPRIGHT:
+    case PLAYER_A_UPLEFT:
+    case PLAYER_A_DOWNRIGHT:
+    case PLAYER_A_DOWNLEFT:
+    case PLAYER_A_UPFIRE:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_LEFTFIRE:
+    case PLAYER_A_DOWNFIRE:
+    case PLAYER_A_UPRIGHTFIRE:
+    case PLAYER_A_UPLEFTFIRE:
+    case PLAYER_A_DOWNRIGHTFIRE:
+    case PLAYER_A_DOWNLEFTFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void TennisSettings::reset() {
-
-    m_reward               = 0;
-    m_prev_delta_points    = 0;
-    m_prev_delta_score     = 0;
-    m_terminal             = false;
+  m_reward = 0;
+  m_prev_delta_points = 0;
+  m_prev_delta_score = 0;
+  m_terminal = false;
 }
 
 /* saves the state of the rom settings */
-void TennisSettings::saveState(Serializer & ser) {
+void TennisSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putBool(m_terminal);
 
@@ -121,7 +101,7 @@ void TennisSettings::saveState(Serializer & ser) {
 }
 
 // loads the state of the rom settings
-void TennisSettings::loadState(Deserializer & ser) {
+void TennisSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_terminal = ser.getBool();
 
@@ -131,32 +111,31 @@ void TennisSettings::loadState(Deserializer & ser) {
 
 // returns a list of mode that the game can be played in
 ModeVect TennisSettings::getAvailableModes() {
-    ModeVect modes = {0, 2};
-    return modes;
+  ModeVect modes = {0, 2};
+  return modes;
 }
 
 // set the mode of the game
 // the given mode must be one returned by the previous function
-void TennisSettings::setMode(game_mode_t m, System &system,
-                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
-
-    if(m == 0 || m == 2) {
-        // read the mode we are currently in
-        unsigned char mode = readRam(&system, 0x80);
-        // press select until the correct mode is reached
-        while (mode != m) {
-            environment->pressSelect(2);
-            mode = readRam(&system, 0x80);
-        }
-        //reset the environment to apply changes.
-        environment->softReset();
+void TennisSettings::setMode(
+    game_mode_t m, System& system,
+    std::unique_ptr<StellaEnvironmentWrapper> environment) {
+  if (m == 0 || m == 2) {
+    // read the mode we are currently in
+    unsigned char mode = readRam(&system, 0x80);
+    // press select until the correct mode is reached
+    while (mode != m) {
+      environment->pressSelect(2);
+      mode = readRam(&system, 0x80);
     }
-    else {
-        throw std::runtime_error("This mode doesn't currently exist for this game");
-    }
- }
+    //reset the environment to apply changes.
+    environment->softReset();
+  } else {
+    throw std::runtime_error("This mode doesn't currently exist for this game");
+  }
+}
 
 DifficultyVect TennisSettings::getAvailableDifficulties() {
-    DifficultyVect diff = {0, 1, 2, 3};
-    return diff;
+  DifficultyVect diff = {0, 1, 2, 3};
+  return diff;
 }

--- a/src/games/supported/Tennis.hpp
+++ b/src/games/supported/Tennis.hpp
@@ -29,65 +29,61 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Tennis */
 class TennisSettings : public RomSettings {
+ public:
+  TennisSettings();
 
-    public:
+  // reset
+  void reset();
 
-        TennisSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "tennis"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // get the available number of modes
+  unsigned int getNumModes() const { return 2; }
 
-        // the rom-name
-        const char* rom() const { return "tennis"; }
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // get the available number of modes
-        unsigned int getNumModes() const { return 2; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  virtual int lives() { return 0; }
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  // returns a list of mode that the game can be played in
+  // in this game, there are 2 available modes
+  ModeVect getAvailableModes();
 
-        virtual int lives() { return 0; }
+  // set the mode of the game
+  // the given mode must be one returned by the previous function
+  void setMode(game_mode_t, System& system,
+               std::unique_ptr<StellaEnvironmentWrapper> environment);
 
-        // returns a list of mode that the game can be played in
-        // in this game, there are 2 available modes
-        ModeVect getAvailableModes();
+  // returns a list of difficulties that the game can be played in
+  // in this game, there are 4 available difficulties
+  DifficultyVect getAvailableDifficulties();
 
-        // set the mode of the game
-        // the given mode must be one returned by the previous function
-        void setMode(game_mode_t, System &system,
-                     std::unique_ptr<StellaEnvironmentWrapper> environment);
-
-        // returns a list of difficulties that the game can be played in
-        // in this game, there are 4 available difficulties
-        DifficultyVect getAvailableDifficulties();
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        int m_prev_delta_points;
-        int m_prev_delta_score;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  int m_prev_delta_points;
+  int m_prev_delta_score;
 };
 
-#endif // __TENNIS_HPP__
+#endif  // __TENNIS_HPP__

--- a/src/games/supported/Tetris.hpp
+++ b/src/games/supported/Tetris.hpp
@@ -27,51 +27,47 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Tetris */
 class TetrisSettings : public RomSettings {
+ public:
+  TetrisSettings();
 
-    public:
+  // reset
+  void reset();
 
-        TetrisSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "tetris"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // the rom-name
-        const char* rom() const { return "tetris"; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  // remaining lives
+  int lives() { return isTerminal() ? 0 : m_lives; }
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
-
-        // remaining lives
-        int lives() { return isTerminal() ? 0 : m_lives; }
-
-    private:
-
-        bool m_terminal;
-        bool m_started;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
+ private:
+  bool m_terminal;
+  bool m_started;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 };
 
-#endif // __TETRIS_HPP__
+#endif  // __TETRIS_HPP__

--- a/src/games/supported/TimePilot.cpp
+++ b/src/games/supported/TimePilot.cpp
@@ -28,89 +28,69 @@
 
 #include "../RomUtils.hpp"
 
-
-TimePilotSettings::TimePilotSettings() {
-
-    reset();
-}
-
+TimePilotSettings::TimePilotSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* TimePilotSettings::clone() const {
-
-    RomSettings* rval = new TimePilotSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new TimePilotSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void TimePilotSettings::step(const System& system) {
+  // update the reward
+  int score = getDecimalScore(0x8D, 0x8F, &system);
+  score *= 100;
+  int reward = score - m_score;
+  m_reward = reward;
+  m_score = score;
 
-    // update the reward
-    int score = getDecimalScore(0x8D, 0x8F, &system);
-    score *= 100;
-    int reward = score - m_score;
-    m_reward = reward;
-    m_score = score;
+  int lives_byte = readRam(&system, 0x8B) & 0x7;
 
-    int lives_byte = readRam(&system, 0x8B) & 0x7;
+  int screen_byte = readRam(&system, 0x80) & 0xF;
 
-    int screen_byte = readRam(&system, 0x80) & 0xF;
-
-    // update terminal status
-    m_terminal = readRam(&system, 0xA0);
-    // Only update lives when actually flying; otherwise funny stuff happens
-    m_lives = (screen_byte == 2) ? (lives_byte + 1) : m_lives;
+  // update terminal status
+  m_terminal = readRam(&system, 0xA0);
+  // Only update lives when actually flying; otherwise funny stuff happens
+  m_lives = (screen_byte == 2) ? (lives_byte + 1) : m_lives;
 }
-
 
 /* is end of game */
-bool TimePilotSettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool TimePilotSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t TimePilotSettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t TimePilotSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool TimePilotSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_UP:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_DOWN:
-        case PLAYER_A_UPFIRE:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_LEFTFIRE:
-        case PLAYER_A_DOWNFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool TimePilotSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_UP:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_DOWN:
+    case PLAYER_A_UPFIRE:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_LEFTFIRE:
+    case PLAYER_A_DOWNFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void TimePilotSettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
-    m_lives    = 5;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
+  m_lives = 5;
 }
 
 /* saves the state of the rom settings */
-void TimePilotSettings::saveState(Serializer & ser) {
+void TimePilotSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
@@ -118,15 +98,14 @@ void TimePilotSettings::saveState(Serializer & ser) {
 }
 
 // loads the state of the rom settings
-void TimePilotSettings::loadState(Deserializer & ser) {
+void TimePilotSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();
   m_lives = ser.getInt();
 }
 
-
 DifficultyVect TimePilotSettings::getAvailableDifficulties() {
-    DifficultyVect diff = {0, 1, 2};
-    return diff;
+  DifficultyVect diff = {0, 1, 2};
+  return diff;
 }

--- a/src/games/supported/TimePilot.hpp
+++ b/src/games/supported/TimePilot.hpp
@@ -29,53 +29,49 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Time Pilot */
 class TimePilotSettings : public RomSettings {
+ public:
+  TimePilotSettings();
 
-    public:
+  // reset
+  void reset();
 
-        TimePilotSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "time_pilot"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // the rom-name
-        const char* rom() const { return "time_pilot"; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  // returns a list of difficulties that the game can be played in
+  // in this game, there are 3 available difficulties
+  DifficultyVect getAvailableDifficulties();
 
-        virtual int lives() { return isTerminal() ? 0 : m_lives; }
-
-        // returns a list of difficulties that the game can be played in
-        // in this game, there are 3 available difficulties
-        DifficultyVect getAvailableDifficulties();
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 };
 
-#endif // __TIMEPILOT_HPP__
+#endif  // __TIMEPILOT_HPP__

--- a/src/games/supported/Trondead.cpp
+++ b/src/games/supported/Trondead.cpp
@@ -13,92 +13,72 @@
 
 #include "../RomUtils.hpp"
 
-
-TrondeadSettings::TrondeadSettings() {
-
-    reset();
-}
-
+TrondeadSettings::TrondeadSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* TrondeadSettings::clone() const {
-
-    RomSettings* rval = new TrondeadSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new TrondeadSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void TrondeadSettings::step(const System& system) {
+  // update the reward
+  int score = getDecimalScore(0xBF, 0xBE, 0xBD, &system);
+  int reward = score - m_score;
+  m_reward = reward;
+  m_score = score;
 
-    // update the reward
-    int score = getDecimalScore(0xBF, 0xBE, 0xBD, &system);
-    int reward = score - m_score;
-    m_reward = reward;
-    m_score = score;
-
-    // update terminal status
-    int hit_count = readRam(&system, 0xC8);
-    m_terminal = (hit_count == 5);	// Five times hit
-    m_lives = 5 - hit_count;
+  // update terminal status
+  int hit_count = readRam(&system, 0xC8);
+  m_terminal = (hit_count == 5); // Five times hit
+  m_lives = 5 - hit_count;
 }
-
 
 /* is end of game */
-bool TrondeadSettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool TrondeadSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t TrondeadSettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t TrondeadSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool TrondeadSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_UP:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_DOWN:
-        case PLAYER_A_UPRIGHT:
-        case PLAYER_A_UPLEFT:
-        case PLAYER_A_DOWNRIGHT:
-        case PLAYER_A_DOWNLEFT:
-        case PLAYER_A_UPFIRE:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_LEFTFIRE:
-        case PLAYER_A_DOWNFIRE:
-        case PLAYER_A_UPRIGHTFIRE:
-        case PLAYER_A_UPLEFTFIRE:
-        case PLAYER_A_DOWNRIGHTFIRE:
-        case PLAYER_A_DOWNLEFTFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool TrondeadSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_UP:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_DOWN:
+    case PLAYER_A_UPRIGHT:
+    case PLAYER_A_UPLEFT:
+    case PLAYER_A_DOWNRIGHT:
+    case PLAYER_A_DOWNLEFT:
+    case PLAYER_A_UPFIRE:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_LEFTFIRE:
+    case PLAYER_A_DOWNFIRE:
+    case PLAYER_A_UPRIGHTFIRE:
+    case PLAYER_A_UPLEFTFIRE:
+    case PLAYER_A_DOWNRIGHTFIRE:
+    case PLAYER_A_DOWNLEFTFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void TrondeadSettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
-    m_lives    = 5;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
+  m_lives = 5;
 }
 
 /* saves the state of the rom settings */
-void TrondeadSettings::saveState(Serializer & ser) {
+void TrondeadSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
@@ -106,7 +86,7 @@ void TrondeadSettings::saveState(Serializer & ser) {
 }
 
 // loads the state of the rom settings
-void TrondeadSettings::loadState(Deserializer & ser) {
+void TrondeadSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();

--- a/src/games/supported/Trondead.hpp
+++ b/src/games/supported/Trondead.hpp
@@ -14,49 +14,45 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Trondead */
 class TrondeadSettings : public RomSettings {
+ public:
+  TrondeadSettings();
 
-    public:
+  // reset
+  void reset();
 
-        TrondeadSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "trondead"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // the rom-name
-        const char* rom() const { return "trondead"; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
-
-        virtual int lives() { return isTerminal() ? 0 : m_lives; }
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 };
 
-#endif // __TRONDEAD_HPP__
+#endif  // __TRONDEAD_HPP__

--- a/src/games/supported/Turmoil.cpp
+++ b/src/games/supported/Turmoil.cpp
@@ -13,89 +13,69 @@
 
 #include "../RomUtils.hpp"
 
-
-TurmoilSettings::TurmoilSettings() {
-
-    reset();
-}
-
+TurmoilSettings::TurmoilSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* TurmoilSettings::clone() const {
-
-    RomSettings* rval = new TurmoilSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new TurmoilSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void TurmoilSettings::step(const System& system) {
+  // update the reward
+  int score = getDecimalScore(0x89, 0x8A, &system);
+  score += readRam(&system, 0xD3);
+  score *= 10;
+  int reward = score - m_score;
+  m_reward = reward;
+  m_score = score;
 
-    // update the reward
-    int score = getDecimalScore(0x89, 0x8A, &system);
-	score += readRam(&system, 0xD3);
-    score *= 10;
-    int reward = score - m_score;
-    m_reward = reward;
-    m_score = score;
+  // update terminal status
+  int lives_byte = readRam(&system, 0xB9);
+  m_terminal = (lives_byte == 0) && readRam(&system, 0xC5) == 0x01;
 
-    // update terminal status
-    int lives_byte = readRam(&system, 0xB9);
-    m_terminal = (lives_byte == 0) && readRam(&system, 0xC5) == 0x01;
-
-    m_lives = lives_byte;
+  m_lives = lives_byte;
 }
-
 
 /* is end of game */
-bool TurmoilSettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool TurmoilSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t TurmoilSettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t TurmoilSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool TurmoilSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_UP:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_DOWN:
-        case PLAYER_A_UPRIGHT:
-        case PLAYER_A_UPLEFT:
-        case PLAYER_A_DOWNRIGHT:
-        case PLAYER_A_DOWNLEFT:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_LEFTFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool TurmoilSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_UP:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_DOWN:
+    case PLAYER_A_UPRIGHT:
+    case PLAYER_A_UPLEFT:
+    case PLAYER_A_DOWNRIGHT:
+    case PLAYER_A_DOWNLEFT:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_LEFTFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void TurmoilSettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
-    m_lives    = 4;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
+  m_lives = 4;
 }
 
 /* saves the state of the rom settings */
-void TurmoilSettings::saveState(Serializer & ser) {
+void TurmoilSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
@@ -103,7 +83,7 @@ void TurmoilSettings::saveState(Serializer & ser) {
 }
 
 // loads the state of the rom settings
-void TurmoilSettings::loadState(Deserializer & ser) {
+void TurmoilSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();
@@ -111,7 +91,7 @@ void TurmoilSettings::loadState(Deserializer & ser) {
 }
 
 ActionVect TurmoilSettings::getStartingActions() {
-    ActionVect startingActions;
-    startingActions.push_back(PLAYER_A_FIRE);
-    return startingActions;
+  ActionVect startingActions;
+  startingActions.push_back(PLAYER_A_FIRE);
+  return startingActions;
 }

--- a/src/games/supported/Turmoil.hpp
+++ b/src/games/supported/Turmoil.hpp
@@ -14,54 +14,50 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Turmoil */
 class TurmoilSettings : public RomSettings {
+ public:
+  TurmoilSettings();
 
-    public:
+  // reset
+  void reset();
 
-        TurmoilSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  // MD5 sum of ROM file:
+  // 7a5463545dfb2dcfdafa6074b2f2c15e  Turmoil.bin
+  const char* rom() const { return "turmoil"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // the rom-name
-		// MD5 sum of ROM file:
-		// 7a5463545dfb2dcfdafa6074b2f2c15e  Turmoil.bin
-        const char* rom() const { return "turmoil"; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  // Turmoil requires the fire action to start the game
+  ActionVect getStartingActions();
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
-        // Turmoil requires the fire action to start the game
-        ActionVect getStartingActions();
-
-        virtual int lives() { return isTerminal() ? 0 : m_lives; }
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 };
 
-#endif // __TURMOIL_HPP__
+#endif  // __TURMOIL_HPP__

--- a/src/games/supported/Tutankham.cpp
+++ b/src/games/supported/Tutankham.cpp
@@ -28,86 +28,66 @@
 
 #include "../RomUtils.hpp"
 
-
-TutankhamSettings::TutankhamSettings() {
-
-    reset();
-}
-
+TutankhamSettings::TutankhamSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* TutankhamSettings::clone() const {
-
-    RomSettings* rval = new TutankhamSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new TutankhamSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void TutankhamSettings::step(const System& system) {
+  // update the reward
+  int score = getDecimalScore(0x9C, 0x9A, &system);
+  int reward = score - m_score;
+  m_reward = reward;
+  m_score = score;
 
-    // update the reward
-    int score = getDecimalScore(0x9C, 0x9A, &system);
-    int reward = score - m_score;
-    m_reward = reward;
-    m_score = score;
+  // update terminal status
+  int lives_byte = readRam(&system, 0x9E);
+  // byte 0x81 is set to 0x84 when the game is loaded, but not reset
+  int some_byte = readRam(&system, 0x81);
 
-    // update terminal status
-    int lives_byte = readRam(&system, 0x9E);
-    // byte 0x81 is set to 0x84 when the game is loaded, but not reset
-    int some_byte = readRam(&system, 0x81);
+  m_terminal = lives_byte == 0 && some_byte != 0x84;
 
-    m_terminal = lives_byte == 0 && some_byte != 0x84;
-
-    m_lives = (lives_byte & 0x3);
+  m_lives = (lives_byte & 0x3);
 }
-
 
 /* is end of game */
-bool TutankhamSettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool TutankhamSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t TutankhamSettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t TutankhamSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool TutankhamSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_UP:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_DOWN:
-        case PLAYER_A_UPFIRE:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_LEFTFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool TutankhamSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_UP:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_DOWN:
+    case PLAYER_A_UPFIRE:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_LEFTFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void TutankhamSettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
-    m_lives    = 3;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
+  m_lives = 3;
 }
 
 /* saves the state of the rom settings */
-void TutankhamSettings::saveState(Serializer & ser) {
+void TutankhamSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
@@ -115,7 +95,7 @@ void TutankhamSettings::saveState(Serializer & ser) {
 }
 
 // loads the state of the rom settings
-void TutankhamSettings::loadState(Deserializer & ser) {
+void TutankhamSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();
@@ -124,27 +104,26 @@ void TutankhamSettings::loadState(Deserializer & ser) {
 
 // returns a list of mode that the game can be played in
 ModeVect TutankhamSettings::getAvailableModes() {
-    ModeVect modes = {0, 4, 8, 12};
-    return modes;
+  ModeVect modes = {0, 4, 8, 12};
+  return modes;
 }
 
 // set the mode of the game
 // the given mode must be one returned by the previous function
-void TutankhamSettings::setMode(game_mode_t m, System &system,
-                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
-
-    if(m == 0 || m == 4 || m == 8 || m == 12) {
-        // read the mode we are currently in
-        unsigned char mode = readRam(&system, 0xAB);
-        // press select until the correct mode is reached
-        while (mode != m) {
-            environment->pressSelect(2);
-            mode = readRam(&system, 0xAB);
-        }
-        //reset the environment to apply changes.
-        environment->softReset();
+void TutankhamSettings::setMode(
+    game_mode_t m, System& system,
+    std::unique_ptr<StellaEnvironmentWrapper> environment) {
+  if (m == 0 || m == 4 || m == 8 || m == 12) {
+    // read the mode we are currently in
+    unsigned char mode = readRam(&system, 0xAB);
+    // press select until the correct mode is reached
+    while (mode != m) {
+      environment->pressSelect(2);
+      mode = readRam(&system, 0xAB);
     }
-    else {
-        throw std::runtime_error("This mode doesn't currently exist for this game");
-    }
- }
+    //reset the environment to apply changes.
+    environment->softReset();
+  } else {
+    throw std::runtime_error("This mode doesn't currently exist for this game");
+  }
+}

--- a/src/games/supported/Tutankham.hpp
+++ b/src/games/supported/Tutankham.hpp
@@ -29,61 +29,57 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Tutankham */
 class TutankhamSettings : public RomSettings {
+ public:
+  TutankhamSettings();
 
-    public:
+  // reset
+  void reset();
 
-        TutankhamSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "tutankham"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // get the available number of modes
+  unsigned int getNumModes() const { return 4; }
 
-        // the rom-name
-        const char* rom() const { return "tutankham"; }
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // get the available number of modes
-        unsigned int getNumModes() const { return 4; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  // returns a list of mode that the game can be played in
+  // in this game, there are 4 available modes
+  ModeVect getAvailableModes();
 
-        virtual int lives() { return isTerminal()? 0 : m_lives; }
+  // set the mode of the game
+  // the given mode must be one returned by the previous function
+  void setMode(game_mode_t, System& system,
+               std::unique_ptr<StellaEnvironmentWrapper> environment);
 
-        // returns a list of mode that the game can be played in
-        // in this game, there are 4 available modes
-        ModeVect getAvailableModes();
-
-        // set the mode of the game
-        // the given mode must be one returned by the previous function
-        void setMode(game_mode_t, System &system,
-                     std::unique_ptr<StellaEnvironmentWrapper> environment);
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 };
 
-#endif // __TUTANKHAM_HPP__
+#endif  // __TUTANKHAM_HPP__

--- a/src/games/supported/UpNDown.cpp
+++ b/src/games/supported/UpNDown.cpp
@@ -28,82 +28,62 @@
 
 #include "../RomUtils.hpp"
 
-
-UpNDownSettings::UpNDownSettings() {
-
-    reset();
-}
-
+UpNDownSettings::UpNDownSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* UpNDownSettings::clone() const {
-
-    RomSettings* rval = new UpNDownSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new UpNDownSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void UpNDownSettings::step(const System& system) {
+  // update the reward
+  int score = getDecimalScore(0x82, 0x81, 0x80, &system);
+  int reward = score - m_score;
+  m_reward = reward;
+  m_score = score;
 
-    // update the reward
-    int score = getDecimalScore(0x82, 0x81, 0x80, &system);
-    int reward = score - m_score;
-    m_reward = reward;
-    m_score = score;
+  // update terminal status
+  int lives_byte = readRam(&system, 0x86) & 0xF;
+  int death_timer = readRam(&system, 0x94);
+  m_terminal = death_timer > 0x40 && lives_byte == 0;
 
-    // update terminal status
-    int lives_byte = readRam(&system, 0x86) & 0xF;
-    int death_timer = readRam(&system, 0x94);
-    m_terminal = death_timer > 0x40 && lives_byte == 0;
-
-    m_lives = lives_byte + 1;
+  m_lives = lives_byte + 1;
 }
-
 
 /* is end of game */
-bool UpNDownSettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool UpNDownSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t UpNDownSettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t UpNDownSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool UpNDownSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_UP:
-        case PLAYER_A_DOWN:
-        case PLAYER_A_UPFIRE:
-        case PLAYER_A_DOWNFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool UpNDownSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_UP:
+    case PLAYER_A_DOWN:
+    case PLAYER_A_UPFIRE:
+    case PLAYER_A_DOWNFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void UpNDownSettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
-    m_lives    = 5;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
+  m_lives = 5;
 }
 
 /* saves the state of the rom settings */
-void UpNDownSettings::saveState(Serializer & ser) {
+void UpNDownSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
@@ -111,7 +91,7 @@ void UpNDownSettings::saveState(Serializer & ser) {
 }
 
 // loads the state of the rom settings
-void UpNDownSettings::loadState(Deserializer & ser) {
+void UpNDownSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();
@@ -119,12 +99,12 @@ void UpNDownSettings::loadState(Deserializer & ser) {
 }
 
 ActionVect UpNDownSettings::getStartingActions() {
-    ActionVect startingActions;
-    startingActions.push_back(PLAYER_A_FIRE);
-    return startingActions;
+  ActionVect startingActions;
+  startingActions.push_back(PLAYER_A_FIRE);
+  return startingActions;
 }
 
 DifficultyVect UpNDownSettings::getAvailableDifficulties() {
-    DifficultyVect diff = {0, 1, 2, 3};
-    return diff;
+  DifficultyVect diff = {0, 1, 2, 3};
+  return diff;
 }

--- a/src/games/supported/UpNDown.hpp
+++ b/src/games/supported/UpNDown.hpp
@@ -29,56 +29,52 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Up N Down */
 class UpNDownSettings : public RomSettings {
+ public:
+  UpNDownSettings();
 
-    public:
+  // reset
+  void reset();
 
-        UpNDownSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "up_n_down"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // the rom-name
-        const char* rom() const { return "up_n_down"; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  // UpNDown requires the fire action to start the game
+  ActionVect getStartingActions();
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
-        // UpNDown requires the fire action to start the game
-        ActionVect getStartingActions();
+  // returns a list of difficulties that the game can be played in
+  // in this game, there are 4 available difficulties
+  DifficultyVect getAvailableDifficulties();
 
-        virtual int lives() { return isTerminal() ? 0 : m_lives; }
-
-        // returns a list of difficulties that the game can be played in
-        // in this game, there are 4 available difficulties
-        DifficultyVect getAvailableDifficulties();
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 };
 
-#endif // __UPNDOWN_HPP__
+#endif  // __UPNDOWN_HPP__

--- a/src/games/supported/Venture.cpp
+++ b/src/games/supported/Venture.cpp
@@ -28,96 +28,76 @@
 
 #include "../RomUtils.hpp"
 
-
-VentureSettings::VentureSettings() {
-
-    reset();
-}
-
+VentureSettings::VentureSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* VentureSettings::clone() const {
-
-    RomSettings* rval = new VentureSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new VentureSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void VentureSettings::step(const System& system) {
+  // update the reward
+  int score = getDecimalScore(0xC8, 0xC7, &system);
+  score *= 100;
+  int reward = score - m_score;
+  m_reward = reward;
+  m_score = score;
 
-    // update the reward
-    int score = getDecimalScore(0xC8, 0xC7, &system);
-    score *= 100;
-    int reward = score - m_score;
-    m_reward = reward;
-    m_score = score;
+  // update terminal status
+  int lives_byte = readRam(&system, 0xC6);
+  int audio_byte = readRam(&system, 0xCD);
+  int death_byte = readRam(&system, 0xBF);
+  m_terminal = (lives_byte == 0 && audio_byte == 0xFF && death_byte & 0x80);
 
-    // update terminal status
-    int lives_byte = readRam(&system, 0xC6);
-    int audio_byte = readRam(&system, 0xCD);
-    int death_byte = readRam(&system, 0xBF);
-    m_terminal = (lives_byte == 0 && audio_byte == 0xFF && death_byte & 0x80);
-
-    m_lives = (lives_byte & 0x7) + 1;
+  m_lives = (lives_byte & 0x7) + 1;
 }
-
 
 /* is end of game */
-bool VentureSettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool VentureSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t VentureSettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t VentureSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool VentureSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_UP:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_DOWN:
-        case PLAYER_A_UPRIGHT:
-        case PLAYER_A_UPLEFT:
-        case PLAYER_A_DOWNRIGHT:
-        case PLAYER_A_DOWNLEFT:
-        case PLAYER_A_UPFIRE:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_LEFTFIRE:
-        case PLAYER_A_DOWNFIRE:
-        case PLAYER_A_UPRIGHTFIRE:
-        case PLAYER_A_UPLEFTFIRE:
-        case PLAYER_A_DOWNRIGHTFIRE:
-        case PLAYER_A_DOWNLEFTFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool VentureSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_UP:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_DOWN:
+    case PLAYER_A_UPRIGHT:
+    case PLAYER_A_UPLEFT:
+    case PLAYER_A_DOWNRIGHT:
+    case PLAYER_A_DOWNLEFT:
+    case PLAYER_A_UPFIRE:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_LEFTFIRE:
+    case PLAYER_A_DOWNFIRE:
+    case PLAYER_A_UPRIGHTFIRE:
+    case PLAYER_A_UPLEFTFIRE:
+    case PLAYER_A_DOWNRIGHTFIRE:
+    case PLAYER_A_DOWNLEFTFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void VentureSettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
-    m_lives    = 4;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
+  m_lives = 4;
 }
 
 /* saves the state of the rom settings */
-void VentureSettings::saveState(Serializer & ser) {
+void VentureSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
@@ -125,15 +105,14 @@ void VentureSettings::saveState(Serializer & ser) {
 }
 
 // loads the state of the rom settings
-void VentureSettings::loadState(Deserializer & ser) {
+void VentureSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();
   m_lives = ser.getInt();
 }
 
-
 DifficultyVect VentureSettings::getAvailableDifficulties() {
-    DifficultyVect diff = {0, 1, 2, 3};
-    return diff;
+  DifficultyVect diff = {0, 1, 2, 3};
+  return diff;
 }

--- a/src/games/supported/Venture.hpp
+++ b/src/games/supported/Venture.hpp
@@ -29,53 +29,49 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Venture */
 class VentureSettings : public RomSettings {
+ public:
+  VentureSettings();
 
-    public:
+  // reset
+  void reset();
 
-        VentureSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "venture"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // the rom-name
-        const char* rom() const { return "venture"; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  // returns a list of difficulties that the game can be played in
+  // in this game, there are 2 available difficulties
+  DifficultyVect getAvailableDifficulties();
 
-        virtual int lives() { return isTerminal() ? 0 : m_lives; }
-
-        // returns a list of difficulties that the game can be played in
-        // in this game, there are 2 available difficulties
-        DifficultyVect getAvailableDifficulties();
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 };
 
-#endif // __VENTURE_HPP__
+#endif  // __VENTURE_HPP__

--- a/src/games/supported/VideoPinball.hpp
+++ b/src/games/supported/VideoPinball.hpp
@@ -29,65 +29,61 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Video Pinball */
 class VideoPinballSettings : public RomSettings {
+ public:
+  VideoPinballSettings();
 
-    public:
+  // reset
+  void reset();
 
-        VideoPinballSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "video_pinball"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // get the available number of modes
+  unsigned int getNumModes() const { return 2; }
 
-        // the rom-name
-        const char* rom() const { return "video_pinball"; }
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // get the available number of modes
-        unsigned int getNumModes() const { return 2; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  // returns a list of mode that the game can be played in
+  // in this game, there are 2 available modes
+  ModeVect getAvailableModes();
 
-        virtual int lives() { return isTerminal() ? 0 : m_lives; }
+  // set the mode of the game
+  // the given mode must be one returned by the previous function
+  void setMode(game_mode_t, System& system,
+               std::unique_ptr<StellaEnvironmentWrapper> environment);
 
-        // returns a list of mode that the game can be played in
-        // in this game, there are 2 available modes
-        ModeVect getAvailableModes();
+  // returns a list of difficulties that the game can be played in
+  // in this game, there are 2 available difficulties
+  DifficultyVect getAvailableDifficulties();
 
-        // set the mode of the game
-        // the given mode must be one returned by the previous function
-        void setMode(game_mode_t, System &system,
-                     std::unique_ptr<StellaEnvironmentWrapper> environment);
-
-        // returns a list of difficulties that the game can be played in
-        // in this game, there are 2 available difficulties
-        DifficultyVect getAvailableDifficulties();
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 };
 
-#endif // __VIDEOPINBALL_HPP__
+#endif  // __VIDEOPINBALL_HPP__

--- a/src/games/supported/WizardOfWor.cpp
+++ b/src/games/supported/WizardOfWor.cpp
@@ -29,92 +29,73 @@
 #include "../RomUtils.hpp"
 #include "stdio.h"
 
-WizardOfWorSettings::WizardOfWorSettings() {
-
-    reset();
-}
-
+WizardOfWorSettings::WizardOfWorSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* WizardOfWorSettings::clone() const {
-
-    RomSettings* rval = new WizardOfWorSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new WizardOfWorSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void WizardOfWorSettings::step(const System& system) {
+  // update the reward
+  reward_t score = getDecimalScore(0x86, 0x88, &system);
+  if (score >= 8000)
+    score -= 8000; // MGB score does not go beyond 999
+  score *= 100;
+  m_reward = score - m_score;
+  m_score = score;
 
-    // update the reward
-    reward_t score = getDecimalScore(0x86, 0x88, &system);
-    if (score >= 8000) score -= 8000; // MGB score does not go beyond 999
-    score *= 100;
-    m_reward = score - m_score;
-    m_score = score;
+  // update terminal status
+  int newLives = readRam(&system, 0x8D) & 15;
+  int byte1 = readRam(&system, 0xF4);
 
-    // update terminal status
-    int newLives = readRam(&system, 0x8D) & 15;
-    int byte1 = readRam(&system, 0xF4);
+  bool isWaiting = (readRam(&system, 0xD7) & 0x1) == 0;
 
-    bool isWaiting = (readRam(&system, 0xD7) & 0x1) == 0;
+  m_terminal = newLives == 0 && byte1 == 0xF8;
 
-    m_terminal = newLives == 0 && byte1 == 0xF8;
-
-    // Wizard of Wor decreases the life total when we move into the play field; we only
-    // change the life total when we actually are waiting
-    m_lives = isWaiting ? newLives : m_lives;
+  // Wizard of Wor decreases the life total when we move into the play field; we only
+  // change the life total when we actually are waiting
+  m_lives = isWaiting ? newLives : m_lives;
 }
-
 
 /* is end of game */
-bool WizardOfWorSettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool WizardOfWorSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t WizardOfWorSettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t WizardOfWorSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool WizardOfWorSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_UP:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_DOWN:
-        case PLAYER_A_UPFIRE:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_LEFTFIRE:
-        case PLAYER_A_DOWNFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool WizardOfWorSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_UP:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_DOWN:
+    case PLAYER_A_UPFIRE:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_LEFTFIRE:
+    case PLAYER_A_DOWNFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void WizardOfWorSettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
-    m_lives    = 3;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
+  m_lives = 3;
 }
 
-
 /* saves the state of the rom settings */
-void WizardOfWorSettings::saveState(Serializer & ser) {
+void WizardOfWorSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
@@ -122,7 +103,7 @@ void WizardOfWorSettings::saveState(Serializer & ser) {
 }
 
 // loads the state of the rom settings
-void WizardOfWorSettings::loadState(Deserializer & ser) {
+void WizardOfWorSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();
@@ -130,6 +111,6 @@ void WizardOfWorSettings::loadState(Deserializer & ser) {
 }
 
 DifficultyVect WizardOfWorSettings::getAvailableDifficulties() {
-    DifficultyVect diff = {0, 1};
-    return diff;
+  DifficultyVect diff = {0, 1};
+  return diff;
 }

--- a/src/games/supported/WizardOfWor.hpp
+++ b/src/games/supported/WizardOfWor.hpp
@@ -29,53 +29,49 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Wizard of Wor */
 class WizardOfWorSettings : public RomSettings {
+ public:
+  WizardOfWorSettings();
 
-    public:
+  // reset
+  void reset();
 
-        WizardOfWorSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "wizard_of_wor"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // the rom-name
-        const char* rom() const { return "wizard_of_wor"; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  // returns a list of difficulties that the game can be played in
+  // in this game, there are 2 available difficulties
+  DifficultyVect getAvailableDifficulties();
 
-        virtual int lives() { return isTerminal() ? 0 : m_lives; }
-
-        // returns a list of difficulties that the game can be played in
-        // in this game, there are 2 available difficulties
-        DifficultyVect getAvailableDifficulties();
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 };
 
-#endif // __WIZARDOFWOR_HPP__
+#endif  // __WIZARDOFWOR_HPP__

--- a/src/games/supported/YarsRevenge.cpp
+++ b/src/games/supported/YarsRevenge.cpp
@@ -28,93 +28,73 @@
 
 #include "../RomUtils.hpp"
 
-
-YarsRevengeSettings::YarsRevengeSettings() {
-
-    reset();
-}
-
+YarsRevengeSettings::YarsRevengeSettings() { reset(); }
 
 /* create a new instance of the rom */
 RomSettings* YarsRevengeSettings::clone() const {
-
-    RomSettings* rval = new YarsRevengeSettings();
-    *rval = *this;
-    return rval;
+  RomSettings* rval = new YarsRevengeSettings();
+  *rval = *this;
+  return rval;
 }
-
 
 /* process the latest information from ALE */
 void YarsRevengeSettings::step(const System& system) {
+  // update the reward
+  int score = getDecimalScore(0xE2, 0xE1, 0xE0, &system);
+  int reward = score - m_score;
+  m_reward = reward;
+  m_score = score;
 
-    // update the reward
-    int score = getDecimalScore(0xE2, 0xE1, 0xE0, &system);
-    int reward = score - m_score;
-    m_reward = reward;
-    m_score = score;
+  // update terminal status
+  int lives_byte = readRam(&system, 0x9E) >> 4;
+  m_terminal = (lives_byte == 0);
 
-    // update terminal status
-    int lives_byte = readRam(&system, 0x9E) >> 4;
-    m_terminal = (lives_byte == 0);
-
-    m_lives = lives_byte;
+  m_lives = lives_byte;
 }
-
 
 /* is end of game */
-bool YarsRevengeSettings::isTerminal() const {
-
-    return m_terminal;
-};
-
+bool YarsRevengeSettings::isTerminal() const { return m_terminal; };
 
 /* get the most recently observed reward */
-reward_t YarsRevengeSettings::getReward() const {
-
-    return m_reward;
-}
-
+reward_t YarsRevengeSettings::getReward() const { return m_reward; }
 
 /* is an action part of the minimal set? */
-bool YarsRevengeSettings::isMinimal(const Action &a) const {
-
-    switch (a) {
-        case PLAYER_A_NOOP:
-        case PLAYER_A_FIRE:
-        case PLAYER_A_UP:
-        case PLAYER_A_RIGHT:
-        case PLAYER_A_LEFT:
-        case PLAYER_A_DOWN:
-        case PLAYER_A_UPRIGHT:
-        case PLAYER_A_UPLEFT:
-        case PLAYER_A_DOWNRIGHT:
-        case PLAYER_A_DOWNLEFT:
-        case PLAYER_A_UPFIRE:
-        case PLAYER_A_RIGHTFIRE:
-        case PLAYER_A_LEFTFIRE:
-        case PLAYER_A_DOWNFIRE:
-        case PLAYER_A_UPRIGHTFIRE:
-        case PLAYER_A_UPLEFTFIRE:
-        case PLAYER_A_DOWNRIGHTFIRE:
-        case PLAYER_A_DOWNLEFTFIRE:
-            return true;
-        default:
-            return false;
-    }
+bool YarsRevengeSettings::isMinimal(const Action& a) const {
+  switch (a) {
+    case PLAYER_A_NOOP:
+    case PLAYER_A_FIRE:
+    case PLAYER_A_UP:
+    case PLAYER_A_RIGHT:
+    case PLAYER_A_LEFT:
+    case PLAYER_A_DOWN:
+    case PLAYER_A_UPRIGHT:
+    case PLAYER_A_UPLEFT:
+    case PLAYER_A_DOWNRIGHT:
+    case PLAYER_A_DOWNLEFT:
+    case PLAYER_A_UPFIRE:
+    case PLAYER_A_RIGHTFIRE:
+    case PLAYER_A_LEFTFIRE:
+    case PLAYER_A_DOWNFIRE:
+    case PLAYER_A_UPRIGHTFIRE:
+    case PLAYER_A_UPLEFTFIRE:
+    case PLAYER_A_DOWNRIGHTFIRE:
+    case PLAYER_A_DOWNLEFTFIRE:
+      return true;
+    default:
+      return false;
+  }
 }
-
 
 /* reset the state of the game */
 void YarsRevengeSettings::reset() {
-
-    m_reward   = 0;
-    m_score    = 0;
-    m_terminal = false;
-    m_lives    = 4;
+  m_reward = 0;
+  m_score = 0;
+  m_terminal = false;
+  m_lives = 4;
 }
 
 /* saves the state of the rom settings */
-void YarsRevengeSettings::saveState(Serializer & ser) {
+void YarsRevengeSettings::saveState(Serializer& ser) {
   ser.putInt(m_reward);
   ser.putInt(m_score);
   ser.putBool(m_terminal);
@@ -122,7 +102,7 @@ void YarsRevengeSettings::saveState(Serializer & ser) {
 }
 
 // loads the state of the rom settings
-void YarsRevengeSettings::loadState(Deserializer & ser) {
+void YarsRevengeSettings::loadState(Deserializer& ser) {
   m_reward = ser.getInt();
   m_score = ser.getInt();
   m_terminal = ser.getBool();
@@ -130,41 +110,40 @@ void YarsRevengeSettings::loadState(Deserializer & ser) {
 }
 
 ActionVect YarsRevengeSettings::getStartingActions() {
-    ActionVect startingActions;
-    startingActions.push_back(PLAYER_A_FIRE);
-    return startingActions;
+  ActionVect startingActions;
+  startingActions.push_back(PLAYER_A_FIRE);
+  return startingActions;
 }
 
 // returns a list of mode that the game can be played in
 ModeVect YarsRevengeSettings::getAvailableModes() {
-    ModeVect modes = {0, 0x20, 0x40, 0x60};
-    return modes;
+  ModeVect modes = {0, 0x20, 0x40, 0x60};
+  return modes;
 }
 
 // set the mode of the game
 // the given mode must be one returned by the previous function
-void YarsRevengeSettings::setMode(game_mode_t m, System &system,
-                              std::unique_ptr<StellaEnvironmentWrapper> environment) {
-
-    if(m == 0 || m == 0x20 || m == 0x40 || m == 0x60) {
-        // enter in mode selection screen
-        environment->pressSelect(2);
-        // read the mode we are currently in
-        unsigned char mode = readRam(&system, 0xE3);
-        // press select until the correct mode is reached
-        while (mode != m) {
-            environment->pressSelect();
-            mode = readRam(&system, 0xE3);
-        }
-        //reset the environment to apply changes.
-        environment->softReset();
+void YarsRevengeSettings::setMode(
+    game_mode_t m, System& system,
+    std::unique_ptr<StellaEnvironmentWrapper> environment) {
+  if (m == 0 || m == 0x20 || m == 0x40 || m == 0x60) {
+    // enter in mode selection screen
+    environment->pressSelect(2);
+    // read the mode we are currently in
+    unsigned char mode = readRam(&system, 0xE3);
+    // press select until the correct mode is reached
+    while (mode != m) {
+      environment->pressSelect();
+      mode = readRam(&system, 0xE3);
     }
-    else {
-        throw std::runtime_error("This mode doesn't currently exist for this game");
-    }
- }
+    //reset the environment to apply changes.
+    environment->softReset();
+  } else {
+    throw std::runtime_error("This mode doesn't currently exist for this game");
+  }
+}
 
 DifficultyVect YarsRevengeSettings::getAvailableDifficulties() {
-    DifficultyVect diff = {0, 1};
-    return diff;
+  DifficultyVect diff = {0, 1};
+  return diff;
 }

--- a/src/games/supported/YarsRevenge.hpp
+++ b/src/games/supported/YarsRevenge.hpp
@@ -29,68 +29,64 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for YarsRevenge */
 class YarsRevengeSettings : public RomSettings {
+ public:
+  YarsRevengeSettings();
 
-    public:
+  // reset
+  void reset();
 
-        YarsRevengeSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "yars_revenge"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // get the available number of modes
+  unsigned int getNumModes() const { return 4; }
 
-        // the rom-name
-        const char* rom() const { return "yars_revenge"; }
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // get the available number of modes
-        unsigned int getNumModes() const { return 4; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  // Gopher requires the fire action to start the game
+  ActionVect getStartingActions();
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
-        // Gopher requires the fire action to start the game
-        ActionVect getStartingActions();
+  // returns a list of mode that the game can be played in
+  // in this game, there are 4 available modes
+  ModeVect getAvailableModes();
 
-        virtual int lives() { return isTerminal() ? 0 : m_lives; }
+  // set the mode of the game
+  // the given mode must be one returned by the previous function
+  void setMode(game_mode_t, System& system,
+               std::unique_ptr<StellaEnvironmentWrapper> environment);
 
-        // returns a list of mode that the game can be played in
-        // in this game, there are 4 available modes
-        ModeVect getAvailableModes();
+  // returns a list of difficulties that the game can be played in
+  // in this game, there are 2 available difficulties
+  DifficultyVect getAvailableDifficulties();
 
-        // set the mode of the game
-        // the given mode must be one returned by the previous function
-        void setMode(game_mode_t, System &system,
-                     std::unique_ptr<StellaEnvironmentWrapper> environment);
-
-        // returns a list of difficulties that the game can be played in
-        // in this game, there are 2 available difficulties
-        DifficultyVect getAvailableDifficulties();
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 };
 
-#endif // __YARS_REVENGE_HPP__
+#endif  // __YARS_REVENGE_HPP__

--- a/src/games/supported/Zaxxon.hpp
+++ b/src/games/supported/Zaxxon.hpp
@@ -29,62 +29,57 @@
 
 #include "../RomSettings.hpp"
 
-
 /* RL wrapper for Zaxxon */
 class ZaxxonSettings : public RomSettings {
+ public:
+  ZaxxonSettings();
 
-    public:
+  // reset
+  void reset();
 
-        ZaxxonSettings();
+  // is end of game
+  bool isTerminal() const;
 
-        // reset
-        void reset();
+  // get the most recently observed reward
+  reward_t getReward() const;
 
-        // is end of game
-        bool isTerminal() const;
+  // the rom-name
+  const char* rom() const { return "zaxxon"; }
 
-        // get the most recently observed reward
-        reward_t getReward() const;
+  // get the available number of modes
+  unsigned int getNumModes() const { return 4; }
 
-        // the rom-name
-        const char* rom() const { return "zaxxon"; }
+  // create a new instance of the rom
+  RomSettings* clone() const;
 
-        // get the available number of modes
-        unsigned int getNumModes() const { return 4; }
+  // is an action part of the minimal set?
+  bool isMinimal(const Action& a) const;
 
-        // create a new instance of the rom
-        RomSettings* clone() const;
+  // process the latest information from ALE
+  void step(const System& system);
 
-        // is an action part of the minimal set?
-        bool isMinimal(const Action& a) const;
+  // saves the state of the rom settings
+  void saveState(Serializer& ser);
 
-        // process the latest information from ALE
-        void step(const System& system);
+  // loads the state of the rom settings
+  void loadState(Deserializer& ser);
 
-        // saves the state of the rom settings
-        void saveState(Serializer & ser);
+  virtual int lives() { return isTerminal() ? 0 : m_lives; }
 
-        // loads the state of the rom settings
-        void loadState(Deserializer & ser);
+  // returns a list of mode that the game can be played in
+  // in this game, there are 4 available modes
+  ModeVect getAvailableModes();
 
-        virtual int lives() { return isTerminal() ? 0 : m_lives; }
+  // set the mode of the game
+  // the given mode must be one returned by the previous function
+  void setMode(game_mode_t, System& system,
+               std::unique_ptr<StellaEnvironmentWrapper> environment);
 
-        // returns a list of mode that the game can be played in
-        // in this game, there are 4 available modes
-        ModeVect getAvailableModes();
-
-        // set the mode of the game
-        // the given mode must be one returned by the previous function
-        void setMode(game_mode_t, System &system,
-                     std::unique_ptr<StellaEnvironmentWrapper> environment);
-
-
-    private:
-
-        bool m_terminal;
-        reward_t m_reward;
-        reward_t m_score;
-        int m_lives;
+ private:
+  bool m_terminal;
+  reward_t m_reward;
+  reward_t m_score;
+  int m_lives;
 };
 
-#endif // __ZAXXON_HPP__
+#endif  // __ZAXXON_HPP__


### PR DESCRIPTION
This change only modifies whitespace (and adds one or two #ifdef
comments). The reformatting is based on clang-format, with manual
review and tweaking.

The goal to harmonize the source code formatting, which is currently
using a variety of local styles. The chosen format is a "compact"
one (as per clang-format default): 2-space indent, Egyptian braces.
Nonetheless, vertical whitespace has been adjusted generously, so as
to have line comments preceded by a blank line for easy visual
segmentation.

Created with:

    clang-format               \
        --sort-includes=false  \
        --style='{ReflowComments: false,
                  PointerAlignment: Left,
                  KeepEmptyLinesAtTheStartOfBlocks: false,
                  IndentCaseLabels: true,
                  AccessModifierOffset: -1}'

    sed -e 's%#endif //%#endif  //%g'