### PR TITLE
Two new features: read memory, check game mode validity

### DIFF
--- a/src/games/RomSettings.cpp
+++ b/src/games/RomSettings.cpp
@@ -18,6 +18,8 @@
 
 #include "RomSettings.hpp"
 
+#include <algorithm>
+
 namespace ale {
 
 RomSettings::RomSettings() {}
@@ -63,6 +65,11 @@ void RomSettings::setMode(game_mode_t m, System&, std::unique_ptr<StellaEnvironm
 
 DifficultyVect RomSettings::getAvailableDifficulties() {
   return DifficultyVect(1, 0);
-};
+}
+
+bool RomSettings::isModeSupported(game_mode_t m) {
+  auto modes = getAvailableModes();
+  return std::find(modes.begin(), modes.end(), m) != modes.end();
+}
 
 }  // namespace ale

--- a/src/games/RomSettings.hpp
+++ b/src/games/RomSettings.hpp
@@ -112,6 +112,10 @@ class RomSettings {
   // Returns a list of difficulties that the game can be played in.
   // By default, there is only one available difficulty.
   virtual DifficultyVect getAvailableDifficulties();
+
+ protected:
+  // Helper function that checks if our settings support this given mode.
+  bool isModeSupported(game_mode_t m);
 };
 
 }  // namespace ale

--- a/src/games/RomUtils.hpp
+++ b/src/games/RomUtils.hpp
@@ -22,8 +22,11 @@ class System;
 
 namespace ale {
 
-// reads a byte at a memory location between 0 and 1023
+// reads a byte at a RAM location between 0 and 0x7f also mapped to [0x80, 0xff]
 extern int readRam(const System* system, int offset);
+
+// reads a byte from anywhere in the memory map between 0x0000 and 0xffff.
+extern int readMappedRam(const System* system, int offset);
 
 // extracts a decimal value from 1, 2, and 3 bytes respectively
 extern int getDecimalScore(int idx, const System* system);


### PR DESCRIPTION
Two commits in this PR:

* one to read a byte of memory from anywhere (not just from [0, 1024) as the existing facility provides)

* one to check whether a game mode is valid

(Please don't squash, but rebase-merge)