### PR TITLE
[emucore/{OSystem,Cart}.cxx] Fix several bugs in handing invalid ROMs.

### DIFF
--- a/src/emucore/Cart.cxx
+++ b/src/emucore/Cart.cxx
@@ -53,7 +53,7 @@ using namespace std;
 Cartridge* Cartridge::create(const uInt8* image, uInt32 size,
     const Properties& properties, const Settings& settings, Random& rng)
 {
-  Cartridge* cartridge = 0;
+  Cartridge* cartridge = nullptr;
 
   // Get the type of the cartridge we're creating
   const string& md5 = properties.get(Cartridge_MD5);
@@ -137,7 +137,9 @@ Cartridge* Cartridge::create(const uInt8* image, uInt32 size,
   else
     ale::Logger::Error << "ERROR: Invalid cartridge type " << type << " ..." << endl;
 
-  cartridge->myAboutString = buf.str();
+  if (cartridge != nullptr)
+    cartridge->myAboutString = buf.str();
+
   return cartridge;
 }
 
@@ -176,7 +178,7 @@ string Cartridge::autodetectType(const uInt8* image, uInt32 size)
   // Guess type based on size
   const char* type = 0;
 
-  if((size % 8448) == 0)
+  if(size != 0 && size % 8448 == 0)
   {
     type = "AR";
   }
@@ -277,7 +279,7 @@ string Cartridge::autodetectType(const uInt8* image, uInt32 size)
     else if(isProbably3F(image, size))
       type = "3F";
     else
-      type = "4K";  // Most common bankswitching type
+      return "Unrecognized cartridge; ROM size was " + std::to_string(size);
   }
 
   return type;
@@ -288,6 +290,8 @@ bool Cartridge::searchForBytes(const uInt8* image, uInt32 imagesize,
                                const uInt8* signature, uInt32 sigsize,
                                uInt32 minhits)
 {
+  if (sigsize > imagesize) return false;
+
   uInt32 count = 0;
   for(uInt32 i = 0; i < imagesize - sigsize; ++i)
   {

--- a/src/emucore/OSystem.cxx
+++ b/src/emucore/OSystem.cxx
@@ -375,13 +375,13 @@ bool OSystem::createConsole(const string& romfile)
     myRomFile = romfile;
 
   // Open the cartridge image and read it in
-  uInt8* image;
+  uInt8* image = nullptr;
   int size = -1;
   string md5;
   if(openROM(myRomFile, md5, &image, &size))
   {
     // Get all required info for creating a valid console
-    Cartridge* cart = (Cartridge*) NULL;
+    Cartridge* cart = nullptr;
     Properties props;
     if(queryConsoleInfo(image, size, md5, &cart, props))
     {
@@ -428,9 +428,8 @@ bool OSystem::createConsole(const string& romfile)
   }
 
   // Free the image since we don't need it any longer
-  if(size != -1) {
-    delete[] image;
-  }
+  delete[] image;
+
   if (mySettings->getBool("display_screen", true)) {
 #ifndef __USE_SDL
     ale::Logger::Error << "Screen display requires directive __USE_SDL to be defined."
@@ -534,30 +533,26 @@ string OSystem::getROMInfo(const string& romfile)
   ostringstream buf;
 
   // Open the cartridge image and read it in
-  uInt8* image;
+  uInt8* image = nullptr;
   int size = -1;
   string md5;
   if(openROM(romfile, md5, &image, &size))
   {
     // Get all required info for creating a temporary console
-    Cartridge* cart = (Cartridge*) NULL;
+    Cartridge* cart = nullptr;
     Properties props;
     if(queryConsoleInfo(image, size, md5, &cart, props))
     {
       Console* console = new Console(this, cart, props);
-      if(console)
-        buf << console->about();
-      else
-        buf << "ERROR: Couldn't get ROM info for " << romfile << " ..." << endl;
-
+      buf << console->about();
       delete console;
     }
     else
       buf << "ERROR: Couldn't open " << romfile << " ..." << endl;
   }
+
   // Free the image and console since we don't need it any longer
-  if(size != -1)
-    delete[] image;
+  delete[] image;
 
   return buf.str();
 }


### PR DESCRIPTION
* Cartridge::create did not check whether a catridge had been created
  before using it (introduced by 2121bf7be7503d66a1b6cd58f952d6e81b0b1d91).

* Cartridge::autodetectType did not check that the "AR" cartridge ROM
  had non-zero size.

* Cartridge::autodetectType did not check that the fallback choice of
  "4K" cartridge had the correct ROM size. Since the size-checked case
  is already handled earlier, we remove the entire fallback case.

* Cartridge::searchForBytes did not check whether the search term was
  within the bounds of the search range.

* OSystem::createConsole and OSystem::getROMInfo failed to deallocate
  the image memory in case of a cartridge loading error.

Note that this change does not provide complete checking for ROM
validity: if the conditional block at Cart.cxx:79 is skipped, no
autodetection is performed and the provided ROM data is assumed to be
valid for the specified cartridge type (with potential out of bounds
accesses otherwise). The block is skipped if the "rominfo" setting is
not set to true and if the cartridge type has been set to something
other than its default of "AUTO-DETECT".