### PR TITLE
Remove unused `Event` types

### DIFF
--- a/src/emucore/Console.cxx
+++ b/src/emucore/Console.cxx
@@ -295,32 +295,6 @@ void Console::initializeAudio()
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-/* Original frying research and code by Fred Quimby.
-   I've tried the following variations on this code:
-   - Both OR and Exclusive OR instead of AND. This generally crashes the game
-     without ever giving us realistic "fried" effects.
-   - Loop only over the RIOT RAM. This still gave us frying-like effects, but
-     it seemed harder to duplicate most effects. I have no idea why, but
-     munging the TIA regs seems to have some effect (I'd think it wouldn't).
-
-   Fred says he also tried mangling the PC and registers, but usually it'd just
-   crash the game (e.g. black screen, no way out of it).
-
-   It's definitely easier to get some effects (e.g. 255 lives in Battlezone)
-   with this code than it is on a real console. My guess is that most "good"
-   frying effects come from a RIOT location getting cleared to 0. Fred's
-   code is more likely to accomplish this than frying a real console is...
-
-   Until someone comes up with a more accurate way to emulate frying, I'm
-   leaving this as Fred posted it.   -- B.
-*/
-void Console::fry() const
-{
-  for (int ZPmem=0; ZPmem<0x100; ZPmem += myOSystem->rng().next() % 4)
-    mySystem->poke(ZPmem, mySystem->peek(ZPmem) & (uint8_t)myOSystem->rng().next() % 256);
-}
-
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Console::changeYStart(int direction)
 {
   int ystart = atoi(myProperties.get(Display_YStart).c_str());

--- a/src/emucore/Console.hxx
+++ b/src/emucore/Console.hxx
@@ -181,11 +181,6 @@ class Console
     void initializeAudio();
 
     /**
-      "Fry" the Atari (mangle memory/TIA contents)
-    */
-    void fry() const;
-
-    /**
       Change the "Display.YStart" variable.
 
       @param direction +1 indicates increase, -1 indicates decrease.

--- a/src/emucore/Event.hxx
+++ b/src/emucore/Event.hxx
@@ -36,8 +36,7 @@ class Event
     */
     enum Type
     {
-      NoType,
-      ConsoleOn, ConsoleOff, ConsoleColor, ConsoleBlackWhite,
+      ConsoleColor, ConsoleBlackWhite,
       ConsoleLeftDifficultyA, ConsoleLeftDifficultyB,
       ConsoleRightDifficultyA, ConsoleRightDifficultyB,
       ConsoleSelect, ConsoleReset,
@@ -55,13 +54,6 @@ class Event
         PaddleTwoDecrease, PaddleTwoIncrease, PaddleTwoAnalog,
       PaddleThreeResistance, PaddleThreeFire,
         PaddleThreeDecrease, PaddleThreeIncrease, PaddleThreeAnalog,
-
-      ChangeState, LoadState, SaveState, TakeSnapshot, Quit,
-      PauseMode, MenuMode, CmdMenuMode, LauncherMode,
-      Fry, VolumeDecrease, VolumeIncrease,
-
-      UIUp, UIDown, UILeft, UIRight, UIHome, UIEnd, UIPgUp, UIPgDown,
-      UISelect, UINavPrev, UINavNext, UIOK, UICancel,
 
       LastType
     };


### PR DESCRIPTION
We can remove the `Fry` event as it was unused in the ALE.