### PR TITLE
Refactor `OSystem` to remove unused methods

### DIFF
--- a/src/emucore/OSystem.cxx
+++ b/src/emucore/OSystem.cxx
@@ -272,36 +272,6 @@ bool OSystem::openROM(const fs::path& rom, std::string& md5, uint8_t** image, in
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-std::string OSystem::getROMInfo(const fs::path& romfile)
-{
-  std::ostringstream buf;
-
-  // Open the cartridge image and read it in
-  uint8_t* image = nullptr;
-  int size = -1;
-  std::string md5;
-  if(openROM(romfile, md5, &image, &size))
-  {
-    // Get all required info for creating a temporary console
-    Cartridge* cart = nullptr;
-    Properties props;
-    if(queryConsoleInfo(image, size, md5, &cart, props))
-    {
-      Console* console = new Console(this, cart, props);
-      buf << console->about();
-      delete console;
-    }
-    else
-      buf << "ERROR: Couldn't open " << romfile << " ..." << std::endl;
-  }
-
-  // Free the image and console since we don't need it any longer
-  delete[] image;
-
-  return buf.str();
-}
-
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 bool OSystem::queryConsoleInfo(const uint8_t* image, uint32_t size,
                                const std::string& md5,
                                Cartridge** cart, Properties& props)

--- a/src/emucore/OSystem.hxx
+++ b/src/emucore/OSystem.hxx
@@ -90,13 +90,6 @@ class OSystem
     inline Settings& settings() const { return *mySettings; }
 
     /**
-      Get the set of game properties for the system
-
-      @return The properties set object
-    */
-    inline PropertiesSet& propSet() const { return *myPropSet; }
-
-    /**
       Get the console of the system.
 
       @return The console object
@@ -139,15 +132,6 @@ class OSystem
       Also prints some statistics (fps, total frames, etc).
     */
     void deleteConsole();
-
-    /**
-      Gets all possible info about the ROM by creating a temporary
-      Console object and querying it.
-
-      @param romfile  The full pathname of the ROM to use
-      @return  Some information about this ROM
-    */
-    std::string getROMInfo(const fs::path& romfile);
 
     /**
       Open the given ROM and return an array containing its contents.
@@ -204,8 +188,6 @@ class OSystem
     uint32_t myDisplayFrameRate;
 
   private:
-    enum { kNumUIPalettes = 2 };
-
     std::string myRomFile;
 
   public: //ALE


### PR DESCRIPTION
* getROMInfo(...) was used by the Stella CLI, we don't use this method.
* propSet() was used by the Stella CLI & GUI, we don't use this method.
* kNumUIPalettes was used in the Stella GUI UI palette