### PR TITLE
[ale_interface, main] Move I/O buffer handling to main

### DIFF
--- a/src/ale_interface.cpp
+++ b/src/ale_interface.cpp
@@ -60,15 +60,6 @@ std::string ALEInterface::welcomeMessage() {
   return oss.str();
 }
 
-void ALEInterface::disableBufferedIO() {
-  setvbuf(stdout, NULL, _IONBF, 0);
-  setvbuf(stdin, NULL, _IONBF, 0);
-  std::cin.rdbuf()->pubsetbuf(0, 0);
-  std::cout.rdbuf()->pubsetbuf(0, 0);
-  std::cin.sync_with_stdio();
-  std::cout.sync_with_stdio();
-}
-
 void ALEInterface::createOSystem(std::unique_ptr<OSystem>& theOSystem,
                                  std::unique_ptr<Settings>& theSettings) {
 #if (defined(WIN32) || defined(__MINGW32__))
@@ -150,13 +141,11 @@ void ALEInterface::loadSettings(const std::string& romfile,
 }
 
 ALEInterface::ALEInterface() {
-  disableBufferedIO();
   Logger::Info << welcomeMessage() << std::endl;
   createOSystem(theOSystem, theSettings);
 }
 
 ALEInterface::ALEInterface(bool display_screen) {
-  disableBufferedIO();
   Logger::Info << welcomeMessage() << std::endl;
   createOSystem(theOSystem, theSettings);
   this->setBool("display_screen", display_screen);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,8 +10,10 @@
  * *****************************************************************************
  */
 
+#include <cstdio>
 #include <cstdlib>
 #include <ctime>
+#include <iostream>
 #include <memory>
 #include <sstream>
 
@@ -69,7 +71,13 @@ ALEController* createController(OSystem* osystem, std::string type) {
 
 /* application entry point */
 int main(int argc, char* argv[]) {
-  ale::ALEInterface::disableBufferedIO();
+  // Disable buffered I/O.
+  setvbuf(stdout, NULL, _IONBF, 0);
+  setvbuf(stdin, NULL, _IONBF, 0);
+  std::cin.rdbuf()->pubsetbuf(0, 0);
+  std::cout.rdbuf()->pubsetbuf(0, 0);
+  std::cin.sync_with_stdio();
+  std::cout.sync_with_stdio();
 
   std::cerr << ale::ALEInterface::welcomeMessage() << std::endl;
 


### PR DESCRIPTION
The state of I/O buffering is global and should not be modified
arbitrarily from within a library. Rather, it should be set only by
the entry point.