### PR TITLE
[ale_interface] Reinstate a call to loadSettings on error path

### DIFF
--- a/src/ale_interface.cpp
+++ b/src/ale_interface.cpp
@@ -73,8 +73,7 @@ void ALEInterface::createOSystem(std::unique_ptr<OSystem>& theOSystem,
   theOSystem->settings().loadConfig();
 }
 
-bool ALEInterface::isSupportedRom(
-    std::unique_ptr<OSystem>& theOSystem) {
+bool ALEInterface::isSupportedRom(std::unique_ptr<OSystem>& theOSystem) {
   const Properties properties = theOSystem->console().properties();
   const std::string md5 = properties.get(Cartridge_MD5);
   bool found = false;
@@ -167,6 +166,10 @@ void ALEInterface::loadROM(std::string rom_file = "") {
   if (wrapper == NULL) {
     Logger::Error << std::endl
       << "Attempt to wrap ROM " << rom_file << " failed." << std::endl;
+
+    // We need to load the settings now to make the isSupportedRom check work;
+    // the check needs the console (and its properties) to be initialized.
+    loadSettings(rom_file, theOSystem);
 
     if (isSupportedRom(theOSystem)) {
       Logger::Error << "It seems the ROM is supported." << std::endl;


### PR DESCRIPTION
The call was moved unconditionally by 3bee0b6a74491ab1c0120d05c94b1a2b0c5d9958,
which left the Console (and its properties) uninitialized on
the error path "wrapper == NULL". This change reinstates that
call locally only on this path, which ends in program exit.