### PR TITLE
[SoundExporter.hpp, games/MiniatureGolf.hpp] Use "constexpr" for static class member integral constants.

### DIFF
--- a/src/common/SoundExporter.hpp
+++ b/src/common/SoundExporter.hpp
@@ -36,7 +36,7 @@ template <typename T> void write(std::ofstream& stream, const T& t) {
 
 class SoundExporter {
  public:
-  static const int SamplesPerFrame = 512;
+  static constexpr int SamplesPerFrame = 512;
 
   using SampleType = uInt8;
 

--- a/src/games/supported/MiniatureGolf.hpp
+++ b/src/games/supported/MiniatureGolf.hpp
@@ -31,8 +31,7 @@
 namespace ale {
 
 class MiniatureGolfSettings final : public RomSettings {
-
-public:
+ public:
   MiniatureGolfSettings();
 
   void reset() override;
@@ -55,7 +54,7 @@ public:
 
   DifficultyVect getAvailableDifficulties() override;
 
-private:
+ private:
   void updateRewardWhenLevelFinishes(int levelNumber);
 
   int m_levelNumber;
@@ -65,8 +64,10 @@ private:
   int m_hitsAtStartOfLevel;
   bool m_terminal;
   reward_t m_reward;
-  static const int kNumberOfLevels = 9;
+
+  static constexpr int kNumberOfLevels = 9;
 };
 
-}
+}  // namespace "ale"
+
 #endif // __MINIATURE_GOLF_HPP__


### PR DESCRIPTION
This doesn't make a difference in C++11, but provides a inline
definition in C++17 (as per
http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0386r2.pdf).

At present, no definition is provided, so those members cannot be ODR-used.