### PR TITLE
[ale_interface] Separate "getString" into copying and non-copying versions.

### DIFF
--- a/src/ale_interface.cpp
+++ b/src/ale_interface.cpp
@@ -218,9 +218,12 @@ void ALEInterface::loadROM(std::string rom_file) {
 }
 
 // Get the value of a setting.
-std::string ALEInterface::getString(const std::string& key) {
+const std::string& ALEInterface::getStringInplace(const std::string& key) {
   assert(theSettings.get());
   return theSettings->getString(key);
+}
+std::string ALEInterface::getString(const std::string& key) {
+  return getStringInplace(key);
 }
 int ALEInterface::getInt(const std::string& key) {
   assert(theSettings.get());

--- a/src/ale_interface.hpp
+++ b/src/ale_interface.hpp
@@ -68,6 +68,12 @@ class ALEInterface {
   bool getBool(const std::string& key);
   float getFloat(const std::string& key);
 
+  // getStringInplace is a version of getString that returns a reference to the
+  // actual, stored settings string object, without making a copy. The reference
+  // is only valid until the next call of any of the setter functions below, so
+  // this function must be used with care.
+  const std::string& getStringInplace(const std::string& key);
+
   // Set the value of a setting. loadRom() must be called before the
   // setting will take effect.
   void setString(const std::string& key, const std::string& value);


### PR DESCRIPTION
The non-copying version is useful for Python bindings in other projects, since it allows viewing the emulator's internal storage without requiring the caller to manage the storage.