### PR TITLE
[emucore/TIA.cxx] Make initialization of static data thread-safe.

### DIFF
--- a/src/emucore/TIA.cxx
+++ b/src/emucore/TIA.cxx
@@ -20,6 +20,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
+#include <mutex>
 
 #include "Console.hxx"
 #include "Control.hxx"
@@ -30,9 +31,12 @@
 #include "Deserializer.hxx"
 #include "Settings.hxx"
 #include "Sound.hxx"
+
 using namespace std;
 
 #define HBLANK 68
+
+static std::once_flag tia_init_once;
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TIA::TIA(const Console& console, Settings& settings)
@@ -95,14 +99,16 @@ TIA::TIA(const Console& console, Settings& settings)
     }
   }
 
-  // Compute all of the mask tables
-  computeBallMaskTable();
-  computeCollisionTable();
-  computeMissleMaskTable();
-  computePlayerMaskTable();
-  computePlayerPositionResetWhenTable();
-  computePlayerReflectTable();
-  computePlayfieldMaskTable();
+  std::call_once(tia_init_once, []() {
+    // Compute all of the mask tables
+    computeBallMaskTable();
+    computeCollisionTable();
+    computeMissleMaskTable();
+    computePlayerMaskTable();
+    computePlayerPositionResetWhenTable();
+    computePlayerReflectTable();
+    computePlayfieldMaskTable();
+  });
 
   // Init stats counters
   myFrameCounter = 0;


### PR DESCRIPTION
The initializing functions are now guarded with std::call_once.

It is someone annoying that we are computing these values at runtime
even though they are perfectly well deterimined statically. However,
the programmatic expressions may be more meaningful than the raw
numbers, so it is useful to retain the code. We _could_ make the code
evaluate as constant expressions, but unfortunately this seems to
require non-standard toolchain settings to allow for a rather large
constant evaluation budget during compilation.

The upstream Stella code has diverged from this code anyway, so this
is just a local fix for the time being.