### PR TITLE
[games] Renumber game modes.

### DIFF
--- a/src/games/supported/BasicMath.cpp
+++ b/src/games/supported/BasicMath.cpp
@@ -94,22 +94,16 @@ DifficultyVect BasicMathSettings::getAvailableDifficulties() {
 // According to https://atariage.com/manual_html_page.php?SoftwareID=850
 // there are four valid game modes with random artihmetic problems.
 ModeVect BasicMathSettings::getAvailableModes() {
-  return {0, 1, 2, 3};
+  return {5, 6, 7, 8};
 }
 
 void BasicMathSettings::setMode(
     game_mode_t m, System& system,
     std::unique_ptr<StellaEnvironmentWrapper> environment) {
-  if (m < 4) {
-    // Read the mode we are currently in.
-    unsigned char mode = readRam(&system, 0xc5);
-    // Game modes with randomly generated questions are actually [5 - 8].
-    unsigned char matching_mode = 5 + m;
-
+  if (isModeSupported(m)) {
     // Press select until the correct mode is reached.
-    while (mode != matching_mode) {
+    while (readRam(&system, 0xc5) != m) {
       environment->pressSelect(2);
-      mode = readRam(&system, 0xc5);
     }
 
     // Reset the environment to apply changes.

--- a/src/games/supported/FlagCapture.cpp
+++ b/src/games/supported/FlagCapture.cpp
@@ -96,22 +96,16 @@ void FlagCaptureSettings::loadState(Deserializer& ser) {
 // player. These determine whether the flag is stationary or moving and are
 // timed against a fixed 75 second clock.
 ModeVect FlagCaptureSettings::getAvailableModes() {
-  return {0, 1, 2};
+  return {8, 9, 10};
 }
 
 void FlagCaptureSettings::setMode(
     game_mode_t m, System& system,
     std::unique_ptr<StellaEnvironmentWrapper> environment) {
-  if (m < 3) {
-    // Read the mode we are currently in.
-    int mode = readRam(&system, 0xd6);
-    // Single player modes are [8, 10]
-    int desired_mode = m + 8;
-
+  if (isModeSupported(m)) {
     // Press select until the correct mode is reached for single player only.
-    while (mode != desired_mode) {
+    while (readRam(&system, 0xd6) != m) {
       environment->pressSelect(2);
-      mode = readRam(&system, 0xd6);
     }
 
     // Reset the environment to apply changes.

--- a/src/games/supported/MarioBros.cpp
+++ b/src/games/supported/MarioBros.cpp
@@ -100,22 +100,16 @@ void MarioBrosSettings::loadState(Deserializer& ser) {
 // determines whether there are fireballs present and how many lives the player
 // gets to start (3 or 5).
 ModeVect MarioBrosSettings::getAvailableModes() {
-  return {0, 1, 2, 3};
+  return {0, 2, 4, 6};
 }
 
 void MarioBrosSettings::setMode(
     game_mode_t m, System& system,
     std::unique_ptr<StellaEnvironmentWrapper> environment) {
-  if (m < 4) {
-    // Read the mode we are currently in.
-    int mode = readRam(&system, 0x80);
-    // Skip the odd numbered modes are these are for two players.
-    int desired_mode = m * 2;
-
+  if (isModeSupported(m)) {
     // Press select until the correct mode is reached.
-    while (mode != desired_mode) {
+    while (readRam(&system, 0x80) != m) {
       environment->pressSelect(5);
-      mode = readRam(&system, 0x80);
     }
 
     // Reset the environment to apply changes.

--- a/src/games/supported/SpaceWar.cpp
+++ b/src/games/supported/SpaceWar.cpp
@@ -102,19 +102,15 @@ void SpaceWarSettings::loadState(Deserializer& ser) {
 // replenished. We therefore remove the first five modes but the rest [6-17] are
 // valid, with the second (inert) player acting as a distractor when present.
 ModeVect SpaceWarSettings::getAvailableModes() {
-  return {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
+  return {6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17};
 }
 
 void SpaceWarSettings::setMode(
     game_mode_t m, System& system,
     std::unique_ptr<StellaEnvironmentWrapper> environment) {
   if (isModeSupported(m)) {
-    // Ignore the first five modes as these not completable without input from
-    // a second player.
-    int wanted_mode = m + 6;
-
     // Press select until the correct mode is reached.
-    while (getDecimalScore(0xa7, &system) != wanted_mode) {
+    while (getDecimalScore(0xa7, &system) != m) {
       environment->pressSelect(2);
     }
 

--- a/src/games/supported/VideoCheckers.cpp
+++ b/src/games/supported/VideoCheckers.cpp
@@ -111,12 +111,12 @@ void VideoCheckersSettings::loadState(Deserializer& ser) {
 }
 
 ModeVect VideoCheckersSettings::getAvailableModes() {
-  // https://atariage.com/manual_html_page.php?SoftwareID=1429
-  // Index 0 to 8 is regular checkers in increasing difficulty
-  // displayed onscreen and stored in memory as 1 to 9
-  // 9 to 17 is reverse checkers in increasing difficulty
-  // displayed onscreen as 11 to 19 and stored in memory as 17 to 25
-  return {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17};
+  // https://atariage.com/manual_html_page.php?SoftwareID=579
+  // Games 1 to 9 are regular checkers in increasing difficulty,
+  // displayed onscreen and stored in memory as 1 to 9.
+  // Games 11 to 19 are reverse checkers in increasing difficulty,
+  // displayed onscreen as 11 to 19 but stored in memory as 17 to 25.
+  return {1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13, 14, 15, 16, 17, 18, 19};
 }
 
 // Set the game mode.
@@ -125,14 +125,11 @@ void VideoCheckersSettings::setMode(
     game_mode_t m, System& system,
     std::unique_ptr<StellaEnvironmentWrapper> environment) {
   auto availableModes = getAvailableModes();
-  if (std::find(availableModes.begin(), availableModes.end(), m)
-      != availableModes.end()) {
-    m_reverse_checkers = m >= 9;
+  if (isModeSupported(m)) {
+    m_reverse_checkers = m >= 11;
     // apply offset to match corresponding value in memory
     if (m_reverse_checkers) {
-      m += 8;
-    } else {
-      ++m;
+      m += 6;
     }
 
     while (readRam(&system, 0xF6) != m) { environment->pressSelect(1); }


### PR DESCRIPTION
This change undoes a previous "hack" that was needed in order to allow "0" to be a valid game mode. After d3f2b258ed4890a8e10a6ff876436f585d6e6cef, this is no longer required, so this change restores the "original" game mode numbering.

This affects BasicMath, FlagCapture, MarioBors, SpaceWars, and VideoCheckers.