### PR TITLE
Ported pacman, surround, videochess from xitari

### DIFF
--- a/md5.txt
+++ b/md5.txt
@@ -1,4 +1,4 @@
-The following is a list of the md5 checksums for the various roms supported by ALE. 
+The following is a list of the md5 checksums for the various roms supported by ALE.
 
 35be55426c1fec32dfb503b4f0651572 air_raid.bin
 f1a0a23e6464d954e3a9579c4ccd01c8 alien.bin
@@ -73,6 +73,7 @@ fb27afe896e7c928089307b32e5642ee trondead.bin
 a499d720e7ee35c62424de882a3351b6 up_n_down.bin
 3e899eba0ca8cd2972da1ae5479b4f0d venture.bin
 107cc025334211e6d29da0b6be46aec7 video_pinball.bin
+f0b7db930ca0e548c41a97160b9f6275 videochess.bin
 7e8aa18bc9502eb57daaf5e7c1e94da7 wizard_of_wor.bin
 c5930d0e8cdae3e037349bfa08e871be yars_revenge.bin
 eea0da9b987d661264cce69a7c13c3bd zaxxon.bin

--- a/src/common/Constants.h
+++ b/src/common/Constants.h
@@ -66,7 +66,6 @@ enum Action {
   SAVE_STATE             = 43,
   LOAD_STATE             = 44,
   SYSTEM_RESET           = 45,
-  SELECT                 = 46, // Used to select game mode... should only be used internally 
   LAST_ACTION_INDEX      = 50
 };
 

--- a/src/common/Constants.h
+++ b/src/common/Constants.h
@@ -66,6 +66,7 @@ enum Action {
   SAVE_STATE             = 43,
   LOAD_STATE             = 44,
   SYSTEM_RESET           = 45,
+  SELECT                 = 46, // Used to select game mode... should only be used internally 
   LAST_ACTION_INDEX      = 50
 };
 

--- a/src/games/Roms.cpp
+++ b/src/games/Roms.cpp
@@ -63,6 +63,7 @@
 #include "supported/MrDo.hpp"
 #include "supported/MsPacman.hpp"
 #include "supported/NameThisGame.hpp"
+#include "supported/Pacman.hpp"
 #include "supported/Phoenix.hpp"
 #include "supported/Pitfall.hpp"
 #include "supported/Pong.hpp"
@@ -78,6 +79,7 @@
 #include "supported/Solaris.hpp"
 #include "supported/SpaceInvaders.hpp"
 #include "supported/StarGunner.hpp"
+#include "supported/Surround.hpp"
 #include "supported/Tennis.hpp"
 #include "supported/Tetris.hpp"
 #include "supported/TimePilot.hpp"
@@ -87,6 +89,7 @@
 #include "supported/UpNDown.hpp"
 #include "supported/Venture.hpp"
 #include "supported/VideoPinball.hpp"
+#include "supported/VideoChess.hpp"
 #include "supported/WizardOfWor.hpp"
 #include "supported/YarsRevenge.hpp"
 #include "supported/Zaxxon.hpp"
@@ -144,6 +147,7 @@ static const RomSettings* roms[] = {
     new MrDoSettings(),
     new MsPacmanSettings(),
     new NameThisGameSettings(),
+    new PacmanSettings(),
     new PhoenixSettings(),
     new PitfallSettings(),
     new PongSettings(),
@@ -159,6 +163,7 @@ static const RomSettings* roms[] = {
     new SolarisSettings(),
     new SpaceInvadersSettings(),
     new StarGunnerSettings(),
+    new SurroundSettings(),
     new TennisSettings(),
     new TetrisSettings(),
     new TimePilotSettings(),
@@ -167,6 +172,7 @@ static const RomSettings* roms[] = {
     new TutankhamSettings(),
     new UpNDownSettings(),
     new VentureSettings(),
+    new VideoChessSettings(),
     new VideoPinballSettings(),
     new WizardOfWorSettings(),
     new YarsRevengeSettings(),

--- a/src/games/module.mk
+++ b/src/games/module.mk
@@ -55,6 +55,7 @@ MODULE_OBJS := \
 	src/games/supported/NameThisGame.o \
 	src/games/supported/Phoenix.o \
 	src/games/supported/Pitfall.o \
+	src/games/supported/Pacman.o \
 	src/games/supported/Pong.o \
 	src/games/supported/Pooyan.o \
 	src/games/supported/PrivateEye.o \
@@ -68,6 +69,7 @@ MODULE_OBJS := \
 	src/games/supported/Solaris.o \
 	src/games/supported/SpaceInvaders.o \
 	src/games/supported/StarGunner.o \
+	src/games/supported/Surround.o \
 	src/games/supported/Tennis.o \
 	src/games/supported/Tetris.o \
 	src/games/supported/TimePilot.o \
@@ -77,6 +79,7 @@ MODULE_OBJS := \
 	src/games/supported/UpNDown.o \
 	src/games/supported/Venture.o \
 	src/games/supported/VideoPinball.o \
+	src/games/supported/VideoChess.o \
 	src/games/supported/WizardOfWor.o \
 	src/games/supported/YarsRevenge.o \
 	src/games/supported/Zaxxon.o \
@@ -84,5 +87,5 @@ MODULE_OBJS := \
 MODULE_DIRS += \
 	src/games
 
-# Include common rules 
+# Include common rules
 include $(srcdir)/common.rules

--- a/src/games/supported/Pacman.cpp
+++ b/src/games/supported/Pacman.cpp
@@ -1,0 +1,127 @@
+/* *****************************************************************************
+ * 
+ * This wrapper was authored by Stig Petersen, March 2014
+ * 
+ * Xitari
+ *
+ * Copyright 2014 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 2
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * *****************************************************************************
+ * A.L.E (Arcade Learning Environment)
+ * Copyright (c) 2009-2013 by Yavar Naddaf, Joel Veness, Marc G. Bellemare and 
+ *   the Reinforcement Learning and Artificial Intelligence Laboratory
+ * Released under the GNU General Public License; see License.txt for details. 
+ *
+ * Based on: Stella  --  "An Atari 2600 VCS Emulator"
+ * Copyright (c) 1995-2007 by Bradford W. Mott and the Stella team
+ *
+ * *****************************************************************************
+ */
+#include "Pacman.hpp"
+
+#include "../RomUtils.hpp"
+
+
+using namespace ale;
+
+
+PacmanSettings::PacmanSettings() {
+
+    reset();
+}
+
+
+/* create a new instance of the rom */
+RomSettings* PacmanSettings::clone() const { 
+    
+    RomSettings* rval = new PacmanSettings();
+    *rval = *this;
+    return rval;
+}
+
+
+/* process the latest information from ALE */
+void PacmanSettings::step(const System& system) {
+  
+    reward_t score = getDecimalScore(0xCC, 0xCE, 0xD0, &system);
+
+    // update the reward
+    m_reward = score - m_score;
+    m_score = score;
+
+    // update terminal status
+    m_lives = readRam(&system, 0x98) + 1;
+	int animationCounter = readRam(&system, 0xE4);
+    m_terminal = m_lives == 1 && animationCounter == 0x3F;
+}
+
+
+/* is end of game */
+bool PacmanSettings::isTerminal() const {
+
+    return m_terminal;
+};
+
+
+/* get the most recently observed reward */
+reward_t PacmanSettings::getReward() const { 
+
+    return m_reward; 
+}
+
+
+/* is an action part of the minimal set? */
+bool PacmanSettings::isMinimal(const Action &a) const {
+
+    switch (a) {
+        case PLAYER_A_NOOP:
+        case PLAYER_A_UP:
+        case PLAYER_A_RIGHT:
+        case PLAYER_A_LEFT:
+        case PLAYER_A_DOWN:
+            return true;
+        default:
+            return false;
+    }   
+}
+
+
+/* reset the state of the game */
+void PacmanSettings::reset() {
+    
+    m_reward   = 0;
+    m_score    = 0;
+    m_terminal = false;
+    m_lives    = 4;
+}
+
+
+        
+/* saves the state of the rom settings */
+void PacmanSettings::saveState(Serializer & ser) {
+  ser.putInt(m_reward);
+  ser.putInt(m_score);
+  ser.putBool(m_terminal);
+  ser.putInt(m_lives);
+}
+
+// loads the state of the rom settings
+void PacmanSettings::loadState(Deserializer & ser) {
+  m_reward = ser.getInt();
+  m_score = ser.getInt();
+  m_terminal = ser.getBool();
+  m_lives = ser.getInt();
+}
+

--- a/src/games/supported/Pacman.cpp
+++ b/src/games/supported/Pacman.cpp
@@ -1,10 +1,5 @@
 /* *****************************************************************************
- * 
- * This wrapper was authored by Stig Petersen, March 2014
- * 
- * Xitari
- *
- * Copyright 2014 Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -20,9 +15,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  * *****************************************************************************
  * A.L.E (Arcade Learning Environment)
- * Copyright (c) 2009-2013 by Yavar Naddaf, Joel Veness, Marc G. Bellemare and 
+ * Copyright (c) 2009-2013 by Yavar Naddaf, Joel Veness, Marc G. Bellemare and
  *   the Reinforcement Learning and Artificial Intelligence Laboratory
- * Released under the GNU General Public License; see License.txt for details. 
+ * Released under the GNU General Public License; see License.txt for details.
  *
  * Based on: Stella  --  "An Atari 2600 VCS Emulator"
  * Copyright (c) 1995-2007 by Bradford W. Mott and the Stella team
@@ -44,8 +39,8 @@ PacmanSettings::PacmanSettings() {
 
 
 /* create a new instance of the rom */
-RomSettings* PacmanSettings::clone() const { 
-    
+RomSettings* PacmanSettings::clone() const {
+
     RomSettings* rval = new PacmanSettings();
     *rval = *this;
     return rval;
@@ -54,7 +49,7 @@ RomSettings* PacmanSettings::clone() const {
 
 /* process the latest information from ALE */
 void PacmanSettings::step(const System& system) {
-  
+
     reward_t score = getDecimalScore(0xCC, 0xCE, 0xD0, &system);
 
     // update the reward
@@ -76,9 +71,9 @@ bool PacmanSettings::isTerminal() const {
 
 
 /* get the most recently observed reward */
-reward_t PacmanSettings::getReward() const { 
+reward_t PacmanSettings::getReward() const {
 
-    return m_reward; 
+    return m_reward;
 }
 
 
@@ -94,13 +89,13 @@ bool PacmanSettings::isMinimal(const Action &a) const {
             return true;
         default:
             return false;
-    }   
+    }
 }
 
 
 /* reset the state of the game */
 void PacmanSettings::reset() {
-    
+
     m_reward   = 0;
     m_score    = 0;
     m_terminal = false;
@@ -108,7 +103,7 @@ void PacmanSettings::reset() {
 }
 
 
-        
+
 /* saves the state of the rom settings */
 void PacmanSettings::saveState(Serializer & ser) {
   ser.putInt(m_reward);
@@ -124,4 +119,3 @@ void PacmanSettings::loadState(Deserializer & ser) {
   m_terminal = ser.getBool();
   m_lives = ser.getInt();
 }
-

--- a/src/games/supported/Pacman.hpp
+++ b/src/games/supported/Pacman.hpp
@@ -1,0 +1,86 @@
+/* *****************************************************************************
+ * 
+ * This wrapper was authored by Stig Petersen, March 2014
+ *
+ * Xitari
+ *
+ * Copyright 2014 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 2
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * *****************************************************************************
+ * A.L.E (Arcade Learning Environment)
+ * Copyright (c) 2009-2013 by Yavar Naddaf, Joel Veness, Marc G. Bellemare and 
+ *   the Reinforcement Learning and Artificial Intelligence Laboratory
+ * Released under the GNU General Public License; see License.txt for details. 
+ *
+ * Based on: Stella  --  "An Atari 2600 VCS Emulator"
+ * Copyright (c) 1995-2007 by Bradford W. Mott and the Stella team
+ *
+ * *****************************************************************************
+ */
+#ifndef __PACMAN_HPP__
+#define __PACMAN_HPP__
+
+#include "../RomSettings.hpp"
+
+namespace ale {
+
+/* RL wrapper for Pacman */
+class PacmanSettings : public RomSettings {
+
+    public:
+
+        PacmanSettings();
+
+        // reset
+        void reset();
+
+        // is end of game
+        bool isTerminal() const;
+
+        // get the most recently observed reward
+        reward_t getReward() const;
+
+        // the rom-name
+        const char* rom() const { return "pacman"; }
+
+        // create a new instance of the rom
+        RomSettings* clone() const;
+
+        // is an action part of the minimal set?
+        bool isMinimal(const Action& a) const;
+
+        // process the latest information from ALE
+        void step(const System& system);
+
+        // saves the state of the rom settings
+        void saveState(Serializer & ser);
+    
+        // loads the state of the rom settings
+        void loadState(Deserializer & ser);
+
+        virtual int lives() const { return isTerminal() ? 0 : m_lives; }
+
+    private:
+
+        bool m_terminal;
+        reward_t m_reward;
+        reward_t m_score;
+        int m_lives;
+};
+
+} // namespace ale
+
+#endif // __PACMAN_HPP__
+

--- a/src/games/supported/Pacman.hpp
+++ b/src/games/supported/Pacman.hpp
@@ -1,10 +1,5 @@
 /* *****************************************************************************
- * 
- * This wrapper was authored by Stig Petersen, March 2014
- *
- * Xitari
- *
- * Copyright 2014 Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -20,9 +15,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  * *****************************************************************************
  * A.L.E (Arcade Learning Environment)
- * Copyright (c) 2009-2013 by Yavar Naddaf, Joel Veness, Marc G. Bellemare and 
+ * Copyright (c) 2009-2013 by Yavar Naddaf, Joel Veness, Marc G. Bellemare and
  *   the Reinforcement Learning and Artificial Intelligence Laboratory
- * Released under the GNU General Public License; see License.txt for details. 
+ * Released under the GNU General Public License; see License.txt for details.
  *
  * Based on: Stella  --  "An Atari 2600 VCS Emulator"
  * Copyright (c) 1995-2007 by Bradford W. Mott and the Stella team
@@ -66,7 +61,7 @@ class PacmanSettings : public RomSettings {
 
         // saves the state of the rom settings
         void saveState(Serializer & ser);
-    
+
         // loads the state of the rom settings
         void loadState(Deserializer & ser);
 
@@ -83,4 +78,3 @@ class PacmanSettings : public RomSettings {
 } // namespace ale
 
 #endif // __PACMAN_HPP__
-

--- a/src/games/supported/Surround.cpp
+++ b/src/games/supported/Surround.cpp
@@ -1,0 +1,129 @@
+/* *****************************************************************************
+ * Xitari
+ *
+ * Copyright 2014 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 2
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * *****************************************************************************
+ * A.L.E (Arcade Learning Environment)
+ * Copyright (c) 2009-2013 by Yavar Naddaf, Joel Veness, Marc G. Bellemare and
+ *   the Reinforcement Learning and Artificial Intelligence Laboratory
+ * Released under the GNU General Public License; see License.txt for details.
+ *
+ * Based on: Stella  --  "An Atari 2600 VCS Emulator"
+ * Copyright (c) 1995-2007 by Bradford W. Mott and the Stella team
+ *
+ * *****************************************************************************
+ */
+#include "Surround.hpp"
+#include "ale_interface.hpp"
+#include "../RomUtils.hpp"
+
+
+using namespace ale;
+
+
+SurroundSettings::SurroundSettings() {
+    reset();
+}
+
+
+/* create a new instance of the rom */
+RomSettings* SurroundSettings::clone() const {
+
+    RomSettings* rval = new SurroundSettings();
+    *rval = *this;
+    return rval;
+}
+
+
+/* process the latest information from ALE */
+void SurroundSettings::step(const System& system) {
+
+    int theirScore = getDecimalScore(0xF6, &system);
+    int myScore = getDecimalScore(0xF7, &system);
+
+    // The RL score is the difference in scores
+    int newScore = myScore - theirScore;
+    m_reward = newScore - m_score;
+    m_score = newScore;
+
+    // The game ends when we reach 10 points
+    m_terminal = (theirScore == 10 || myScore == 10);
+}
+
+
+/* is end of game */
+bool SurroundSettings::isTerminal() const {
+
+    return m_terminal;
+};
+
+
+/* get the most recently observed reward */
+reward_t SurroundSettings::getReward() const {
+
+    return m_reward;
+}
+
+
+/* is an action part of the minimal set? */
+bool SurroundSettings::isMinimal(const Action &a) const {
+
+    switch (a) {
+        case PLAYER_A_NOOP:
+        case PLAYER_A_LEFT:
+        case PLAYER_A_RIGHT:
+        case PLAYER_A_UP:
+        case PLAYER_A_DOWN:
+            return true;
+        default:
+            return false;
+    }
+}
+
+
+/* reset the state of the game */
+void SurroundSettings::reset() {
+
+    m_reward   = 0;
+    m_score    = 0;
+    m_terminal = false;
+}
+
+
+/* saves the state of the rom settings */
+void SurroundSettings::saveState(Serializer & ser) {
+  ser.putInt(m_reward);
+  ser.putInt(m_score);
+  ser.putBool(m_terminal);
+}
+
+// loads the state of the rom settings
+void SurroundSettings::loadState(Deserializer & ser) {
+  m_reward = ser.getInt();
+  m_score = ser.getInt();
+  m_terminal = ser.getBool();
+}
+
+ActionVect SurroundSettings::getStartingActions() {
+
+    // This is allocated here rather than once per instantiation to ensure thread safety
+    ActionVect vec;
+
+    // Select game, then reset again
+    vec.push_back(RESET);
+
+    return vec;
+}

--- a/src/games/supported/Surround.cpp
+++ b/src/games/supported/Surround.cpp
@@ -1,7 +1,5 @@
 /* *****************************************************************************
- * Xitari
- *
- * Copyright 2014 Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2

--- a/src/games/supported/Surround.hpp
+++ b/src/games/supported/Surround.hpp
@@ -1,0 +1,93 @@
+/* *****************************************************************************
+ * Xitari
+ *
+ * Copyright 2014 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 2
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * *****************************************************************************
+ * A.L.E (Arcade Learning Environment)
+ * Copyright (c) 2009-2013 by Yavar Naddaf, Joel Veness, Marc G. Bellemare and 
+ *   the Reinforcement Learning and Artificial Intelligence Laboratory
+ * Released under the GNU General Public License; see License.txt for details. 
+ *
+ * Based on: Stella  --  "An Atari 2600 VCS Emulator"
+ * Copyright (c) 1995-2007 by Bradford W. Mott and the Stella team
+ *
+ * *****************************************************************************
+ */
+#ifndef __SURROUND_HPP__
+#define __SURROUND_HPP__
+
+#include "../RomSettings.hpp"
+
+namespace ale {
+
+// RL wrapper for SpaceInvaders
+class SurroundSettings : public RomSettings {
+
+    public:
+
+        SurroundSettings();
+
+        // reset
+        void reset();
+
+        // is end of game
+        bool isTerminal() const;
+
+        // get the most recently observed reward
+        reward_t getReward() const;
+
+        // the rom-name
+        const char* rom() const { return "surround"; }
+
+        // create a new instance of the rom
+        RomSettings* clone() const;
+
+        // is an action part of the minimal set?
+        bool isMinimal(const Action& a) const;
+
+        // process the latest information from ALE
+        void step(const System& system);
+
+        // saves the state of the rom settings
+        void saveState(Serializer & ser);
+    
+        // loads the state of the rom settings
+        void loadState(Deserializer & ser);
+
+        // Minimum possible instantaneous reward. 
+        reward_t minReward() const { return -1; }
+
+        // Maximum possible instantaneous reward.
+        reward_t maxReward() const { return 1; }
+
+        // Returns a list of actions required to start the game & set it in 'computer' mode. 
+        virtual ActionVect getStartingActions();
+
+        virtual int lives() const { return 0; } 
+
+        virtual bool swapPorts() const { return true; }
+
+    private:
+
+        bool m_terminal;
+        reward_t m_reward;
+        reward_t m_score;
+};
+
+} // namespace ale
+
+#endif // __SURROUND_HPP__
+

--- a/src/games/supported/Surround.hpp
+++ b/src/games/supported/Surround.hpp
@@ -1,7 +1,5 @@
 /* *****************************************************************************
- * Xitari
- *
- * Copyright 2014 Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -17,9 +15,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  * *****************************************************************************
  * A.L.E (Arcade Learning Environment)
- * Copyright (c) 2009-2013 by Yavar Naddaf, Joel Veness, Marc G. Bellemare and 
+ * Copyright (c) 2009-2013 by Yavar Naddaf, Joel Veness, Marc G. Bellemare and
  *   the Reinforcement Learning and Artificial Intelligence Laboratory
- * Released under the GNU General Public License; see License.txt for details. 
+ * Released under the GNU General Public License; see License.txt for details.
  *
  * Based on: Stella  --  "An Atari 2600 VCS Emulator"
  * Copyright (c) 1995-2007 by Bradford W. Mott and the Stella team
@@ -63,20 +61,20 @@ class SurroundSettings : public RomSettings {
 
         // saves the state of the rom settings
         void saveState(Serializer & ser);
-    
+
         // loads the state of the rom settings
         void loadState(Deserializer & ser);
 
-        // Minimum possible instantaneous reward. 
+        // Minimum possible instantaneous reward.
         reward_t minReward() const { return -1; }
 
         // Maximum possible instantaneous reward.
         reward_t maxReward() const { return 1; }
 
-        // Returns a list of actions required to start the game & set it in 'computer' mode. 
+        // Returns a list of actions required to start the game & set it in 'computer' mode.
         virtual ActionVect getStartingActions();
 
-        virtual int lives() const { return 0; } 
+        virtual int lives() const { return 0; }
 
         virtual bool swapPorts() const { return true; }
 
@@ -90,4 +88,3 @@ class SurroundSettings : public RomSettings {
 } // namespace ale
 
 #endif // __SURROUND_HPP__
-

--- a/src/games/supported/VideoChess.cpp
+++ b/src/games/supported/VideoChess.cpp
@@ -1,0 +1,224 @@
+/* *****************************************************************************
+ *
+ * This wrapper was authored by Stig Petersen, March 2014
+ *
+ * Xitari
+ *
+ * Copyright 2014 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 2
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * *****************************************************************************
+ * A.L.E (Arcade Learning Environment)
+ * Copyright (c) 2009-2013 by Yavar Naddaf, Joel Veness, Marc G. Bellemare and
+ *   the Reinforcement Learning and Artificial Intelligence Laboratory
+ * Released under the GNU General Public License; see License.txt for details.
+ *
+ * Based on: Stella  --  "An Atari 2600 VCS Emulator"
+ * Copyright (c) 1995-2007 by Bradford W. Mott and the Stella team
+ *
+ * *****************************************************************************
+ */
+#include "VideoChess.hpp"
+
+#include "../RomUtils.hpp"
+
+
+using namespace ale;
+
+
+VideoChessSettings::VideoChessSettings() {
+
+    reset();
+}
+
+
+/* create a new instance of the rom */
+RomSettings* VideoChessSettings::clone() const {
+
+    RomSettings* rval = new VideoChessSettings();
+    *rval = *this;
+    return rval;
+}
+
+
+/* Calculate the material value based on pieces present on the board */
+int VideoChessSettings::CalculateMaterialValue(const System& system) const {
+//    const int KING_VALUE    = 10000;
+    const int QUEEN_VALUE   = 9;
+    const int ROOK_VALUE    = 5;
+    const int KNIGHT_VALUE  = 3;
+    const int BISHOP_VALUE  = 3;
+    const int PAWN_VALUE    = 1;
+
+//    const int BLACK_KING_ID     = 0x01;
+    const int BLACK_QUEEN_ID    = 0x02;
+    const int BLACK_BISHOP_ID   = 0x03;
+    const int BLACK_KNIGHT_ID   = 0x04;
+    const int BLACK_ROOK_ID     = 0x05;
+    const int BLACK_PAWN_ID     = 0x06;
+//    const int WHITE_KING_ID     = 0x09;
+    const int WHITE_QUEEN_ID    = 0x0A;
+    const int WHITE_BISHOP_ID   = 0x0B;
+    const int WHITE_KNIGHT_ID   = 0x0C;
+    const int WHITE_ROOK_ID     = 0x0D;
+    const int WHITE_PAWN_ID     = 0x0E;
+
+    int totalMaterialValue = 0;
+
+    // Loop through board squares and sum up material values
+    for (int address = 0x80; address < 0xC0; ++address) {
+        int squareState = (readRam(&system, address) & 0x0F);
+        switch (squareState) {
+        case BLACK_QUEEN_ID:
+            totalMaterialValue -= QUEEN_VALUE;
+            break;
+        case BLACK_BISHOP_ID:
+            totalMaterialValue -= BISHOP_VALUE;
+            break;
+        case BLACK_KNIGHT_ID:
+            totalMaterialValue -= KNIGHT_VALUE;
+            break;
+        case BLACK_ROOK_ID:
+            totalMaterialValue -= ROOK_VALUE;
+            break;
+        case BLACK_PAWN_ID:
+            totalMaterialValue -= PAWN_VALUE;
+            break;
+        case WHITE_QUEEN_ID:
+            totalMaterialValue += QUEEN_VALUE;
+            break;
+        case WHITE_BISHOP_ID:
+            totalMaterialValue += BISHOP_VALUE;
+            break;
+        case WHITE_KNIGHT_ID:
+            totalMaterialValue += KNIGHT_VALUE;
+            break;
+        case WHITE_ROOK_ID:
+            totalMaterialValue += ROOK_VALUE;
+            break;
+        case WHITE_PAWN_ID:
+            totalMaterialValue += PAWN_VALUE;
+            break;
+        }
+    }
+
+    return totalMaterialValue;
+}
+
+
+/* process the latest information from ALE */
+void VideoChessSettings::step(const System& system) {
+
+    // TURN_BLACK = 0x0;
+    const int TURN_WHITE = 0x82;
+    int currentPlayer = readRam(&system, 0xE1);
+
+    if (currentPlayer == TURN_WHITE) {
+
+        int materialValue = CalculateMaterialValue(system);
+        m_reward = materialValue - m_materialValue;
+        m_materialValue = materialValue;
+
+        // 0xEE == 0: check mate black
+        // 0xEE == 1: check mate white
+        // 0xEE == 3: game ongoing
+        const int CHECK_MATE_BLACK = 0x00;
+        const int CHECK_MATE_WHITE = 0x01;
+        int checkMateByte = readRam(&system, 0xEE);
+
+        const int CHECK_MATE_REWARD = 10000;
+
+        if (checkMateByte == CHECK_MATE_BLACK) {
+            m_reward += CHECK_MATE_REWARD;
+            m_terminal = true;
+        }
+        else if (checkMateByte == CHECK_MATE_WHITE) {
+            m_reward -= CHECK_MATE_REWARD;
+            m_terminal = true;
+        }
+    }
+    else // Atari AI simulates moves while it searches the tree, so we want to ignore those
+    {
+        m_reward = 0;
+    }
+
+    // 0xE4: Number of moves by black
+
+    // Notes on addresses that change when players make a move
+    // E0*, E1=82/0 , E2*, E3*, E4*, E5=FF/80/0C, E6*, E7*, E8*, E9*, EA*, EB=40/98, EC*, ED*, *EE, *EF
+    // *change wildly during colour flashes
+}
+
+
+/* is end of game */
+bool VideoChessSettings::isTerminal() const {
+
+    return m_terminal;
+};
+
+
+/* get the most recently observed reward */
+reward_t VideoChessSettings::getReward() const {
+
+    return m_reward;
+}
+
+
+/* is an action part of the minimal set? */
+bool VideoChessSettings::isMinimal(const Action &a) const {
+
+    switch (a) {
+        case PLAYER_A_NOOP:
+        case PLAYER_A_FIRE:
+        case PLAYER_A_UP:
+        case PLAYER_A_RIGHT:
+        case PLAYER_A_LEFT:
+        case PLAYER_A_DOWN:
+        case PLAYER_A_UPRIGHT:
+        case PLAYER_A_UPLEFT:
+        case PLAYER_A_DOWNRIGHT:
+        case PLAYER_A_DOWNLEFT:
+            return true;
+        default:
+            return false;
+    }
+}
+
+
+/* reset the state of the game */
+void VideoChessSettings::reset() {
+
+    m_reward   = 0;
+    m_terminal = false;
+    m_lives    = 1;
+    m_materialValue = 0;
+}
+
+
+/* saves the state of the rom settings */
+void VideoChessSettings::saveState(Serializer & ser) {
+  ser.putInt(m_reward);
+  ser.putBool(m_terminal);
+  ser.putInt(m_lives);
+  ser.putInt(m_materialValue);
+}
+
+// loads the state of the rom settings
+void VideoChessSettings::loadState(Deserializer & ser) {
+  m_reward = ser.getInt();
+  m_terminal = ser.getBool();
+  m_lives = ser.getInt();
+  m_materialValue = ser.getInt();
+}
+

--- a/src/games/supported/VideoChess.cpp
+++ b/src/games/supported/VideoChess.cpp
@@ -1,10 +1,5 @@
 /* *****************************************************************************
- *
- * This wrapper was authored by Stig Petersen, March 2014
- *
- * Xitari
- *
- * Copyright 2014 Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -221,4 +216,3 @@ void VideoChessSettings::loadState(Deserializer & ser) {
   m_lives = ser.getInt();
   m_materialValue = ser.getInt();
 }
-

--- a/src/games/supported/VideoChess.hpp
+++ b/src/games/supported/VideoChess.hpp
@@ -1,0 +1,88 @@
+/* *****************************************************************************
+ * 
+ * This wrapper was authored by Stig Petersen, March 2014
+ *
+ * Xitari
+ *
+ * Copyright 2014 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 2
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * *****************************************************************************
+ * A.L.E (Arcade Learning Environment)
+ * Copyright (c) 2009-2013 by Yavar Naddaf, Joel Veness, Marc G. Bellemare and 
+ *   the Reinforcement Learning and Artificial Intelligence Laboratory
+ * Released under the GNU General Public License; see License.txt for details. 
+ *
+ * Based on: Stella  --  "An Atari 2600 VCS Emulator"
+ * Copyright (c) 1995-2007 by Bradford W. Mott and the Stella team
+ *
+ * *****************************************************************************
+ */
+#ifndef __VIDEOCHESS_HPP__
+#define __VIDEOCHESS_HPP__
+
+#include "../RomSettings.hpp"
+
+namespace ale {
+
+/* RL wrapper for Video Chess */
+class VideoChessSettings : public RomSettings {
+
+    public:
+
+        VideoChessSettings();
+
+        // reset
+        void reset();
+
+        // is end of game
+        bool isTerminal() const;
+
+        // get the most recently observed reward
+        reward_t getReward() const;
+
+        // the rom-name
+        const char* rom() const { return "videochess"; }
+
+        // create a new instance of the rom
+        RomSettings* clone() const;
+
+        // is an action part of the minimal set?
+        bool isMinimal(const Action& a) const;
+
+        // process the latest information from ALE
+        void step(const System& system);
+
+        // saves the state of the rom settings
+        void saveState(Serializer & ser);
+    
+        // loads the state of the rom settings
+        void loadState(Deserializer & ser);
+
+        virtual int lives() const { return isTerminal() ? 0 : m_lives; }
+
+    private:
+        int CalculateMaterialValue(const System& system) const;
+
+        bool m_terminal;
+        reward_t m_reward;
+
+        int m_lives;
+        int m_materialValue;
+};
+
+} // namespace ale
+
+#endif // __VIDEOCHESS_HPP__
+

--- a/src/games/supported/VideoChess.hpp
+++ b/src/games/supported/VideoChess.hpp
@@ -1,10 +1,5 @@
 /* *****************************************************************************
- * 
- * This wrapper was authored by Stig Petersen, March 2014
- *
- * Xitari
- *
- * Copyright 2014 Google Inc.
+ * The method lives() is based on Xitari's code, from Google Inc.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2
@@ -20,9 +15,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  * *****************************************************************************
  * A.L.E (Arcade Learning Environment)
- * Copyright (c) 2009-2013 by Yavar Naddaf, Joel Veness, Marc G. Bellemare and 
+ * Copyright (c) 2009-2013 by Yavar Naddaf, Joel Veness, Marc G. Bellemare and
  *   the Reinforcement Learning and Artificial Intelligence Laboratory
- * Released under the GNU General Public License; see License.txt for details. 
+ * Released under the GNU General Public License; see License.txt for details.
  *
  * Based on: Stella  --  "An Atari 2600 VCS Emulator"
  * Copyright (c) 1995-2007 by Bradford W. Mott and the Stella team
@@ -66,7 +61,7 @@ class VideoChessSettings : public RomSettings {
 
         // saves the state of the rom settings
         void saveState(Serializer & ser);
-    
+
         // loads the state of the rom settings
         void loadState(Deserializer & ser);
 
@@ -85,4 +80,3 @@ class VideoChessSettings : public RomSettings {
 } // namespace ale
 
 #endif // __VIDEOCHESS_HPP__
-


### PR DESCRIPTION
Moved over Pacman, Surround, VideoChess from xitari. 

Addresses issues #172 #319 

Tested by running the following code on the 3 environments and seeing if the results were as expected. 

```
import os
from ale_py import ALEInterface
import time
from PIL import Image
import random


def test_load_rom():
    ale = ALEInterface()
    rom = os.path.join(os.path.dirname(__file__), "fixtures/pacman.bin")
    ale.loadROM(rom)
    action_set = list(ale.getMinimalActionSet())
    for x in range(1000):
        randint = random.choice(action_set)
        res = ale.act(randint)
        obj_data = ale.getScreenRGB()
        img = Image.fromarray(obj_data)
        img.save("imgs/" + str(x) + ".jpg")


test_load_rom()
```