### PR TITLE
User feedback if we can't find a valid wrapper

### DIFF
--- a/src/ale_interface.hpp
+++ b/src/ale_interface.hpp
@@ -193,7 +193,7 @@ class ALEInterface {
                            std::unique_ptr<OSystem>& theOSystem);
 
  private:
-  static void checkForUnsupportedRom(std::unique_ptr<OSystem>& theOSystem);
+  static bool isSupportedRom(std::unique_ptr<OSystem>& theOSystem);
 };
 
 #endif


### PR DESCRIPTION
Give useful feedback if we can't valid a valid ROM wrapper. Hopefully, this will prevent issues like #292.

I just refactored `checkForUnsupportedRom` into `isSupportedRom` so we can give some useful feedback if the ROM isn't supported and we failed to find a wrapper.