### PR TITLE
[emucore, Cart*] Delete old, process-global RNG instance.

### DIFF
--- a/src/emucore/Cart.cxx
+++ b/src/emucore/Cart.cxx
@@ -51,7 +51,7 @@
 using namespace std;
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Cartridge* Cartridge::create(const uInt8* image, uInt32 size,
-    const Properties& properties, const Settings& settings)
+    const Properties& properties, const Settings& settings, Random& rng)
 {
   Cartridge* cartridge = 0;
 
@@ -92,7 +92,7 @@ Cartridge* Cartridge::create(const uInt8* image, uInt32 size,
   if(type == "2K")
     cartridge = new Cartridge2K(image);
   else if(type == "3E")
-    cartridge = new Cartridge3E(image, size);
+    cartridge = new Cartridge3E(image, size, rng);
   else if(type == "3F")
     cartridge = new Cartridge3F(image, size);
   else if(type == "4A50")
@@ -100,37 +100,37 @@ Cartridge* Cartridge::create(const uInt8* image, uInt32 size,
   else if(type == "4K")
     cartridge = new Cartridge4K(image);
   else if(type == "AR")
-    cartridge = new CartridgeAR(image, size, true); //settings.getBool("fastscbios")
+    cartridge = new CartridgeAR(image, size, true, rng);
   else if(type == "DPC")
     cartridge = new CartridgeDPC(image, size);
   else if(type == "E0")
     cartridge = new CartridgeE0(image);
   else if(type == "E7")
-    cartridge = new CartridgeE7(image);
+    cartridge = new CartridgeE7(image, rng);
   else if(type == "F4")
     cartridge = new CartridgeF4(image);
   else if(type == "F4SC")
-    cartridge = new CartridgeF4SC(image);
+    cartridge = new CartridgeF4SC(image, rng);
   else if(type == "F6")
     cartridge = new CartridgeF6(image);
   else if(type == "F6SC")
-    cartridge = new CartridgeF6SC(image);
+    cartridge = new CartridgeF6SC(image, rng);
   else if(type == "F8")
     cartridge = new CartridgeF8(image, false);
   else if(type == "F8 swapped")
     cartridge = new CartridgeF8(image, true);
   else if(type == "F8SC")
-    cartridge = new CartridgeF8SC(image);
+    cartridge = new CartridgeF8SC(image, rng);
   else if(type == "FASC")
-    cartridge = new CartridgeFASC(image);
+    cartridge = new CartridgeFASC(image, rng);
   else if(type == "FE")
     cartridge = new CartridgeFE(image);
   else if(type == "MC")
-    cartridge = new CartridgeMC(image, size);
+    cartridge = new CartridgeMC(image, size, rng);
   else if(type == "MB")
     cartridge = new CartridgeMB(image);
   else if(type == "CV")
-    cartridge = new CartridgeCV(image, size);
+    cartridge = new CartridgeCV(image, size, rng);
   else if(type == "UA")
     cartridge = new CartridgeUA(image);
   else if(type == "0840")

--- a/src/emucore/Cart.hxx
+++ b/src/emucore/Cart.hxx
@@ -27,6 +27,7 @@ class Settings;
 #include <fstream>
 #include "m6502/src/bspf/src/bspf.hxx"
 #include "m6502/src/Device.hxx"
+#include "Random.hxx"
 #include "../common/Log.hpp"
 
 /**
@@ -50,7 +51,7 @@ class Cartridge : public Device
       @return   Pointer to the new cartridge object allocated on the heap
     */
     static Cartridge* create(const uInt8* image, uInt32 size, 
-        const Properties& props, const Settings& settings);
+        const Properties& props, const Settings& settings, Random& rng);
 
     /**
       Create a new cartridge

--- a/src/emucore/Cart3E.cxx
+++ b/src/emucore/Cart3E.cxx
@@ -27,7 +27,7 @@
 using namespace std;
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Cartridge3E::Cartridge3E(const uInt8* image, uInt32 size)
+Cartridge3E::Cartridge3E(const uInt8* image, uInt32 size, Random& rng)
   : mySize(size)
 {
   // Allocate array for the ROM image
@@ -40,10 +40,9 @@ Cartridge3E::Cartridge3E(const uInt8* image, uInt32 size)
   }
 
   // Initialize RAM with random values
-  class Random& random = Random::getInstance();
   for(uInt32 i = 0; i < 32768; ++i)
   {
-    myRam[i] = random.next();
+    myRam[i] = rng.next();
   }
 }
 

--- a/src/emucore/Cart3E.hxx
+++ b/src/emucore/Cart3E.hxx
@@ -25,6 +25,7 @@ class Deserializer;
 
 #include "m6502/src/bspf/src/bspf.hxx"
 #include "Cart.hxx"
+#include "Random.hxx"
 
 /**
   This is the cartridge class for Tigervision's bankswitched
@@ -70,8 +71,9 @@ class Cartridge3E : public Cartridge
 
       @param image Pointer to the ROM image
       @param size The size of the ROM image
+      @param rng A random number generator used to populate the initial extra RAM
     */
-    Cartridge3E(const uInt8* image, uInt32 size);
+    Cartridge3E(const uInt8* image, uInt32 size, Random& rng);
  
     /**
       Destructor

--- a/src/emucore/CartAR.cxx
+++ b/src/emucore/CartAR.cxx
@@ -29,7 +29,7 @@
 using namespace std;
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-CartridgeAR::CartridgeAR(const uInt8* image, uInt32 size, bool fastbios)
+CartridgeAR::CartridgeAR(const uInt8* image, uInt32 size, bool fastbios, Random& rng)
   : my6502(0)
 {
   uInt32 i;
@@ -40,11 +40,9 @@ CartridgeAR::CartridgeAR(const uInt8* image, uInt32 size, bool fastbios)
   memcpy(myLoadImages, image, size);
 
   // Initialize RAM with random values
-  class Random& random = Random::getInstance();
-
   for(i = 0; i < 6 * 1024; ++i)
   {
-    myImage[i] = random.next();
+    myImage[i] = rng.next();
   }
 
   // Initialize SC BIOS ROM

--- a/src/emucore/CartAR.hxx
+++ b/src/emucore/CartAR.hxx
@@ -26,6 +26,7 @@ class Deserializer;
 
 #include "m6502/src/bspf/src/bspf.hxx"
 #include "Cart.hxx"
+#include "Random.hxx"
 
 /**
   This is the cartridge class for Arcadia (aka Starpath) Supercharger 
@@ -48,8 +49,9 @@ class CartridgeAR : public Cartridge
       @param image     Pointer to the ROM image
       @param size      The size of the ROM image
       @param fastbios  Whether or not to quickly execute the BIOS code
+      @param rng       A random number generator used to populate the initial extra RAM
     */
-    CartridgeAR(const uInt8* image, uInt32 size, bool fastbios);
+    CartridgeAR(const uInt8* image, uInt32 size, bool fastbios, Random& rng);
 
     /**
       Destructor

--- a/src/emucore/CartCV.cxx
+++ b/src/emucore/CartCV.cxx
@@ -26,7 +26,7 @@
 using namespace std;
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-CartridgeCV::CartridgeCV(const uInt8* image, uInt32 size)
+CartridgeCV::CartridgeCV(const uInt8* image, uInt32 size, Random& rng)
 {
   uInt32 addr;
   if(size == 2048)
@@ -38,11 +38,9 @@ CartridgeCV::CartridgeCV(const uInt8* image, uInt32 size)
     }
 
     // Initialize RAM with random values
-  class Random& random = Random::getInstance();
-
     for(uInt32 i = 0; i < 1024; ++i)
     {
-      myRAM[i] = random.next();
+      myRAM[i] = rng.next();
     }
   }
   else if(size == 4096)

--- a/src/emucore/CartCV.hxx
+++ b/src/emucore/CartCV.hxx
@@ -25,6 +25,7 @@ class Deserializer;
 
 #include "m6502/src/bspf/src/bspf.hxx"
 #include "Cart.hxx"
+#include "Random.hxx"
 
 /**
   Cartridge class used for Commavid's extra-RAM games.
@@ -43,8 +44,9 @@ class CartridgeCV : public Cartridge
       Create a new cartridge using the specified image
 
       @param image Pointer to the ROM image
+      @param rng A random number generator used to populate the initial extra RAM
     */
-    CartridgeCV(const uInt8* image, uInt32 size);
+    CartridgeCV(const uInt8* image, uInt32 size, Random& rng);
 
     /**
       Destructor

--- a/src/emucore/CartE7.cxx
+++ b/src/emucore/CartE7.cxx
@@ -26,7 +26,7 @@
 using namespace std;
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-CartridgeE7::CartridgeE7(const uInt8* image)
+CartridgeE7::CartridgeE7(const uInt8* image, Random& rng)
 {
   // Copy the ROM image into my buffer
   for(uInt32 addr = 0; addr < 16384; ++addr)
@@ -35,11 +35,9 @@ CartridgeE7::CartridgeE7(const uInt8* image)
   }
 
   // Initialize RAM with random values
-  class Random& random = Random::getInstance();
-
   for(uInt32 i = 0; i < 2048; ++i)
   {
-    myRAM[i] = random.next();
+    myRAM[i] = rng.next();
   }
 }
 

--- a/src/emucore/CartE7.hxx
+++ b/src/emucore/CartE7.hxx
@@ -25,6 +25,7 @@ class Deserializer;
 
 #include "m6502/src/bspf/src/bspf.hxx"
 #include "Cart.hxx"
+#include "Random.hxx"
 
 /**
   This is the cartridge class for M-Network bankswitched games.  
@@ -62,8 +63,9 @@ class CartridgeE7 : public Cartridge
       Create a new cartridge using the specified image
 
       @param image Pointer to the ROM image
+      @param rng A random number generator used to populate the initial extra RAM
     */
-    CartridgeE7(const uInt8* image);
+    CartridgeE7(const uInt8* image, Random& rng);
  
     /**
       Destructor

--- a/src/emucore/CartF4SC.cxx
+++ b/src/emucore/CartF4SC.cxx
@@ -26,7 +26,7 @@
 using namespace std;
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-CartridgeF4SC::CartridgeF4SC(const uInt8* image)
+CartridgeF4SC::CartridgeF4SC(const uInt8* image, Random& rng)
 {
   // Copy the ROM image into my buffer
   for(uInt32 addr = 0; addr < 32768; ++addr)
@@ -35,11 +35,9 @@ CartridgeF4SC::CartridgeF4SC(const uInt8* image)
   }
 
   // Initialize RAM with random values
-  class Random& random = Random::getInstance();
-
   for(uInt32 i = 0; i < 128; ++i)
   {
-    myRAM[i] = random.next();
+    myRAM[i] = rng.next();
   }
 }
 

--- a/src/emucore/CartF4SC.hxx
+++ b/src/emucore/CartF4SC.hxx
@@ -25,6 +25,7 @@ class Deserializer;
 
 #include "m6502/src/bspf/src/bspf.hxx"
 #include "Cart.hxx"
+#include "Random.hxx"
 
 /**
   Cartridge class used for Atari's 32K bankswitched games with
@@ -40,8 +41,9 @@ class CartridgeF4SC : public Cartridge
       Create a new cartridge using the specified image
 
       @param image Pointer to the ROM image
+      @param rng A random number generator used to populate the initial extra RAM
     */
-    CartridgeF4SC(const uInt8* image);
+    CartridgeF4SC(const uInt8* image, Random& rng);
  
     /**
       Destructor

--- a/src/emucore/CartF6SC.cxx
+++ b/src/emucore/CartF6SC.cxx
@@ -26,7 +26,7 @@
 using namespace std;
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-CartridgeF6SC::CartridgeF6SC(const uInt8* image)
+CartridgeF6SC::CartridgeF6SC(const uInt8* image, Random& rng)
 {
   // Copy the ROM image into my buffer
   for(uInt32 addr = 0; addr < 16384; ++addr)
@@ -35,11 +35,9 @@ CartridgeF6SC::CartridgeF6SC(const uInt8* image)
   }
 
   // Initialize RAM with random values
-  class Random& random = Random::getInstance();
-
   for(uInt32 i = 0; i < 128; ++i)
   {
-    myRAM[i] = random.next();
+    myRAM[i] = rng.next();
   }
 }
 

--- a/src/emucore/CartF6SC.hxx
+++ b/src/emucore/CartF6SC.hxx
@@ -25,6 +25,7 @@ class Deserializer;
 
 #include "m6502/src/bspf/src/bspf.hxx"
 #include "Cart.hxx"
+#include "Random.hxx"
 
 /**
   Cartridge class used for Atari's 16K bankswitched games with
@@ -40,8 +41,9 @@ class CartridgeF6SC : public Cartridge
       Create a new cartridge using the specified image
 
       @param image Pointer to the ROM image
+      @param rng A random number generator used to populate the initial extra RAM
     */
-    CartridgeF6SC(const uInt8* image);
+    CartridgeF6SC(const uInt8* image, Random& rng);
  
     /**
       Destructor

--- a/src/emucore/CartF8SC.cxx
+++ b/src/emucore/CartF8SC.cxx
@@ -26,7 +26,7 @@
 using namespace std;
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-CartridgeF8SC::CartridgeF8SC(const uInt8* image)
+CartridgeF8SC::CartridgeF8SC(const uInt8* image, Random& rng)
 {
   // Copy the ROM image into my buffer
   for(uInt32 addr = 0; addr < 8192; ++addr)
@@ -35,11 +35,9 @@ CartridgeF8SC::CartridgeF8SC(const uInt8* image)
   }
 
   // Initialize RAM with random values
-  class Random& random = Random::getInstance();
-
   for(uInt32 i = 0; i < 128; ++i)
   {
-    myRAM[i] = random.next();
+    myRAM[i] = rng.next();
   }
 }
 

--- a/src/emucore/CartF8SC.hxx
+++ b/src/emucore/CartF8SC.hxx
@@ -25,6 +25,7 @@ class Deserializer;
 
 #include "m6502/src/bspf/src/bspf.hxx"
 #include "Cart.hxx"
+#include "Random.hxx"
 
 /**
   Cartridge class used for Atari's 8K bankswitched games with
@@ -40,8 +41,9 @@ class CartridgeF8SC : public Cartridge
       Create a new cartridge using the specified image
 
       @param image Pointer to the ROM image
+      @param rng A random number generator used to populate the initial extra RAM
     */
-    CartridgeF8SC(const uInt8* image);
+    CartridgeF8SC(const uInt8* image, Random& rng);
  
     /**
       Destructor

--- a/src/emucore/CartFASC.cxx
+++ b/src/emucore/CartFASC.cxx
@@ -26,7 +26,7 @@
 using namespace std;
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-CartridgeFASC::CartridgeFASC(const uInt8* image)
+CartridgeFASC::CartridgeFASC(const uInt8* image, Random& rng)
 {
   // Copy the ROM image into my buffer
   for(uInt32 addr = 0; addr < 12288; ++addr)
@@ -35,11 +35,9 @@ CartridgeFASC::CartridgeFASC(const uInt8* image)
   }
 
   // Initialize RAM with random values
-  class Random& random = Random::getInstance();
-
   for(uInt32 i = 0; i < 256; ++i)
   {
-    myRAM[i] = random.next();
+    myRAM[i] = rng.next();
   }
 }
  

--- a/src/emucore/CartFASC.hxx
+++ b/src/emucore/CartFASC.hxx
@@ -25,6 +25,7 @@ class Deserializer;
 
 #include "m6502/src/bspf/src/bspf.hxx"
 #include "Cart.hxx"
+#include "Random.hxx"
 
 /**
   Cartridge class used for CBS' RAM Plus cartridges.  There are
@@ -40,8 +41,9 @@ class CartridgeFASC : public Cartridge
       Create a new cartridge using the specified image
 
       @param image Pointer to the ROM image
+      @param rng A random number generator used to populate the initial extra RAM
     */
-    CartridgeFASC(const uInt8* image);
+    CartridgeFASC(const uInt8* image, Random& rng);
  
     /**
       Destructor

--- a/src/emucore/CartMC.cxx
+++ b/src/emucore/CartMC.cxx
@@ -26,7 +26,7 @@
 using namespace std;
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-CartridgeMC::CartridgeMC(const uInt8* image, uInt32 size)
+CartridgeMC::CartridgeMC(const uInt8* image, uInt32 size, Random& rng)
   : mySlot3Locked(false)
 {
   uInt32 i;
@@ -38,11 +38,9 @@ CartridgeMC::CartridgeMC(const uInt8* image, uInt32 size)
   myRAM = new uInt8[32 * 1024];
 
   // Initialize RAM with random values
-  class Random& random = Random::getInstance();
-
   for(i = 0; i < 32 * 1024; ++i)
   {
-    myRAM[i] = random.next();
+    myRAM[i] = rng.next();
   }
 
   // Allocate array for the ROM image

--- a/src/emucore/CartMC.hxx
+++ b/src/emucore/CartMC.hxx
@@ -25,6 +25,7 @@ class Deserializer;
 
 #include "m6502/src/bspf/src/bspf.hxx"
 #include "Cart.hxx"
+#include "Random.hxx"
 
 /**
   This is the cartridge class for Chris Wilkson's Megacart.  It does not 
@@ -147,8 +148,9 @@ class CartridgeMC : public Cartridge
 
       @param image Pointer to the ROM image
       @param size The size of the ROM image
+      @param rng A random number generator used to populate the initial extra RAM
     */
-    CartridgeMC(const uInt8* image, uInt32 size);
+    CartridgeMC(const uInt8* image, uInt32 size, Random& rng);
  
     /**
       Destructor

--- a/src/emucore/OSystem.cxx
+++ b/src/emucore/OSystem.cxx
@@ -600,7 +600,7 @@ bool OSystem::queryConsoleInfo(const uInt8* image, uInt32 size,
     s = mySettings->getString("hmove");
     if(s != "") props.set(Emulation_HmoveBlanks, s);
 
-  *cart = Cartridge::create(image, size, props, *mySettings);
+  *cart = Cartridge::create(image, size, props, *mySettings, myRandGen);
   if(!*cart)
     return false;
 

--- a/src/emucore/Random.cxx
+++ b/src/emucore/Random.cxx
@@ -25,9 +25,6 @@
 #include <random>
 #include <sstream>
 
-// A static Random object for compatibility purposes. Don't use this.
-Random Random::s_random;
-
 // Implementation of Random's random number generator wrapper. 
 class Random::Impl {
   
@@ -107,10 +104,6 @@ uInt32 Random::next()
 double Random::nextDouble()
 {
   return m_pimpl->nextDouble();
-}
-
-Random& Random::getInstance() {
-  return s_random;
 }
 
 bool Random::saveState(Serializer& ser) {

--- a/src/emucore/Random.hxx
+++ b/src/emucore/Random.hxx
@@ -61,10 +61,6 @@ class Random
     */
     double nextDouble();
 
-    // Returns a static Random object. DO NOT USE THIS. This is mostly meant for use by the
-    // code for the various cartridges. 
-    static Random& getInstance();
-
     /**
       Serializes the RNG state.
     */
@@ -80,9 +76,6 @@ class Random
     // Actual rng (implementation hidden away from the header to avoid depending on rng libraries). 
     class Impl;
     Impl *m_pimpl;
-
-    // A static Random object. Don't use this.
-    static Random s_random;
 };
 #endif
 


### PR DESCRIPTION
Instead, forward the OSystem's RNG to each cartridge constructor that
needs randomess (to initialize memory).

This makes the system more deterministic.