### PR TITLE
[ale_interface] Move default argument to the public declaration

### DIFF
--- a/src/ale_interface.cpp
+++ b/src/ale_interface.cpp
@@ -154,9 +154,8 @@ ALEInterface::~ALEInterface() {}
 
 // Loads and initializes a game. After this call the game should be
 // ready to play. Resets the OSystem/Console/Environment/etc. This is
-// necessary after changing a setting. Optionally specify a new rom to
-// load.
-void ALEInterface::loadROM(std::string rom_file = "") {
+// necessary after changing a setting.
+void ALEInterface::loadROM(std::string rom_file) {
   assert(theOSystem.get());
   if (rom_file.empty()) {
     rom_file = theOSystem->romFile();

--- a/src/ale_interface.hpp
+++ b/src/ale_interface.hpp
@@ -75,8 +75,9 @@ class ALEInterface {
 
   // Resets the Atari and loads a game. After this call the game
   // should be ready to play. This is necessary after changing a
-  // setting for the setting to take effect.
-  void loadROM(std::string rom_file);
+  // setting for the setting to take effect. Optionally specify
+  // a new ROM to load.
+  void loadROM(std::string rom_file = {});
 
   // Applies an action to the game and returns the reward. It is the
   // user's responsibility to check if the game has ended and reset


### PR DESCRIPTION
The default argument was not used and not useful in the .cpp file;
it is reasonable and useful in the interface.

The relevant documentation is also moved.