### PR TITLE
Remove leftover settings

### DIFF
--- a/src/common/SoundNull.cxx
+++ b/src/common/SoundNull.cxx
@@ -29,9 +29,6 @@
 SoundNull::SoundNull(OSystem* osystem)
     : Sound(osystem)
 {
-  // Show some info
-  if(myOSystem->settings().getBool("showinfo"))
-    std::cerr << "Sound disabled." << std::endl << std::endl;
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/src/common/SoundSDL.cxx
+++ b/src/common/SoundSDL.cxx
@@ -78,8 +78,6 @@ void SoundSDL::initialize()
   if(!myIsEnabled)
   {
     close();
-    if(myOSystem->settings().getBool("showinfo"))
-      cerr << "Sound disabled." << endl << endl;
     return;
   }
 
@@ -151,17 +149,6 @@ void SoundSDL::initialize()
       // Adjust volume to that defined in settings
       myVolume = myOSystem->settings().getInt("volume");
       setVolume(myVolume);
-
-      // Show some info
-      if(myOSystem->settings().getBool("showinfo"))
-        cerr << "Sound enabled:"  << endl
-             << "  Volume     : " << myVolume << endl
-             << "  Frag size  : " << fragsize << endl
-             << "  Frequency  : " << myHardwareSpec.freq << endl
-             << "  Format     : " << myHardwareSpec.format << endl
-             << "  TIA Freq.  : " << tiafreq << endl
-             << "  Channels   : " << myNumChannels << endl
-             << "  Clip volume: " << (int)clipvol << endl << endl;
     }
   }
 

--- a/src/emucore/OSystem.cxx
+++ b/src/emucore/OSystem.cxx
@@ -53,9 +53,6 @@ OSystem::OSystem()
     myFeatures(""),
     p_display_screen(NULL)
 {
-    #ifdef DISPLAY_OPENGL
-      myFeatures += "OpenGL ";
-    #endif
     #ifdef SOUND_SUPPORT
       myFeatures += "Sound ";
     #endif
@@ -199,14 +196,9 @@ bool OSystem::createConsole(const string& romfile)
       // Create an instance of the 2600 game console
       myConsole = new Console(this, cart, props);
 
-      if(mySettings->getBool("showinfo"))
-        cerr << "Game console created:" << endl
-             << "  ROM file:  " << myRomFile << endl
-             << myConsole->about() << endl;
-      else
-        ale::Logger::Info << "Game console created:" << endl
-             << "  ROM file:  " << myRomFile << endl
-             << myConsole->about() << endl;
+      ale::Logger::Info << "Game console created:" << endl
+            << "  ROM file:  " << myRomFile << endl
+            << myConsole->about() << endl;
 
       // Update the timing info for a new console run
       resetLoopTiming();
@@ -249,16 +241,6 @@ void OSystem::deleteConsole()
   if(myConsole)
   {
     mySound->close();
-    // if(mySettings != NULL && mySettings->getBool("showinfo"))
-    // {
-    //   double executionTime   = (double) myTimingInfo.totalTime / 1000000.0;
-    //   double framesPerSecond = (double) myTimingInfo.totalFrames / executionTime;
-    //   cerr << "Game console stats:" << endl
-    //        << "  Total frames drawn: " << myTimingInfo.totalFrames << endl
-    //        << "  Total time (sec):   " << executionTime << endl
-    //        << "  Frames per second:  " << framesPerSecond << endl
-    //        << endl;
-    // }
     delete myConsole;  
     myConsole = NULL;
   }

--- a/src/emucore/Settings.cxx
+++ b/src/emucore/Settings.cxx
@@ -32,24 +32,7 @@ Settings::Settings(OSystem* osystem) : myOSystem(osystem) {
     // Add this settings object to the OSystem
     myOSystem->attach(this);
 
-    // Add options that are common to all versions of Stella
-    setInternal("video", "soft");
-
-    setInternal("gl_filter", "nearest");
-    setInternal("gl_aspect", "100");
-    setInternal("gl_fsmax", "never");
-    setInternal("gl_lib", "libGL.so");
-    setInternal("gl_vsync", "false");
-    setInternal("gl_texrect", "false");
-
-    setInternal("zoom_ui", "2");
-    setInternal("zoom_tia", "2");
-    setInternal("fullscreen", "false");
-    setInternal("fullres", "");
-    setInternal("center", "true");
-    setInternal("grabmouse", "false");
     setInternal("palette", "standard");
-    setInternal("colorloss", "false");
 
     setInternal("sound", "false");
     setInternal("fragsize", "512");
@@ -57,33 +40,6 @@ Settings::Settings(OSystem* osystem) : myOSystem(osystem) {
     setInternal("tiafreq", "31400");
     setInternal("volume", "100");
     setInternal("clipvol", "true");
-
-    setInternal("keymap", "");
-    setInternal("joymap", "");
-    setInternal("joyaxismap", "");
-    setInternal("joyhatmap", "");
-    setInternal("paddle", "0");
-    setInternal("sa1", "left");
-    setInternal("sa2", "right");
-    setInternal("p0speed", "50");
-    setInternal("p1speed", "50");
-    setInternal("p2speed", "50");
-    setInternal("p3speed", "50");
-    setInternal("pthresh", "600");
-
-    setInternal("showinfo", "false");
-
-    setInternal("ssdir", string(".") + BSPF_PATH_SEPARATOR);
-    setInternal("sssingle", "false");
-
-    setInternal("rombrowse", "true");
-    setInternal("lastrom", "");
-
-    setInternal("debuggerres", "1030x690");
-    setInternal("launcherres", "400x300");
-    setInternal("uipalette", "0");
-    setInternal("mwheel", "4");
-    setInternal("autoslot", "false");
 
     setDefaultSettings();
 }
@@ -101,24 +57,6 @@ void Settings::validate()
   string s;
   int i;
 
-  s = getString("video");
-  if(s != "soft" && s != "gl")
-    setInternal("video", "soft");
-
-#ifdef DISPLAY_OPENGL
-  s = getString("gl_filter");
-  if(s != "linear" && s != "nearest")
-    setInternal("gl_filter", "nearest");
-
-  i = getInt("gl_aspect");
-  if(i < 50 || i > 100)
-    setInternal("gl_aspect", "100");
-
-  s = getString("gl_fsmax");
-  if(s != "never" && s != "ui" && s != "tia" && s != "always")
-    setInternal("gl_fsmax", "never");
-#endif
-
 #ifdef SOUND_SUPPORT
   i = getInt("volume");
   if(i < 0 || i > 100)
@@ -130,24 +68,6 @@ void Settings::validate()
   if(i < 0 || i > 48000)
     setInternal("tiafreq", "31400");
 #endif
-
-  i = getInt("zoom_ui");
-  if(i < 1 || i > 10)
-    setInternal("zoom_ui", "2");
-
-  i = getInt("zoom_tia");
-  if(i < 1 || i > 10)
-    setInternal("zoom_tia", "2");
-
-  i = getInt("paddle");
-  if(i < 0 || i > 3)
-    setInternal("paddle", "0");
-
-  i = getInt("pthresh");
-  if(i < 400)
-    setInternal("pthresh", "400");
-  else if(i > 800)
-    setInternal("pthresh", "800");
 
   s = getString("palette");
   if(s != "standard" && s != "z26" && s != "user")


### PR DESCRIPTION
There were some internal settings leftover from Stella. These are unused and can be removed along with their corresponding side-effects (e.g., `showinfo`, we use Logger).