### PR TITLE
[emucore/Cart] Make "about string" part of the state

### DIFF
--- a/src/emucore/Cart.cxx
+++ b/src/emucore/Cart.cxx
@@ -86,7 +86,6 @@ Cartridge* Cartridge::create(const uInt8* image, uInt32 size,
     type = detected;
   }
   buf << endl;
-  myAboutString = buf.str();
 
   // We should know the cart's type by now so let's create it
   if(type == "2K")
@@ -138,6 +137,7 @@ Cartridge* Cartridge::create(const uInt8* image, uInt32 size,
   else
     ale::Logger::Error << "ERROR: Invalid cartridge type " << type << " ..." << endl;
 
+  cartridge->myAboutString = buf.str();
   return cartridge;
 }
 
@@ -467,6 +467,3 @@ Cartridge& Cartridge::operator = (const Cartridge&)
   assert(false);
   return *this;
 }
-
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-string Cartridge::myAboutString;

--- a/src/emucore/Cart.hxx
+++ b/src/emucore/Cart.hxx
@@ -66,7 +66,7 @@ class Cartridge : public Device
     /**
       Query some information about this cartridge.
     */
-    static const std::string& about() { return myAboutString; }
+    const std::string& about() const { return myAboutString; }
 
     /**
       Save the internal (patched) ROM image.
@@ -127,6 +127,9 @@ class Cartridge : public Device
     // If bankLocked is true, ignore attempts at bankswitching. This is used
     // by the debugger, when disassembling/dumping ROM.
     bool bankLocked;
+
+    // Info about this cartridge in string format
+    std::string myAboutString;
 
   private:
     /**
@@ -194,9 +197,6 @@ class Cartridge : public Device
     static bool isProbablyFE(const uInt8* image, uInt32 size);
 
   private:
-    // Contains info about this cartridge in string format
-    static std::string myAboutString;
-
     // Copy constructor isn't supported by cartridges so make it private
     Cartridge(const Cartridge&);
 


### PR DESCRIPTION
Previously, it was a static variable, which is difficult to use in complex situations.