### PR TITLE
Added functional md5 checking

### DIFF
--- a/src/ale_interface.hpp
+++ b/src/ale_interface.hpp
@@ -204,6 +204,8 @@ class ALEInterface {
   int max_num_frames; // Maximum number of frames for each episode
 
  public:
+  // Check if the rom with filename matches a supported MD5
+  static bool isSupportedRom(const std::string& rom_file);
   // Display ALE welcome message
   static std::string welcomeMessage();
   static void disableBufferedIO();
@@ -211,9 +213,6 @@ class ALEInterface {
                             std::unique_ptr<Settings>& theSettings);
   static void loadSettings(const std::string& romfile,
                            std::unique_ptr<OSystem>& theOSystem);
-
- private:
-  static bool isSupportedRom(std::unique_ptr<OSystem>& theOSystem);
 };
 
 }  // namespace ale

--- a/src/ale_python_interface.hpp
+++ b/src/ale_python_interface.hpp
@@ -127,6 +127,7 @@ PYBIND11_MODULE(ale_py, m) {
       .def("setBool", &ale::ALEPythonInterface::setBool)
       .def("setFloat", &ale::ALEPythonInterface::setFloat)
       .def("loadROM", &ale::ALEPythonInterface::loadROM)
+      .def_static("isSupportedRom", &ale::ALEPythonInterface::isSupportedRom)
       .def("act", (ale::reward_t(ale::ALEPythonInterface::*)(uint32_t)) &
                       ale::ALEPythonInterface::act)
       .def("act", (ale::reward_t(ale::ALEInterface::*)(ale::Action)) &

--- a/src/games/RomSettings.hpp
+++ b/src/games/RomSettings.hpp
@@ -72,6 +72,9 @@ class RomSettings {
   // the rom-name
   virtual const char* rom() const = 0;
 
+  // the md5 of the supported ROM version
+  virtual const char* md5() const = 0;
+
   // create a new instance of the rom
   virtual RomSettings* clone() const = 0;
 

--- a/src/games/Roms.cpp
+++ b/src/games/Roms.cpp
@@ -228,9 +228,9 @@ static const RomSettings* roms[] = {
     new YarsRevengeSettings(),
     new ZaxxonSettings(),
 };
-
-/* looks for the RL wrapper corresponding to a particular rom title */
-RomSettings* buildRomRLWrapper(const std::string& rom) {
+/* looks for the RL wrapper corresponding to a particular rom filename,
+ * and optionally md5. returns null if neither match */
+RomSettings* buildRomRLWrapper(const std::string& rom, const std::string rom_md5 = std::string()){
   size_t slash_ind = rom.find_last_of("/\\");
   std::string rom_str = rom.substr(slash_ind + 1);
   size_t dot_idx = rom_str.find_first_of(".");
@@ -238,10 +238,9 @@ RomSettings* buildRomRLWrapper(const std::string& rom) {
   std::transform(rom_str.begin(), rom_str.end(), rom_str.begin(), ::tolower);
 
   for (size_t i = 0; i < sizeof(roms) / sizeof(roms[0]); i++) {
-    if (rom_str == roms[i]->rom())
+    if (rom_md5 == roms[i]->md5() || rom_str == roms[i]->rom())
       return roms[i]->clone();
   }
-
   return NULL;
 }
 

--- a/src/games/Roms.hpp
+++ b/src/games/Roms.hpp
@@ -20,7 +20,7 @@
 namespace ale {
 
 // looks for the RL wrapper corresponding to a particular rom title
-RomSettings* buildRomRLWrapper(const std::string& rom);
+RomSettings* buildRomRLWrapper(const std::string& rom, const std::string md5);
 
 }  // namespace ale
 

--- a/src/games/supported/Adventure.hpp
+++ b/src/games/supported/Adventure.hpp
@@ -48,6 +48,9 @@ class AdventureSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "adventure"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "4b27f5397c442d25f0c418ccdacf1926"; }
+
   // create a new instance of the rom
   RomSettings* clone() const override;
 

--- a/src/games/supported/AirRaid.hpp
+++ b/src/games/supported/AirRaid.hpp
@@ -34,6 +34,9 @@ class AirRaidSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "air_raid"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "35be55426c1fec32dfb503b4f0651572"; }
+
   // get the available number of modes
   unsigned int getNumModes() const { return 8; }
 

--- a/src/games/supported/Alien.hpp
+++ b/src/games/supported/Alien.hpp
@@ -49,6 +49,9 @@ class AlienSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "alien"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "f1a0a23e6464d954e3a9579c4ccd01c8"; }
+
   // get the available number of modes
   unsigned int getNumModes() const { return 4; }
 

--- a/src/games/supported/Amidar.hpp
+++ b/src/games/supported/Amidar.hpp
@@ -49,6 +49,9 @@ class AmidarSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "amidar"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "acb7750b4d0c4bd34969802a7deb2990"; }
+
   // create a new instance of the rom
   RomSettings* clone() const override;
 

--- a/src/games/supported/Assault.hpp
+++ b/src/games/supported/Assault.hpp
@@ -49,6 +49,9 @@ class AssaultSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "assault"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "de78b3a064d374390ac0710f95edde92"; }
+
   // create a new instance of the rom
   RomSettings* clone() const override;
 

--- a/src/games/supported/Asterix.hpp
+++ b/src/games/supported/Asterix.hpp
@@ -49,6 +49,9 @@ class AsterixSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "asterix"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "89a68746eff7f266bbf08de2483abe55"; }
+
   // create a new instance of the rom
   RomSettings* clone() const override;
 

--- a/src/games/supported/Asteroids.hpp
+++ b/src/games/supported/Asteroids.hpp
@@ -49,6 +49,9 @@ class AsteroidsSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "asteroids"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "ccbd36746ed4525821a8083b0d6d2c2c"; }
+
   // get the available number of modes
   unsigned int getNumModes() const { return 33; }
 

--- a/src/games/supported/Atlantis.hpp
+++ b/src/games/supported/Atlantis.hpp
@@ -49,6 +49,9 @@ class AtlantisSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "atlantis"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "9ad36e699ef6f45d9eb6c4cf90475c9f"; }
+
   // get the available number of modes
   unsigned int getNumModes() const { return 4; }
 

--- a/src/games/supported/Atlantis2.hpp
+++ b/src/games/supported/Atlantis2.hpp
@@ -52,6 +52,9 @@ class Atlantis2Settings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "atlantis2"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "826481f6fc53ea47c9f272f7050eedf7"; }
+
   // create a new instance of the rom
   RomSettings* clone() const override;
 

--- a/src/games/supported/Backgammon.hpp
+++ b/src/games/supported/Backgammon.hpp
@@ -46,6 +46,9 @@ class BackgammonSettings : public RomSettings {
 
   const char* rom() const override { return "backgammon"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "8556b42aa05f94bc29ff39c39b11bff4"; }
+
   RomSettings* clone() const override;
 
   bool isMinimal(const Action& a) const override;

--- a/src/games/supported/BankHeist.hpp
+++ b/src/games/supported/BankHeist.hpp
@@ -49,6 +49,9 @@ class BankHeistSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "bank_heist"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "00ce0bdd43aed84a983bef38fe7f5ee3"; }
+
   // get the available number of modes
   unsigned int getNumModes() const { return 8; }
 

--- a/src/games/supported/BasicMath.hpp
+++ b/src/games/supported/BasicMath.hpp
@@ -42,6 +42,9 @@ class BasicMathSettings : public RomSettings {
 
   const char* rom() const override { return "basic_math"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "819aeeb9a2e11deb54e6de334f843894"; }
+
   RomSettings* clone() const override;
 
   bool isMinimal(const Action& a) const override;

--- a/src/games/supported/BattleZone.hpp
+++ b/src/games/supported/BattleZone.hpp
@@ -49,6 +49,9 @@ class BattleZoneSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "battle_zone"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "41f252a66c6301f1e8ab3612c19bc5d4"; }
+
   // get the available number of modes
   unsigned int getNumModes() const { return 3; }
 

--- a/src/games/supported/BeamRider.hpp
+++ b/src/games/supported/BeamRider.hpp
@@ -49,6 +49,9 @@ class BeamRiderSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "beam_rider"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "79ab4123a83dc11d468fb2108ea09e2e"; }
+
   // create a new instance of the rom
   RomSettings* clone() const override;
 

--- a/src/games/supported/Berzerk.hpp
+++ b/src/games/supported/Berzerk.hpp
@@ -49,6 +49,9 @@ class BerzerkSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "berzerk"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "136f75c4dd02c29283752b7e5799f978"; }
+
   // get the available number of modes
   unsigned int getNumModes() const { return 12; }
 

--- a/src/games/supported/Blackjack.hpp
+++ b/src/games/supported/Blackjack.hpp
@@ -44,6 +44,9 @@ class BlackjackSettings : public RomSettings {
 
   const char* rom() const override { return "blackjack"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "0a981c03204ac2b278ba392674682560"; }
+
   RomSettings* clone() const override;
 
   bool isMinimal(const Action& a) const override;

--- a/src/games/supported/Bowling.hpp
+++ b/src/games/supported/Bowling.hpp
@@ -49,6 +49,9 @@ class BowlingSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "bowling"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "c9b7afad3bfd922e006a6bfc1d4f3fe7"; }
+
   // get the available number of modes
   unsigned int getNumModes() const { return 3; }
 

--- a/src/games/supported/Boxing.hpp
+++ b/src/games/supported/Boxing.hpp
@@ -49,6 +49,9 @@ class BoxingSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "boxing"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "c3ef5c4653212088eda54dc91d787870"; }
+
   // create a new instance of the rom
   RomSettings* clone() const override;
 

--- a/src/games/supported/Breakout.hpp
+++ b/src/games/supported/Breakout.hpp
@@ -49,6 +49,9 @@ class BreakoutSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "breakout"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "f34f08e5eb96e500e851a80be3277a56"; }
+
   // get the available number of modes
   unsigned int getNumModes() const { return 12; }
 

--- a/src/games/supported/Carnival.hpp
+++ b/src/games/supported/Carnival.hpp
@@ -49,6 +49,9 @@ class CarnivalSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "carnival"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "028024fb8e5e5f18ea586652f9799c96"; }
+
   // create a new instance of the rom
   RomSettings* clone() const override;
 

--- a/src/games/supported/Casino.hpp
+++ b/src/games/supported/Casino.hpp
@@ -42,6 +42,9 @@ class CasinoSettings : public RomSettings {
 
   const char* rom() const override { return "casino"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "b816296311019ab69a21cb9e9e235d12"; }
+
   RomSettings* clone() const override;
 
   bool isMinimal(const Action& a) const override;

--- a/src/games/supported/Centipede.hpp
+++ b/src/games/supported/Centipede.hpp
@@ -49,6 +49,9 @@ class CentipedeSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "centipede"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "91c2098e88a6b13f977af8c003e0bca5"; }
+
   // get the available number of modes
   unsigned int getNumModes() const { return 2; }
 

--- a/src/games/supported/ChopperCommand.hpp
+++ b/src/games/supported/ChopperCommand.hpp
@@ -49,6 +49,9 @@ class ChopperCommandSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "chopper_command"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "c1cb228470a87beb5f36e90ac745da26"; }
+
   // get the available number of modes
   unsigned int getNumModes() const { return 2; }
 

--- a/src/games/supported/CrazyClimber.hpp
+++ b/src/games/supported/CrazyClimber.hpp
@@ -49,6 +49,9 @@ class CrazyClimberSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "crazy_climber"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "55ef7b65066428367844342ed59f956c"; }
+
   // get the available number of modes
   unsigned int getNumModes() const { return 4; }
 

--- a/src/games/supported/Crossbow.hpp
+++ b/src/games/supported/Crossbow.hpp
@@ -42,6 +42,9 @@ class CrossbowSettings : public RomSettings {
 
   const char* rom() const override { return "crossbow"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "8cd26dcf249456fe4aeb8db42d49df74"; }
+
   RomSettings* clone() const override;
 
   bool isMinimal(const Action& a) const override;

--- a/src/games/supported/DarkChambers.hpp
+++ b/src/games/supported/DarkChambers.hpp
@@ -43,6 +43,9 @@ public:
 
   const char* rom() const override { return "darkchambers"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "106855474c69d08c8ffa308d47337269"; }
+
   RomSettings* clone() const override;
 
   bool isMinimal(const Action& a) const override;

--- a/src/games/supported/Defender.hpp
+++ b/src/games/supported/Defender.hpp
@@ -49,6 +49,9 @@ class DefenderSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "defender"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "0f643c34e40e3f1daafd9c524d3ffe64"; }
+
   // get the available number of modes
   unsigned int getNumModes() const { return 10; }
 

--- a/src/games/supported/DemonAttack.hpp
+++ b/src/games/supported/DemonAttack.hpp
@@ -49,6 +49,9 @@ class DemonAttackSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "demon_attack"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "f0e0addc07971561ab80d9abe1b8d333"; }
+
   // get the available number of modes
   unsigned int getNumModes() const { return 8; }
 

--- a/src/games/supported/DonkeyKong.hpp
+++ b/src/games/supported/DonkeyKong.hpp
@@ -35,6 +35,9 @@ class DonkeyKongSettings : public RomSettings {
   // MD5 36b20c427975760cb9cf4a47e41369e4
   const char* rom() const override { return "donkey_kong"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "36b20c427975760cb9cf4a47e41369e4"; }
+
   // create a new instance of the rom
   RomSettings* clone() const override;
 

--- a/src/games/supported/DoubleDunk.hpp
+++ b/src/games/supported/DoubleDunk.hpp
@@ -49,6 +49,9 @@ class DoubleDunkSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "double_dunk"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "368d88a6c071caba60b4f778615aae94"; }
+
   // get the available number of modes
   unsigned int getNumModes() const { return 16; }
 

--- a/src/games/supported/Earthworld.hpp
+++ b/src/games/supported/Earthworld.hpp
@@ -42,6 +42,9 @@ class EarthworldSettings : public RomSettings {
 
   const char* rom() const override { return "earthworld"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "5aea9974b975a6a844e6df10d2b861c4"; }
+
   RomSettings* clone() const override;
 
   bool isMinimal(const Action& a) const override;

--- a/src/games/supported/ElevatorAction.hpp
+++ b/src/games/supported/ElevatorAction.hpp
@@ -49,6 +49,9 @@ class ElevatorActionSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "elevator_action"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "71f8bacfbdca019113f3f0801849057e"; }
+
   // create a new instance of the rom
   RomSettings* clone() const override;
 

--- a/src/games/supported/Enduro.hpp
+++ b/src/games/supported/Enduro.hpp
@@ -49,6 +49,9 @@ class EnduroSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "enduro"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "94b92a882f6dbaa6993a46e2dcc58402"; }
+
   // create a new instance of the rom
   RomSettings* clone() const override;
 

--- a/src/games/supported/Entombed.hpp
+++ b/src/games/supported/Entombed.hpp
@@ -42,6 +42,9 @@ class EntombedSettings : public RomSettings {
 
   const char* rom() const override { return "entombed"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "6b683be69f92958abe0e2a9945157ad5"; }
+
   RomSettings* clone() const override;
 
   bool isMinimal(const Action& a) const override;

--- a/src/games/supported/Et.hpp
+++ b/src/games/supported/Et.hpp
@@ -42,6 +42,9 @@ class EtSettings : public RomSettings {
 
   const char* rom() const override { return "et"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "615a3bf251a38eb6638cdc7ffbde5480"; }
+
   RomSettings* clone() const override;
 
   bool isMinimal(const Action& a) const override;

--- a/src/games/supported/FishingDerby.hpp
+++ b/src/games/supported/FishingDerby.hpp
@@ -49,6 +49,9 @@ class FishingDerbySettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "fishing_derby"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "b8865f05676e64f3bec72b9defdacfa7"; }
+
   // create a new instance of the rom
   RomSettings* clone() const override;
 

--- a/src/games/supported/FlagCapture.hpp
+++ b/src/games/supported/FlagCapture.hpp
@@ -42,6 +42,9 @@ class FlagCaptureSettings : public RomSettings {
 
   const char* rom() const override { return "flag_capture"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "30512e0e83903fc05541d2f6a6a62654"; }
+
   RomSettings* clone() const override;
 
   bool isMinimal(const Action& a) const override;

--- a/src/games/supported/Freeway.hpp
+++ b/src/games/supported/Freeway.hpp
@@ -50,6 +50,9 @@ class FreewaySettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "freeway"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "8e0ab801b1705a740b476b7f588c6d16"; }
+
   // get the available number of modes
   unsigned int getNumModes() const { return 8; }
 

--- a/src/games/supported/Frogger.hpp
+++ b/src/games/supported/Frogger.hpp
@@ -35,6 +35,9 @@ class FroggerSettings : public RomSettings {
   // MD5 081e2c114c9c20b61acf25fc95c71bf4
   const char* rom() const override { return "frogger"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "081e2c114c9c20b61acf25fc95c71bf4"; }
+
   // create a new instance of the rom
   RomSettings* clone() const override;
 

--- a/src/games/supported/Frostbite.hpp
+++ b/src/games/supported/Frostbite.hpp
@@ -49,6 +49,9 @@ class FrostbiteSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "frostbite"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "4ca73eb959299471788f0b685c3ba0b5"; }
+
   // get the available number of modes
   unsigned int getNumModes() const { return 2; }
 

--- a/src/games/supported/Galaxian.hpp
+++ b/src/games/supported/Galaxian.hpp
@@ -48,6 +48,9 @@ class GalaxianSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "galaxian"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "211774f4c5739042618be8ff67351177"; }
+
   // create a new instance of the rom
   RomSettings* clone() const override;
 

--- a/src/games/supported/Gopher.hpp
+++ b/src/games/supported/Gopher.hpp
@@ -49,6 +49,9 @@ class GopherSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "gopher"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "c16c79aad6272baffb8aae9a7fff0864"; }
+
   // get the available number of modes
   unsigned int getNumModes() const { return 2; }
 

--- a/src/games/supported/Gravitar.hpp
+++ b/src/games/supported/Gravitar.hpp
@@ -49,6 +49,9 @@ class GravitarSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "gravitar"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "8ac18076d01a6b63acf6e2cab4968940"; }
+
   // get the available number of modes
   unsigned int getNumModes() const { return 5; }
 

--- a/src/games/supported/Hangman.hpp
+++ b/src/games/supported/Hangman.hpp
@@ -47,6 +47,9 @@ class HangmanSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "hangman"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "f16c709df0a6c52f47ff52b9d95b7d8d"; }
+
 
   // create a new instance of the rom
   RomSettings* clone() const override;

--- a/src/games/supported/HauntedHouse.hpp
+++ b/src/games/supported/HauntedHouse.hpp
@@ -42,6 +42,9 @@ class HauntedHouseSettings : public RomSettings {
 
   const char* rom() const override { return "haunted_house"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "f0a6e99f5875891246c3dbecbf2d2cea"; }
+
   RomSettings* clone() const override;
 
   bool isMinimal(const Action& a) const override;

--- a/src/games/supported/Hero.hpp
+++ b/src/games/supported/Hero.hpp
@@ -49,6 +49,9 @@ class HeroSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "hero"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "fca4a5be1251927027f2c24774a02160"; }
+
   // get the available number of modes
   unsigned int getNumModes() const { return 5; }
 

--- a/src/games/supported/HumanCannonball.hpp
+++ b/src/games/supported/HumanCannonball.hpp
@@ -42,6 +42,9 @@ class HumanCannonballSettings : public RomSettings {
 
   const char* rom() const override { return "human_cannonball"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "7972e5101fa548b952d852db24ad6060"; }
+
   RomSettings* clone() const override;
 
   bool isMinimal(const Action& a) const override;

--- a/src/games/supported/IceHockey.hpp
+++ b/src/games/supported/IceHockey.hpp
@@ -49,6 +49,9 @@ class IceHockeySettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "ice_hockey"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "a4c08c4994eb9d24fb78be1793e82e26"; }
+
   // get the available number of modes
   unsigned int getNumModes() const { return 2; }
 

--- a/src/games/supported/JamesBond.hpp
+++ b/src/games/supported/JamesBond.hpp
@@ -49,6 +49,9 @@ class JamesBondSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "jamesbond"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "e51030251e440cffaab1ac63438b44ae"; }
+
   // get the available number of modes
   unsigned int getNumModes() const { return 2; }
 

--- a/src/games/supported/JourneyEscape.hpp
+++ b/src/games/supported/JourneyEscape.hpp
@@ -49,6 +49,9 @@ class JourneyEscapeSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "journey_escape"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "718ae62c70af4e5fd8e932fee216948a"; }
+
   // create a new instance of the rom
   RomSettings* clone() const override;
 

--- a/src/games/supported/Kaboom.hpp
+++ b/src/games/supported/Kaboom.hpp
@@ -34,6 +34,9 @@ class KaboomSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "kaboom"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "5428cdfada281c569c74c7308c7f2c26"; }
+
   // create a new instance of the rom
   RomSettings* clone() const override;
 

--- a/src/games/supported/Kangaroo.hpp
+++ b/src/games/supported/Kangaroo.hpp
@@ -49,6 +49,9 @@ class KangarooSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "kangaroo"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "4326edb70ff20d0ee5ba58fa5cb09d60"; }
+
   // get the available number of modes
   unsigned int getNumModes() const { return 2; }
 

--- a/src/games/supported/KeystoneKapers.hpp
+++ b/src/games/supported/KeystoneKapers.hpp
@@ -35,6 +35,9 @@ class KeystoneKapersSettings : public RomSettings {
   // MD5 be929419902e21bd7830a7a7d746195d
   const char* rom() const override { return "keystone_kapers"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "6c1f3f2e359dbf55df462ccbcdd2f6bf"; }
+
   // create a new instance of the rom
   RomSettings* clone() const override;
 

--- a/src/games/supported/Kingkong.hpp
+++ b/src/games/supported/Kingkong.hpp
@@ -49,6 +49,9 @@ class KingkongSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "king_kong"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "0dd4c69b5f9a7ae96a7a08329496779a"; }
+
   // create a new instance of the rom
   RomSettings* clone() const override;
 

--- a/src/games/supported/Klax.hpp
+++ b/src/games/supported/Klax.hpp
@@ -42,6 +42,9 @@ class KlaxSettings : public RomSettings {
 
   const char* rom() const override { return "klax"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "eed9eaf1a0b6a2b9bc4c8032cb43e3fb"; }
+
   RomSettings* clone() const override;
 
   bool isMinimal(const Action& a) const override;

--- a/src/games/supported/Koolaid.hpp
+++ b/src/games/supported/Koolaid.hpp
@@ -34,6 +34,9 @@ class KoolaidSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "koolaid"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "534e23210dd1993c828d944c6ac4d9fb"; }
+
   // create a new instance of the rom
   RomSettings* clone() const override;
 

--- a/src/games/supported/Krull.hpp
+++ b/src/games/supported/Krull.hpp
@@ -49,6 +49,9 @@ class KrullSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "krull"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "4baada22435320d185c95b7dd2bcdb24"; }
+
   // create a new instance of the rom
   RomSettings* clone() const override;
 

--- a/src/games/supported/KungFuMaster.hpp
+++ b/src/games/supported/KungFuMaster.hpp
@@ -49,6 +49,9 @@ class KungFuMasterSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "kung_fu_master"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "5b92a93b23523ff16e2789b820e2a4c5"; }
+
   // create a new instance of the rom
   RomSettings* clone() const override;
 

--- a/src/games/supported/LaserGates.hpp
+++ b/src/games/supported/LaserGates.hpp
@@ -35,6 +35,9 @@ class LaserGatesSettings : public RomSettings {
   // MD5 1fa58679d4a39052bd9db059e8cda4ad
   const char* rom() const override { return "laser_gates"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "8e4cd60d93fcde8065c1a2b972a26377"; }
+
   // create a new instance of the rom
   RomSettings* clone() const override;
 

--- a/src/games/supported/LostLuggage.hpp
+++ b/src/games/supported/LostLuggage.hpp
@@ -35,6 +35,9 @@ class LostLuggageSettings : public RomSettings {
   // MD5 7c00e7a205d3fda98eb20da7c9c50a55
   const char* rom() const override { return "lost_luggage"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "2d76c5d1aad506442b9e9fb67765e051"; }
+
   // create a new instance of the rom
   RomSettings* clone() const override;
 

--- a/src/games/supported/MarioBros.hpp
+++ b/src/games/supported/MarioBros.hpp
@@ -42,6 +42,9 @@ class MarioBrosSettings : public RomSettings {
 
   const char* rom() const override { return "mario_bros"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "e908611d99890733be31733a979c62d8"; }
+
   RomSettings* clone() const override;
 
   bool isMinimal(const Action& a) const override;

--- a/src/games/supported/MiniatureGolf.hpp
+++ b/src/games/supported/MiniatureGolf.hpp
@@ -42,6 +42,9 @@ class MiniatureGolfSettings final : public RomSettings {
 
   const char* rom() const override { return "miniature_golf"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "df62a658496ac98a3aa4a6ee5719c251"; }
+
   RomSettings* clone() const override;
 
   bool isMinimal(const Action& a) const override;

--- a/src/games/supported/MontezumaRevenge.hpp
+++ b/src/games/supported/MontezumaRevenge.hpp
@@ -49,6 +49,9 @@ class MontezumaRevengeSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "montezuma_revenge"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "3347a6dd59049b15a38394aa2dafa585"; }
+
   // create a new instance of the rom
   RomSettings* clone() const override;
 

--- a/src/games/supported/MrDo.hpp
+++ b/src/games/supported/MrDo.hpp
@@ -34,6 +34,9 @@ class MrDoSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "mr_do"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "aa7bb54d2c189a31bb1fa20099e42859"; }
+
   // create a new instance of the rom
   RomSettings* clone() const override;
 

--- a/src/games/supported/MsPacman.hpp
+++ b/src/games/supported/MsPacman.hpp
@@ -49,6 +49,9 @@ class MsPacmanSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "ms_pacman"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "87e79cd41ce136fd4f72cc6e2c161bee"; }
+
   // get the available number of modes
   unsigned int getNumModes() const { return 4; }
 

--- a/src/games/supported/NameThisGame.hpp
+++ b/src/games/supported/NameThisGame.hpp
@@ -49,6 +49,9 @@ class NameThisGameSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "name_this_game"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "36306070f0c90a72461551a7a4f3a209"; }
+
   // get the available number of modes
   unsigned int getNumModes() const { return 3; }
 

--- a/src/games/supported/Othello.hpp
+++ b/src/games/supported/Othello.hpp
@@ -42,6 +42,9 @@ class OthelloSettings : public RomSettings {
 
   virtual const char* rom() const { return "othello"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "113cd09c9771ac278544b7e90efe7df2"; }
+
   virtual RomSettings* clone() const;
 
   virtual bool isMinimal(const Action& a) const;

--- a/src/games/supported/Pacman.hpp
+++ b/src/games/supported/Pacman.hpp
@@ -55,6 +55,9 @@ class PacmanSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "pacman"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "fc2233fc116faef0d3c31541717ca2db"; }
+
   // create a new instance of the rom
   RomSettings* clone() const override;
 

--- a/src/games/supported/Phoenix.hpp
+++ b/src/games/supported/Phoenix.hpp
@@ -49,6 +49,9 @@ class PhoenixSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "phoenix"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "7e52a95074a66640fcfde124fffd491a"; }
+
   // create a new instance of the rom
   RomSettings* clone() const override;
 

--- a/src/games/supported/Pitfall.hpp
+++ b/src/games/supported/Pitfall.hpp
@@ -49,6 +49,9 @@ class PitfallSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "pitfall"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "3e90cf23106f2e08b2781e41299de556"; }
+
   // create a new instance of the rom
   RomSettings* clone() const override;
 

--- a/src/games/supported/Pitfall2.hpp
+++ b/src/games/supported/Pitfall2.hpp
@@ -47,6 +47,9 @@ class Pitfall2Settings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "pitfall2"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "6d842c96d5a01967be9680080dd5be54"; }
+
   // create a new instance of the rom
   RomSettings* clone() const override;
 

--- a/src/games/supported/Pong.hpp
+++ b/src/games/supported/Pong.hpp
@@ -49,6 +49,9 @@ class PongSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "pong"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "60e0ea3cbe0913d39803477945e9e5ec"; }
+
   // get the available number of modes
   unsigned int getNumModes() const { return 2; }
 

--- a/src/games/supported/Pooyan.hpp
+++ b/src/games/supported/Pooyan.hpp
@@ -49,6 +49,9 @@ class PooyanSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "pooyan"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "4799a40b6e889370b7ee55c17ba65141"; }
+
   // get the available number of modes
   unsigned int getNumModes() const { return 4; }
 

--- a/src/games/supported/PrivateEye.hpp
+++ b/src/games/supported/PrivateEye.hpp
@@ -49,6 +49,9 @@ class PrivateEyeSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "private_eye"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "ef3a4f64b6494ba770862768caf04b86"; }
+
   // get the available number of modes
   unsigned int getNumModes() const { return 5; }
 

--- a/src/games/supported/QBert.hpp
+++ b/src/games/supported/QBert.hpp
@@ -49,6 +49,9 @@ class QBertSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "qbert"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "484b0076816a104875e00467d431c2d2"; }
+
   // create a new instance of the rom
   RomSettings* clone() const override;
 

--- a/src/games/supported/RiverRaid.hpp
+++ b/src/games/supported/RiverRaid.hpp
@@ -51,6 +51,9 @@ class RiverRaidSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "riverraid"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "393948436d1f4cc3192410bb918f9724"; }
+
   // create a new instance of the rom
   RomSettings* clone() const override;
 

--- a/src/games/supported/RoadRunner.hpp
+++ b/src/games/supported/RoadRunner.hpp
@@ -49,6 +49,9 @@ class RoadRunnerSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "road_runner"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "ce5cc62608be2cd3ed8abd844efb8919"; }
+
   // create a new instance of the rom
   RomSettings* clone() const override;
 

--- a/src/games/supported/RoboTank.hpp
+++ b/src/games/supported/RoboTank.hpp
@@ -49,6 +49,9 @@ class RoboTankSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "robotank"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "4f618c2429138e0280969193ed6c107e"; }
+
   // create a new instance of the rom
   RomSettings* clone() const override;
 

--- a/src/games/supported/Seaquest.hpp
+++ b/src/games/supported/Seaquest.hpp
@@ -49,6 +49,9 @@ class SeaquestSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "seaquest"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "240bfbac5163af4df5ae713985386f92"; }
+
   // create a new instance of the rom
   RomSettings* clone() const override;
 

--- a/src/games/supported/SirLancelot.hpp
+++ b/src/games/supported/SirLancelot.hpp
@@ -35,6 +35,9 @@ class SirLancelotSettings : public RomSettings {
   // MD5 7ead257e8b5a44cac538f5f54c7a0023
   const char* rom() const override { return "sir_lancelot"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "dd0cbe5351551a538414fb9e37fc56e8"; }
+
   // create a new instance of the rom
   RomSettings* clone() const override;
 

--- a/src/games/supported/Skiing.hpp
+++ b/src/games/supported/Skiing.hpp
@@ -49,6 +49,9 @@ class SkiingSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "skiing"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "b76fbadc8ffb1f83e2ca08b6fb4d6c9f"; }
+
   // create a new instance of the rom
   RomSettings* clone() const override;
 

--- a/src/games/supported/Solaris.hpp
+++ b/src/games/supported/Solaris.hpp
@@ -49,6 +49,9 @@ class SolarisSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "solaris"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "e72eb8d4410152bdcb69e7fba327b420"; }
+
   // create a new instance of the rom
   RomSettings* clone() const override;
 

--- a/src/games/supported/SpaceInvaders.hpp
+++ b/src/games/supported/SpaceInvaders.hpp
@@ -49,6 +49,9 @@ class SpaceInvadersSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "space_invaders"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "72ffbef6504b75e69ee1045af9075f66"; }
+
   // get the available number of modes
   unsigned int getNumModes() const { return 16; }
 

--- a/src/games/supported/SpaceWar.hpp
+++ b/src/games/supported/SpaceWar.hpp
@@ -42,6 +42,9 @@ class SpaceWarSettings : public RomSettings {
 
   const char* rom() const override { return "space_war"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "b702641d698c60bcdc922dbd8c9dd49c"; }
+
   RomSettings* clone() const override;
 
   bool isMinimal(const Action& a) const override;

--- a/src/games/supported/StarGunner.hpp
+++ b/src/games/supported/StarGunner.hpp
@@ -49,6 +49,9 @@ class StarGunnerSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "star_gunner"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "a3c1c70024d7aabb41381adbfb6d3b25"; }
+
   // get the available number of modes
   unsigned int getNumModes() const { return 4; }
 

--- a/src/games/supported/Superman.hpp
+++ b/src/games/supported/Superman.hpp
@@ -42,6 +42,9 @@ class SupermanSettings : public RomSettings {
 
   const char* rom() const override { return "superman"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "a9531c763077464307086ec9a1fd057d"; }
+
   RomSettings* clone() const override;
 
   bool isMinimal(const Action& a) const override;

--- a/src/games/supported/Surround.hpp
+++ b/src/games/supported/Surround.hpp
@@ -51,6 +51,9 @@ class SurroundSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "surround"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "4d7517ae69f95cfbc053be01312b7dba"; }
+
   // create a new instance of the rom
   RomSettings* clone() const override;
 

--- a/src/games/supported/Tennis.hpp
+++ b/src/games/supported/Tennis.hpp
@@ -49,6 +49,9 @@ class TennisSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "tennis"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "42cdd6a9e42a3639e190722b8ea3fc51"; }
+
   // get the available number of modes
   unsigned int getNumModes() const { return 2; }
 

--- a/src/games/supported/Tetris.hpp
+++ b/src/games/supported/Tetris.hpp
@@ -47,6 +47,9 @@ class TetrisSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "tetris"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "b0e1ee07fbc73493eac5651a52f90f00"; }
+
   // create a new instance of the rom
   RomSettings* clone() const override;
 

--- a/src/games/supported/TicTacToe3d.hpp
+++ b/src/games/supported/TicTacToe3d.hpp
@@ -43,6 +43,9 @@ public:
 
   const char* rom() const override { return "tic_tac_toe_3d"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "0db4f4150fecf77e4ce72ca4d04c052f"; }
+
   RomSettings* clone() const override;
 
   bool isMinimal(const Action& a) const override;

--- a/src/games/supported/TimePilot.hpp
+++ b/src/games/supported/TimePilot.hpp
@@ -49,6 +49,9 @@ class TimePilotSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "time_pilot"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "fc2104dd2dadf9a6176c1c1c8f87ced9"; }
+
   // create a new instance of the rom
   RomSettings* clone() const override;
 

--- a/src/games/supported/Trondead.hpp
+++ b/src/games/supported/Trondead.hpp
@@ -34,6 +34,9 @@ class TrondeadSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "trondead"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "fb27afe896e7c928089307b32e5642ee"; }
+
   // create a new instance of the rom
   RomSettings* clone() const override;
 

--- a/src/games/supported/Turmoil.hpp
+++ b/src/games/supported/Turmoil.hpp
@@ -36,6 +36,9 @@ class TurmoilSettings : public RomSettings {
   // 7a5463545dfb2dcfdafa6074b2f2c15e  Turmoil.bin
   const char* rom() const override { return "turmoil"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "7a5463545dfb2dcfdafa6074b2f2c15e"; }
+
   // create a new instance of the rom
   RomSettings* clone() const override;
 

--- a/src/games/supported/Tutankham.hpp
+++ b/src/games/supported/Tutankham.hpp
@@ -49,6 +49,9 @@ class TutankhamSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "tutankham"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "085322bae40d904f53bdcc56df0593fc"; }
+
   // get the available number of modes
   unsigned int getNumModes() const { return 4; }
 

--- a/src/games/supported/UpNDown.hpp
+++ b/src/games/supported/UpNDown.hpp
@@ -49,6 +49,9 @@ class UpNDownSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "up_n_down"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "a499d720e7ee35c62424de882a3351b6"; }
+
   // create a new instance of the rom
   RomSettings* clone() const override;
 

--- a/src/games/supported/Venture.hpp
+++ b/src/games/supported/Venture.hpp
@@ -49,6 +49,9 @@ class VentureSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "venture"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "3e899eba0ca8cd2972da1ae5479b4f0d"; }
+
   // create a new instance of the rom
   RomSettings* clone() const override;
 

--- a/src/games/supported/VideoCheckers.hpp
+++ b/src/games/supported/VideoCheckers.hpp
@@ -44,6 +44,9 @@ class VideoCheckersSettings : public RomSettings {
 
   const char* rom() const  override { return "video_checkers"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "539d26b6e9df0da8e7465f0f5ad863b7"; }
+
   RomSettings* clone() const override;
 
   bool isMinimal(const Action& a) const override;

--- a/src/games/supported/VideoChess.hpp
+++ b/src/games/supported/VideoChess.hpp
@@ -54,6 +54,9 @@ class VideoChessSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "videochess"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "f0b7db930ca0e548c41a97160b9f6275"; }
+
   // create a new instance of the rom
   RomSettings* clone() const override;
 

--- a/src/games/supported/VideoCube.hpp
+++ b/src/games/supported/VideoCube.hpp
@@ -42,6 +42,9 @@ class VideoCubeSettings : public RomSettings {
 
   const char* rom() const override { return "videocube"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "3f540a30fdee0b20aed7288e4a5ea528"; }
+
   RomSettings* clone() const override;
 
   bool isMinimal(const Action& a) const override;

--- a/src/games/supported/VideoPinball.hpp
+++ b/src/games/supported/VideoPinball.hpp
@@ -49,6 +49,9 @@ class VideoPinballSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "video_pinball"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "107cc025334211e6d29da0b6be46aec7"; }
+
   // get the available number of modes
   unsigned int getNumModes() const { return 2; }
 

--- a/src/games/supported/WizardOfWor.hpp
+++ b/src/games/supported/WizardOfWor.hpp
@@ -49,6 +49,9 @@ class WizardOfWorSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "wizard_of_wor"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "7e8aa18bc9502eb57daaf5e7c1e94da7"; }
+
   // create a new instance of the rom
   RomSettings* clone() const override;
 

--- a/src/games/supported/WordZapper.hpp
+++ b/src/games/supported/WordZapper.hpp
@@ -41,6 +41,9 @@ class WordZapperSettings : public RomSettings {
 
   const char* rom() const override { return "word_zapper"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "ec3beb6d8b5689e867bafb5d5f507491"; }
+
   RomSettings* clone() const override;
 
   bool isMinimal(const Action& a) const override;

--- a/src/games/supported/YarsRevenge.hpp
+++ b/src/games/supported/YarsRevenge.hpp
@@ -49,6 +49,9 @@ class YarsRevengeSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "yars_revenge"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "c5930d0e8cdae3e037349bfa08e871be"; }
+
   // get the available number of modes
   unsigned int getNumModes() const { return 4; }
 

--- a/src/games/supported/Zaxxon.hpp
+++ b/src/games/supported/Zaxxon.hpp
@@ -49,6 +49,9 @@ class ZaxxonSettings : public RomSettings {
   // the rom-name
   const char* rom() const override { return "zaxxon"; }
 
+  // The md5 checksum of the ROM that this game supports
+  const char* md5() const override { return "eea0da9b987d661264cce69a7c13c3bd"; }
+
   // get the available number of modes
   unsigned int getNumModes() const { return 4; }
 

--- a/tests/test_python_interface.py
+++ b/tests/test_python_interface.py
@@ -193,6 +193,11 @@ def test_save_screen_png(tetris):
     os.remove(file)
 
 
+def test_is_rom_supported(ale, test_rom_path):
+    assert ale.isSupportedRom(test_rom_path)
+    with pytest.raises(RuntimeError) as exc_info:
+        ale.isSupportedRom("notfound")
+
 def test_save_load_state(tetris):
     state = tetris.cloneState()
     tetris.saveState()


### PR DESCRIPTION
Hardcodes all md5 values into ALE. addresses #337 

Now ALE searches for an ALE game setting with a md5 that matches the ROM setting 
 when roms are loaded.

For backwards compatibility, after the md5 check fails, the old filename
check initiates, and if a matching filename is found, the old warning is generated, along with
an additional message saying what the md5 should be.

Also adds an isSupportedRom method to the interface so that the user can 
verify forcibly whether the rom md5 matches the expected md5, rather than just getting a warning. 