### PR TITLE
`Sound*` only requires access to `Settings` not `OSystem`

### DIFF
--- a/src/common/SoundNull.cxx
+++ b/src/common/SoundNull.cxx
@@ -20,13 +20,12 @@
 #include "emucore/Deserializer.hxx"
 
 
-#include "emucore/OSystem.hxx"
 #include "emucore/Settings.hxx"
 #include "common/SoundNull.hxx"
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-SoundNull::SoundNull(OSystem* osystem)
-    : Sound(osystem)
+SoundNull::SoundNull(Settings* settings)
+    : Sound(settings)
 {
 }
 

--- a/src/common/SoundNull.hxx
+++ b/src/common/SoundNull.hxx
@@ -19,7 +19,7 @@
 #ifndef SOUND_NULL_HXX
 #define SOUND_NULL_HXX
 
-class OSystem;
+class Settings;
 class Serializer;
 class Deserializer;
 
@@ -39,7 +39,7 @@ class SoundNull : public Sound
       Create a new sound object.  The init method must be invoked before
       using the object.
     */
-    SoundNull(OSystem* osystem);
+    SoundNull(Settings* settings);
 
     /**
       Destructor

--- a/src/common/SoundSDL.cxx
+++ b/src/common/SoundSDL.cxx
@@ -29,15 +29,14 @@
 #include "emucore/Deserializer.hxx"
 #include "emucore/Settings.hxx"
 #include "emucore/System.hxx"
-#include "emucore/OSystem.hxx"
 
 #include "common/SoundSDL.hxx"
 #include "common/Log.hpp"
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-SoundSDL::SoundSDL(OSystem* osystem)
-  : Sound(osystem),
-    myIsEnabled(osystem->settings().getBool("sound")),
+SoundSDL::SoundSDL(Settings* settings)
+  : Sound(settings),
+    myIsEnabled(settings->getBool("sound")),
     myIsInitializedFlag(false),
     myLastRegisterSetCycle(0),
     myDisplayFrameRate(60),
@@ -48,9 +47,9 @@ SoundSDL::SoundSDL(OSystem* osystem)
     myNumRecordSamplesNeeded(0)
 {
 
-    if (osystem->settings().getString("record_sound_filename").size() > 0) {
+    if (mySettings->getString("record_sound_filename").size() > 0) {
       
-        std::string filename = osystem->settings().getString("record_sound_filename");
+        std::string filename = mySettings->getString("record_sound_filename");
         mySoundExporter.reset(new ale::sound::SoundExporter(filename, myNumChannels));
     }
 }
@@ -66,7 +65,7 @@ SoundSDL::~SoundSDL()
 void SoundSDL::setEnabled(bool state)
 {
   myIsEnabled = state;
-  myOSystem->settings().setBool("sound", state);
+  mySettings->setBool("sound", state);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -97,9 +96,9 @@ void SoundSDL::initialize()
     }
     else
     {
-      uint32_t fragsize = myOSystem->settings().getInt("fragsize");
-      int frequency = myOSystem->settings().getInt("freq");
-      int tiafreq   = myOSystem->settings().getInt("tiafreq");
+      uint32_t fragsize = mySettings->getInt("fragsize");
+      int frequency = mySettings->getInt("freq");
+      int tiafreq   = mySettings->getInt("tiafreq");
 
       SDL_AudioSpec desired;
       desired.freq   = frequency;
@@ -141,11 +140,11 @@ void SoundSDL::initialize()
       myTIASound.tiaFrequency(tiafreq);
       myTIASound.channels(myHardwareSpec.channels);
 
-      bool clipvol = myOSystem->settings().getBool("clipvol");
+      bool clipvol = mySettings->getBool("clipvol");
       myTIASound.clipVolume(clipvol);
 
       // Adjust volume to that defined in settings
-      myVolume = myOSystem->settings().getInt("volume");
+      myVolume = mySettings->getInt("volume");
       setVolume(myVolume);
     }
   }
@@ -212,7 +211,7 @@ void SoundSDL::setVolume(int percent)
   {
     if((percent >= 0) && (percent <= 100))
     {
-      myOSystem->settings().setInt("volume", percent);
+      mySettings->setInt("volume", percent);
       SDL_LockAudio();
       myVolume = percent;
       myTIASound.volume(percent);
@@ -238,12 +237,6 @@ void SoundSDL::adjustVolume(int8_t direction)
     return;
 
   setVolume(percent);
-
-  // Now show an onscreen message
-  // strval << percent;
-  // message = "Volume set to ";
-  // message += strval.str();
-  // myOSystem->frameBuffer().showMessage(message);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/src/common/SoundSDL.hxx
+++ b/src/common/SoundSDL.hxx
@@ -21,7 +21,7 @@
 
 #ifdef SOUND_SUPPORT
 
-class OSystem;
+class Settings;
 
 #include "SDL.h"
 
@@ -46,7 +46,7 @@ class SoundSDL : public Sound
       Create a new sound object.  The init method must be invoked before
       using the object.
     */
-    SoundSDL(OSystem* osystem);
+    SoundSDL(Settings* settings);
  
     /**
       Destructor

--- a/src/emucore/Console.hxx
+++ b/src/emucore/Console.hxx
@@ -19,6 +19,7 @@
 #ifndef CONSOLE_HXX
 #define CONSOLE_HXX
 
+class OSystem;
 class Console;
 class Controller;
 class Event;

--- a/src/emucore/OSystem.cxx
+++ b/src/emucore/OSystem.cxx
@@ -138,15 +138,15 @@ void OSystem::createSound()
 #ifdef SOUND_SUPPORT
   // If requested (& supported), enable sound
   if (mySettings->getBool("sound") == true) {
-      mySound = new SoundSDL(this);
+      mySound = new SoundSDL(mySettings);
       mySound->initialize();
   }
   else {
-      mySound = new SoundNull(this);
+      mySound = new SoundNull(mySettings);
   }
 #else
   mySettings->setBool("sound", false);
-  mySound = new SoundNull(this);
+  mySound = new SoundNull(mySettings);
 #endif
 }
 

--- a/src/emucore/Sound.hxx
+++ b/src/emucore/Sound.hxx
@@ -19,7 +19,7 @@
 #ifndef SOUND_HXX
 #define SOUND_HXX
 
-class OSystem;
+class Settings;
 class Serializer;
 class Deserializer;
 
@@ -38,7 +38,7 @@ class Sound
       Create a new sound object.  The init method must be invoked before
       using the object.
     */
-    Sound(OSystem* osystem) { myOSystem = osystem; }
+    Sound(Settings* settings) { mySettings = settings; }
 
     /**
       Destructor
@@ -156,8 +156,8 @@ public:
     virtual bool save(Serializer& out) = 0;
 
   protected:
-    // The OSystem for this sound object
-    OSystem* myOSystem;
+    // The emulator Settings
+    Settings* mySettings;
 };
 
 #endif


### PR DESCRIPTION
We should only require what we use as a parameter. We don't require `OSystem` for anything other than `Settings`.