### PR TITLE
Move OSystem::Random -> System::Random for determinism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `isSupportedROM(path)` to check if a ROM file is supported by the ALE
 - Added new games: Atlantis2, Backgammon, BasicMath, Blackjack, Casino, Crossbow, DarkChambers, Earthworld, Entombed, ET, FlagCapture, Hangman, HauntedHouse, HumanCannonball, Klax, MarioBros, MiniatureGolf, Othello, Pacman, Pitfall2, SpaceWar, Superman, Surround, TicTacToe3D, VideoCheckers, VideoChess, VideoCube, WordZapper (thanks @tkoppe)
 - Added (additional) mode/difficulty settings for: Lost Luggage, Turmoil, Tron Dead Discs, Pong, Mr. Do, King Kong, Frogger, Adventure (thanks @tkoppe)
+- Added `cloneState(include_rng)` which will eventually replace `cloneSystemState` (behind the scenes `cloneSystemState` is equivalent to `cloneState(include_rng=True)`).
 
 ### Changed
 - Rewrote SDL support using SDL2 primitives
@@ -38,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed RL-GLUE support
 - Removed ALE CLI interface
 - Removed Java interface
+- Removed `ALEInterface::load()`, `ALEInterface::save()`. If you require this stack functionality it's easy to implement on your own using `ALEInterface::cloneState(include_rng)`
 - Removed os-dependent filesystem code in favour of C++17 `std::fs`
 - Removed human control mode
 - Removed old makefile build system in favour of CMake

--- a/src/ale_interface.cpp
+++ b/src/ale_interface.cpp
@@ -91,12 +91,6 @@ void ALEInterface::loadSettings(const fs::path& romfile,
     std::exit(1);
   }
 
-  // Must force the resetting of the OSystem's random seed, which is set before we change
-  // choose our random seed.
-  Logger::Info << "Random seed is "
-               << theOSystem->settings().getInt("random_seed") << std::endl;
-  theOSystem->resetRNGSeed();
-
   std::string currentDisplayFormat = theOSystem->console().getFormat();
   theOSystem->colourPalette().setPalette("standard", currentDisplayFormat);
 }
@@ -361,24 +355,20 @@ void ALEInterface::getScreenRGB(std::vector<unsigned char>& output_rgb_buffer) {
 // Returns the current RAM content
 const ALERAM& ALEInterface::getRAM() { return environment->getRAM(); }
 
-// Saves the state of the system
-void ALEInterface::saveState() { environment->save(); }
-
-// Loads the state of the system
-void ALEInterface::loadState() { environment->load(); }
-
-ALEState ALEInterface::cloneState() { return environment->cloneState(); }
+ALEState ALEInterface::cloneState(bool include_rng) {
+  return environment->cloneState(include_rng);
+}
 
 void ALEInterface::restoreState(const ALEState& state) {
   return environment->restoreState(state);
 }
 
 ALEState ALEInterface::cloneSystemState() {
-  return environment->cloneSystemState();
+  return cloneState(true);
 }
 
 void ALEInterface::restoreSystemState(const ALEState& state) {
-  return environment->restoreSystemState(state);
+  return restoreState(state);
 }
 
 void ALEInterface::saveScreenPNG(const std::string& filename) {

--- a/src/ale_interface.hpp
+++ b/src/ale_interface.hpp
@@ -161,26 +161,23 @@ class ALEInterface {
   // Returns the current RAM content
   const ALERAM& getRAM();
 
-  // Saves the state of the system
-  void saveState();
+  // This makes a copy of the environment state. By defualt this copy does *not* include pseudorandomness
+  // making it suitable for planning purposes. If `include_prng` is set to true, then the
+  // pseudorandom number generator is also serialized.
+  ALEState cloneState(bool include_rng = false);
 
-  // Loads the state of the system
-  void loadState();
-
-  // This makes a copy of the environment state. This copy does *not* include pseudorandomness,
-  // making it suitable for planning purposes. By contrast, see cloneSystemState.
-  ALEState cloneState();
-
-  // Reverse operation of cloneState(). This does not restore pseudorandomness, so that repeated
-  // calls to restoreState() in the stochastic controls setting will not lead to the same outcomes.
-  // By contrast, see restoreSystemState.
+  // Reverse operation of cloneState(). This will restore the ALEState, if it was
+  // cloned including the RNG then the RNG will be restored. Otherwise the current
+  // state of the RNG will be kept as is.
   void restoreState(const ALEState& state);
 
   // This makes a copy of the system & environment state, suitable for serialization. This includes
   // pseudorandomness and so is *not* suitable for planning purposes.
+  // This is equivalent to calling cloneState(true) but is maintained for backwards compatibility.
   ALEState cloneSystemState();
 
   // Reverse operation of cloneSystemState.
+  // This is maintained for backwards compatability and is equivalent to calling restoreState(state).
   void restoreSystemState(const ALEState& state);
 
   // Save the current screen as a png file

--- a/src/emucore/Cart.cxx
+++ b/src/emucore/Cart.cxx
@@ -51,7 +51,7 @@
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Cartridge* Cartridge::create(const uint8_t* image, uint32_t size,
-    const Properties& properties, const Settings& settings, Random& rng)
+    const Properties& properties, const Settings& settings)
 {
   Cartridge* cartridge = nullptr;
 
@@ -91,7 +91,7 @@ Cartridge* Cartridge::create(const uint8_t* image, uint32_t size,
   if(type == "2K")
     cartridge = new Cartridge2K(image);
   else if(type == "3E")
-    cartridge = new Cartridge3E(image, size, rng);
+    cartridge = new Cartridge3E(image, size);
   else if(type == "3F")
     cartridge = new Cartridge3F(image, size);
   else if(type == "4A50")
@@ -99,37 +99,37 @@ Cartridge* Cartridge::create(const uint8_t* image, uint32_t size,
   else if(type == "4K")
     cartridge = new Cartridge4K(image);
   else if(type == "AR")
-    cartridge = new CartridgeAR(image, size, true, rng);
+    cartridge = new CartridgeAR(image, size, true);
   else if(type == "DPC")
     cartridge = new CartridgeDPC(image, size);
   else if(type == "E0")
     cartridge = new CartridgeE0(image);
   else if(type == "E7")
-    cartridge = new CartridgeE7(image, rng);
+    cartridge = new CartridgeE7(image);
   else if(type == "F4")
     cartridge = new CartridgeF4(image);
   else if(type == "F4SC")
-    cartridge = new CartridgeF4SC(image, rng);
+    cartridge = new CartridgeF4SC(image);
   else if(type == "F6")
     cartridge = new CartridgeF6(image);
   else if(type == "F6SC")
-    cartridge = new CartridgeF6SC(image, rng);
+    cartridge = new CartridgeF6SC(image);
   else if(type == "F8")
     cartridge = new CartridgeF8(image, false);
   else if(type == "F8 swapped")
     cartridge = new CartridgeF8(image, true);
   else if(type == "F8SC")
-    cartridge = new CartridgeF8SC(image, rng);
+    cartridge = new CartridgeF8SC(image);
   else if(type == "FASC")
-    cartridge = new CartridgeFASC(image, rng);
+    cartridge = new CartridgeFASC(image);
   else if(type == "FE")
     cartridge = new CartridgeFE(image);
   else if(type == "MC")
-    cartridge = new CartridgeMC(image, size, rng);
+    cartridge = new CartridgeMC(image, size);
   else if(type == "MB")
     cartridge = new CartridgeMB(image);
   else if(type == "CV")
-    cartridge = new CartridgeCV(image, size, rng);
+    cartridge = new CartridgeCV(image, size);
   else if(type == "UA")
     cartridge = new CartridgeUA(image);
   else if(type == "0840")

--- a/src/emucore/Cart.hxx
+++ b/src/emucore/Cart.hxx
@@ -26,7 +26,6 @@ class Settings;
 
 #include <fstream>
 #include "emucore/Device.hxx"
-#include "emucore/Random.hxx"
 #include "common/Log.hpp"
 
 /**
@@ -50,7 +49,7 @@ class Cartridge : public Device
       @return   Pointer to the new cartridge object allocated on the heap
     */
     static Cartridge* create(const uint8_t* image, uint32_t size, 
-        const Properties& props, const Settings& settings, Random& rng);
+        const Properties& props, const Settings& settings);
 
     /**
       Create a new cartridge

--- a/src/emucore/Cart3E.cxx
+++ b/src/emucore/Cart3E.cxx
@@ -18,7 +18,6 @@
 
 #include <cassert>
 
-#include "emucore/Random.hxx"
 #include "emucore/System.hxx"
 #include "emucore/TIA.hxx"
 #include "emucore/Serializer.hxx"
@@ -26,7 +25,7 @@
 #include "emucore/Cart3E.hxx"
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Cartridge3E::Cartridge3E(const uint8_t* image, uint32_t size, Random& rng)
+Cartridge3E::Cartridge3E(const uint8_t* image, uint32_t size)
   : mySize(size)
 {
   // Allocate array for the ROM image
@@ -36,12 +35,6 @@ Cartridge3E::Cartridge3E(const uint8_t* image, uint32_t size, Random& rng)
   for(uint32_t addr = 0; addr < mySize; ++addr)
   {
     myImage[addr] = image[addr];
-  }
-
-  // Initialize RAM with random values
-  for(uint32_t i = 0; i < 32768; ++i)
-  {
-    myRam[i] = rng.next();
   }
 }
 
@@ -60,6 +53,10 @@ const char* Cartridge3E::name() const
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Cartridge3E::reset()
 {
+  // Initialize RAM with random values
+  for(uint32_t i = 0; i < 32768; ++i)
+    myRam[i] = mySystem->rng().next();
+
   // We'll map bank 0 into the first segment upon reset
   bank(0);
 }

--- a/src/emucore/Cart3E.hxx
+++ b/src/emucore/Cart3E.hxx
@@ -24,7 +24,6 @@ class Serializer;
 class Deserializer;
 
 #include "emucore/Cart.hxx"
-#include "emucore/Random.hxx"
 
 /**
   This is the cartridge class for Tigervision's bankswitched
@@ -70,9 +69,8 @@ class Cartridge3E : public Cartridge
 
       @param image Pointer to the ROM image
       @param size The size of the ROM image
-      @param rng A random number generator used to populate the initial extra RAM
     */
-    Cartridge3E(const uint8_t* image, uint32_t size, Random& rng);
+    Cartridge3E(const uint8_t* image, uint32_t size);
  
     /**
       Destructor

--- a/src/emucore/CartAR.cxx
+++ b/src/emucore/CartAR.cxx
@@ -21,28 +21,19 @@
 #include <cassert>
 
 #include "emucore/M6502Hi.hxx"
-#include "emucore/Random.hxx"
 #include "emucore/System.hxx"
 #include "emucore/Serializer.hxx"
 #include "emucore/Deserializer.hxx"
 #include "emucore/CartAR.hxx"
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-CartridgeAR::CartridgeAR(const uint8_t* image, uint32_t size, bool fastbios, Random& rng)
+CartridgeAR::CartridgeAR(const uint8_t* image, uint32_t size, bool fastbios)
   : my6502(0)
 {
-  uint32_t i;
-
   // Create a load image buffer and copy the given image
   myLoadImages = new uint8_t[size];
   myNumberOfLoadImages = size / 8448;
   std::memcpy(myLoadImages, image, size);
-
-  // Initialize RAM with random values
-  for(i = 0; i < 6 * 1024; ++i)
-  {
-    myImage[i] = rng.next();
-  }
 
   // Initialize SC BIOS ROM
   initializeROM(fastbios);
@@ -63,6 +54,10 @@ const char* CartridgeAR::name() const
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void CartridgeAR::reset()
 {
+  // Initialize RAM with random values
+  for(uint32_t i = 0; i < 6 * 1024; ++i)
+    myImage[i] = mySystem->rng().next();
+
   myPower = true;
   myPowerRomCycle = mySystem->cycles();
   myWriteEnabled = false;

--- a/src/emucore/CartAR.hxx
+++ b/src/emucore/CartAR.hxx
@@ -25,7 +25,6 @@ class Serializer;
 class Deserializer;
 
 #include "emucore/Cart.hxx"
-#include "emucore/Random.hxx"
 
 /**
   This is the cartridge class for Arcadia (aka Starpath) Supercharger 
@@ -48,9 +47,8 @@ class CartridgeAR : public Cartridge
       @param image     Pointer to the ROM image
       @param size      The size of the ROM image
       @param fastbios  Whether or not to quickly execute the BIOS code
-      @param rng       A random number generator used to populate the initial extra RAM
     */
-    CartridgeAR(const uint8_t* image, uint32_t size, bool fastbios, Random& rng);
+    CartridgeAR(const uint8_t* image, uint32_t size, bool fastbios);
 
     /**
       Destructor

--- a/src/emucore/CartCV.cxx
+++ b/src/emucore/CartCV.cxx
@@ -17,15 +17,15 @@
 //============================================================================
 
 #include <cassert>
+#include <cstring>
 
-#include "emucore/Random.hxx"
 #include "emucore/System.hxx"
 #include "emucore/Serializer.hxx"
 #include "emucore/Deserializer.hxx"
 #include "emucore/CartCV.hxx"
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-CartridgeCV::CartridgeCV(const uint8_t* image, uint32_t size, Random& rng)
+CartridgeCV::CartridgeCV(const uint8_t* image, uint32_t size)
 {
   uint32_t addr;
   if(size == 2048)
@@ -34,12 +34,6 @@ CartridgeCV::CartridgeCV(const uint8_t* image, uint32_t size, Random& rng)
     for(uint32_t addr = 0; addr < 2048; ++addr)
     {
       myImage[addr] = image[addr];
-    }
-
-    // Initialize RAM with random values
-    for(uint32_t i = 0; i < 1024; ++i)
-    {
-      myRAM[i] = rng.next();
     }
   }
   else if(size == 4096)
@@ -53,12 +47,8 @@ CartridgeCV::CartridgeCV(const uint8_t* image, uint32_t size, Random& rng)
       myImage[addr] = image[addr + 2048];
     }
 
-    // Copy the RAM image into my buffer
-    for(addr = 0; addr < 1024; ++addr)
-    {
-      myRAM[addr] = image[addr];
-    }
-
+    myInitialRAM = new uint8_t[1024];
+    std::memcpy(myInitialRAM, image, 1024);
   }
 }
 
@@ -76,6 +66,14 @@ const char* CartridgeCV::name() const
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void CartridgeCV::reset()
 {
+  if (myInitialRAM) {
+    // Copy the RAM image into my buffer
+    std::memcpy(myRAM, myInitialRAM, 1024);
+  } else {
+    // Initialize RAM with random values
+    for(uint32_t i = 0; i < 1024; ++i)
+      myRAM[i] = mySystem->rng().next();
+  }
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/src/emucore/CartCV.hxx
+++ b/src/emucore/CartCV.hxx
@@ -24,7 +24,6 @@ class Serializer;
 class Deserializer;
 
 #include "emucore/Cart.hxx"
-#include "emucore/Random.hxx"
 
 /**
   Cartridge class used for Commavid's extra-RAM games.
@@ -43,9 +42,8 @@ class CartridgeCV : public Cartridge
       Create a new cartridge using the specified image
 
       @param image Pointer to the ROM image
-      @param rng A random number generator used to populate the initial extra RAM
     */
-    CartridgeCV(const uint8_t* image, uint32_t size, Random& rng);
+    CartridgeCV(const uint8_t* image, uint32_t size);
 
     /**
       Destructor
@@ -147,6 +145,10 @@ class CartridgeCV : public Cartridge
 
     // The 1024 bytes of RAM
     uint8_t myRAM[1024];
+
+    // Pointer to the initial RAM data from the cart
+    // This doesn't always exist, so we don't pre-allocate it
+    uint8_t* myInitialRAM;
 };
 
 #endif

--- a/src/emucore/CartE7.cxx
+++ b/src/emucore/CartE7.cxx
@@ -18,25 +18,18 @@
 
 #include <cassert>
 
-#include "emucore/Random.hxx"
 #include "emucore/System.hxx"
 #include "emucore/Serializer.hxx"
 #include "emucore/Deserializer.hxx"
 #include "emucore/CartE7.hxx"
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-CartridgeE7::CartridgeE7(const uint8_t* image, Random& rng)
+CartridgeE7::CartridgeE7(const uint8_t* image)
 {
   // Copy the ROM image into my buffer
   for(uint32_t addr = 0; addr < 16384; ++addr)
   {
     myImage[addr] = image[addr];
-  }
-
-  // Initialize RAM with random values
-  for(uint32_t i = 0; i < 2048; ++i)
-  {
-    myRAM[i] = rng.next();
   }
 }
 
@@ -54,6 +47,10 @@ const char* CartridgeE7::name() const
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void CartridgeE7::reset()
 {
+  // Initialize RAM with random values
+  for(uint32_t i = 0; i < 2048; ++i)
+    myRAM[i] = mySystem->rng().next();
+
   // Install some default banks for the RAM and first segment
   bankRAM(0);
   bank(0);

--- a/src/emucore/CartE7.hxx
+++ b/src/emucore/CartE7.hxx
@@ -24,7 +24,6 @@ class Serializer;
 class Deserializer;
 
 #include "emucore/Cart.hxx"
-#include "emucore/Random.hxx"
 
 /**
   This is the cartridge class for M-Network bankswitched games.  
@@ -62,9 +61,8 @@ class CartridgeE7 : public Cartridge
       Create a new cartridge using the specified image
 
       @param image Pointer to the ROM image
-      @param rng A random number generator used to populate the initial extra RAM
     */
-    CartridgeE7(const uint8_t* image, Random& rng);
+    CartridgeE7(const uint8_t* image);
  
     /**
       Destructor

--- a/src/emucore/CartF4SC.cxx
+++ b/src/emucore/CartF4SC.cxx
@@ -25,18 +25,12 @@
 #include "emucore/CartF4SC.hxx"
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-CartridgeF4SC::CartridgeF4SC(const uint8_t* image, Random& rng)
+CartridgeF4SC::CartridgeF4SC(const uint8_t* image)
 {
   // Copy the ROM image into my buffer
   for(uint32_t addr = 0; addr < 32768; ++addr)
   {
     myImage[addr] = image[addr];
-  }
-
-  // Initialize RAM with random values
-  for(uint32_t i = 0; i < 128; ++i)
-  {
-    myRAM[i] = rng.next();
   }
 }
 
@@ -54,6 +48,10 @@ const char* CartridgeF4SC::name() const
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void CartridgeF4SC::reset()
 {
+  // Initialize RAM with random values
+  for(uint32_t i = 0; i < 128; ++i)
+    myRAM[i] = mySystem->rng().next();
+
   // Upon reset we switch to bank 0
   bank(0);
 }

--- a/src/emucore/CartF4SC.hxx
+++ b/src/emucore/CartF4SC.hxx
@@ -24,7 +24,6 @@ class Serializer;
 class Deserializer;
 
 #include "emucore/Cart.hxx"
-#include "emucore/Random.hxx"
 
 /**
   Cartridge class used for Atari's 32K bankswitched games with
@@ -40,9 +39,8 @@ class CartridgeF4SC : public Cartridge
       Create a new cartridge using the specified image
 
       @param image Pointer to the ROM image
-      @param rng A random number generator used to populate the initial extra RAM
     */
-    CartridgeF4SC(const uint8_t* image, Random& rng);
+    CartridgeF4SC(const uint8_t* image);
  
     /**
       Destructor

--- a/src/emucore/CartF6SC.cxx
+++ b/src/emucore/CartF6SC.cxx
@@ -18,25 +18,18 @@
 
 #include <cassert>
 
-#include "emucore/Random.hxx"
 #include "emucore/System.hxx"
 #include "emucore/Serializer.hxx"
 #include "emucore/Deserializer.hxx"
 #include "emucore/CartF6SC.hxx"
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-CartridgeF6SC::CartridgeF6SC(const uint8_t* image, Random& rng)
+CartridgeF6SC::CartridgeF6SC(const uint8_t* image)
 {
   // Copy the ROM image into my buffer
   for(uint32_t addr = 0; addr < 16384; ++addr)
   {
     myImage[addr] = image[addr];
-  }
-
-  // Initialize RAM with random values
-  for(uint32_t i = 0; i < 128; ++i)
-  {
-    myRAM[i] = rng.next();
   }
 }
 
@@ -54,6 +47,10 @@ const char* CartridgeF6SC::name() const
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void CartridgeF6SC::reset()
 {
+  // Initialize RAM with random values
+  for(uint32_t i = 0; i < 128; ++i)
+    myRAM[i] = mySystem->rng().next();
+
   // Upon reset we switch to bank 0
   bank(0);
 }

--- a/src/emucore/CartF6SC.hxx
+++ b/src/emucore/CartF6SC.hxx
@@ -24,7 +24,6 @@ class Serializer;
 class Deserializer;
 
 #include "emucore/Cart.hxx"
-#include "emucore/Random.hxx"
 
 /**
   Cartridge class used for Atari's 16K bankswitched games with
@@ -40,9 +39,8 @@ class CartridgeF6SC : public Cartridge
       Create a new cartridge using the specified image
 
       @param image Pointer to the ROM image
-      @param rng A random number generator used to populate the initial extra RAM
     */
-    CartridgeF6SC(const uint8_t* image, Random& rng);
+    CartridgeF6SC(const uint8_t* image);
  
     /**
       Destructor

--- a/src/emucore/CartF8SC.cxx
+++ b/src/emucore/CartF8SC.cxx
@@ -18,25 +18,18 @@
 
 #include <cassert>
 
-#include "emucore/Random.hxx"
 #include "emucore/System.hxx"
 #include "emucore/Serializer.hxx"
 #include "emucore/Deserializer.hxx"
 #include "emucore/CartF8SC.hxx"
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-CartridgeF8SC::CartridgeF8SC(const uint8_t* image, Random& rng)
+CartridgeF8SC::CartridgeF8SC(const uint8_t* image)
 {
   // Copy the ROM image into my buffer
   for(uint32_t addr = 0; addr < 8192; ++addr)
   {
     myImage[addr] = image[addr];
-  }
-
-  // Initialize RAM with random values
-  for(uint32_t i = 0; i < 128; ++i)
-  {
-    myRAM[i] = rng.next();
   }
 }
 
@@ -54,6 +47,10 @@ const char* CartridgeF8SC::name() const
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void CartridgeF8SC::reset()
 {
+  // Initialize RAM with random values
+  for(uint32_t i = 0; i < 128; ++i)
+    myRAM[i] = mySystem->rng().next();
+
   // Upon reset we switch to bank 1
   bank(1);
 }

--- a/src/emucore/CartF8SC.hxx
+++ b/src/emucore/CartF8SC.hxx
@@ -24,7 +24,6 @@ class Serializer;
 class Deserializer;
 
 #include "emucore/Cart.hxx"
-#include "emucore/Random.hxx"
 
 /**
   Cartridge class used for Atari's 8K bankswitched games with
@@ -40,9 +39,8 @@ class CartridgeF8SC : public Cartridge
       Create a new cartridge using the specified image
 
       @param image Pointer to the ROM image
-      @param rng A random number generator used to populate the initial extra RAM
     */
-    CartridgeF8SC(const uint8_t* image, Random& rng);
+    CartridgeF8SC(const uint8_t* image);
  
     /**
       Destructor

--- a/src/emucore/CartFASC.cxx
+++ b/src/emucore/CartFASC.cxx
@@ -18,25 +18,18 @@
 
 #include <cassert>
 
-#include "emucore/Random.hxx"
 #include "emucore/System.hxx"
 #include "emucore/Serializer.hxx"
 #include "emucore/Deserializer.hxx"
 #include "emucore/CartFASC.hxx"
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-CartridgeFASC::CartridgeFASC(const uint8_t* image, Random& rng)
+CartridgeFASC::CartridgeFASC(const uint8_t* image)
 {
   // Copy the ROM image into my buffer
   for(uint32_t addr = 0; addr < 12288; ++addr)
   {
     myImage[addr] = image[addr];
-  }
-
-  // Initialize RAM with random values
-  for(uint32_t i = 0; i < 256; ++i)
-  {
-    myRAM[i] = rng.next();
   }
 }
  
@@ -54,6 +47,10 @@ const char* CartridgeFASC::name() const
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void CartridgeFASC::reset()
 {
+  // Initialize RAM with random values
+  for(uint32_t i = 0; i < 256; ++i)
+    myRAM[i] = mySystem->rng().next();
+
   // Upon reset we switch to bank 2
   bank(2);
 }

--- a/src/emucore/CartFASC.hxx
+++ b/src/emucore/CartFASC.hxx
@@ -24,7 +24,6 @@ class Serializer;
 class Deserializer;
 
 #include "emucore/Cart.hxx"
-#include "emucore/Random.hxx"
 
 /**
   Cartridge class used for CBS' RAM Plus cartridges.  There are
@@ -40,9 +39,8 @@ class CartridgeFASC : public Cartridge
       Create a new cartridge using the specified image
 
       @param image Pointer to the ROM image
-      @param rng A random number generator used to populate the initial extra RAM
     */
-    CartridgeFASC(const uint8_t* image, Random& rng);
+    CartridgeFASC(const uint8_t* image);
  
     /**
       Destructor

--- a/src/emucore/CartMC.cxx
+++ b/src/emucore/CartMC.cxx
@@ -18,41 +18,32 @@
 
 #include <cassert>
 
-#include "emucore/Random.hxx"
 #include "emucore/System.hxx"
 #include "emucore/Serializer.hxx"
 #include "emucore/Deserializer.hxx"
 #include "emucore/CartMC.hxx"
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-CartridgeMC::CartridgeMC(const uint8_t* image, uint32_t size, Random& rng)
+CartridgeMC::CartridgeMC(const uint8_t* image, uint32_t size)
   : mySlot3Locked(false)
 {
-  uint32_t i;
-
   // Make sure size is reasonable
   assert(size <= 128 * 1024);
 
   // Allocate array for the cart's RAM
   myRAM = new uint8_t[32 * 1024];
 
-  // Initialize RAM with random values
-  for(i = 0; i < 32 * 1024; ++i)
-  {
-    myRAM[i] = rng.next();
-  }
-
   // Allocate array for the ROM image
   myImage = new uint8_t[128 * 1024];
 
   // Set the contents of the entire ROM to 0
-  for(i = 0; i < 128 * 1024; ++i)
+  for(uint32_t i = 0; i < 128 * 1024; ++i)
   {
     myImage[i] = 0;
   }
 
   // Copy the ROM image to the end of the ROM buffer
-  for(i = 0; i < size; ++i)
+  for(uint32_t i = 0; i < size; ++i)
   {
     myImage[128 * 1024 - size + i] = image[i];
   }
@@ -74,6 +65,9 @@ const char* CartridgeMC::name() const
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void CartridgeMC::reset()
 {
+  // Initialize RAM with random values
+  for(uint32_t i = 0; i < 32 * 1024; ++i)
+    myRAM[i] = mySystem->rng().next();
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/src/emucore/CartMC.hxx
+++ b/src/emucore/CartMC.hxx
@@ -24,7 +24,6 @@ class Serializer;
 class Deserializer;
 
 #include "emucore/Cart.hxx"
-#include "emucore/Random.hxx"
 
 /**
   This is the cartridge class for Chris Wilkson's Megacart.  It does not 
@@ -147,9 +146,8 @@ class CartridgeMC : public Cartridge
 
       @param image Pointer to the ROM image
       @param size The size of the ROM image
-      @param rng A random number generator used to populate the initial extra RAM
     */
-    CartridgeMC(const uint8_t* image, uint32_t size, Random& rng);
+    CartridgeMC(const uint8_t* image, uint32_t size);
  
     /**
       Destructor

--- a/src/emucore/Console.cxx
+++ b/src/emucore/Console.cxx
@@ -99,7 +99,7 @@ Console::Console(OSystem* osystem, Cartridge* cart, const Properties& props)
   mySwitches = new Switches(*myEvent, myProperties);
 
   // Now, we can construct the system and components
-  mySystem = new System();
+  mySystem = new System(myOSystem->settings());
 
   // Inform the controllers about the system
   myControllers[0]->setSystem(mySystem);

--- a/src/emucore/M6532.cxx
+++ b/src/emucore/M6532.cxx
@@ -36,7 +36,7 @@ M6532::M6532(const Console& console)
 
   for(uint32_t t = 0; t < 128; ++t)
   {
-    myRAM[t] = myConsole.osystem().rng().next();
+    myRAM[t] = myConsole.system().rng().next();
   }
 
   // Initialize other data members
@@ -57,7 +57,7 @@ const char* M6532::name() const
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void M6532::reset()
 {
-  myTimer = 25 + (myConsole.osystem().rng().next() % 75);
+  myTimer = 25 + (myConsole.system().rng().next() % 75);
   myIntervalShift = 6;
   myCyclesWhenTimerSet = 0;
   myCyclesWhenInterruptReset = 0;

--- a/src/emucore/OSystem.cxx
+++ b/src/emucore/OSystem.cxx
@@ -29,6 +29,7 @@
 #include "emucore/PropsSet.hxx"
 #include "emucore/Event.hxx"
 #include "emucore/OSystem.hxx"
+#include "emucore/System.hxx"
 
 #ifdef SDL_SUPPORT
   #include "common/ScreenSDL.hpp"
@@ -94,35 +95,8 @@ bool OSystem::create()
   // opened until needed, so this is non-blocking (on those systems
   // that only have a single sound device (no hardware mixing)
   createSound();
-  
-  // Seed RNG. This will likely get re-called, e.g. by the ALEInterface, but is needed
-  // by other interfaces.
-  resetRNGSeed();
 
   return true;
-}
-
-void OSystem::resetRNGSeed() {
-
-  // We seed the random number generator. The 'time' seed is somewhat redundant, since the
-  // rng defaults to time. But we'll do it anyway.
-  if (mySettings->getInt("random_seed") == 0) {
-    myRandGen.seed((uint32_t)time(NULL));
-  } else {
-    int seed = mySettings->getInt("random_seed");
-    assert(seed >= 0);
-    myRandGen.seed((uint32_t)seed);
-  }
-}
-
-bool OSystem::saveState(Serializer& out) {
-
-    // Here we serialize the RNG state.
-    return myRandGen.saveState(out);
-}
-
-bool OSystem::loadState(Deserializer& in) {
-    return myRandGen.loadState(in);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -321,7 +295,7 @@ bool OSystem::queryConsoleInfo(const uint8_t* image, uint32_t size,
     s = mySettings->getString("hmove");
     if(s != "") props.set(Emulation_HmoveBlanks, s);
 
-  *cart = Cartridge::create(image, size, props, *mySettings, myRandGen);
+  *cart = Cartridge::create(image, size, props, *mySettings);
   if(!*cart)
     return false;
 

--- a/src/emucore/OSystem.hxx
+++ b/src/emucore/OSystem.hxx
@@ -152,26 +152,6 @@ class OSystem
     */
     bool openROM(const fs::path& rom, std::string& md5, uint8_t** image, int* size);
 
-    /**
-      Returns the random number generator for this emulator.
-    */
-    Random& rng() { return myRandGen; }
-
-    /**
-      Resets the seed for our random number generator.
-    */
-    void resetRNGSeed();
-
-    /** 
-      Serializes the OSystem state.
-    */
-    bool saveState(Serializer& out);
-
-    /** 
-      Deserializes the OSystem state.
-    */
-    bool loadState(Deserializer& in);
-
   protected:
     // Global Event object  //ALE 
     Event* myEvent;
@@ -190,9 +170,6 @@ class OSystem
 
     // Pointer to the (currently defined) Console object
     Console* myConsole;
-
-    // Random number generator shared across the emulator's components
-    Random myRandGen; 
 
     // Number of times per second to iterate through the main loop
     uint32_t myDisplayFrameRate;

--- a/src/emucore/Settings.cxx
+++ b/src/emucore/Settings.cxx
@@ -387,6 +387,9 @@ void Settings::setDefaultSettings() {
 
     // Stella settings
     stringSettings.insert(std::pair<std::string, std::string>("cpu", "low")); // Reduce CPU emulation fidelity for speed
+    // Random seed for ale::stella::System.
+    // This random seed should be fixed to enable full determinism in the ALE
+    intSettings.insert(std::pair<std::string, int>("system_random_seed", 4753849));
 
     // Controller settings
     intSettings.insert(std::pair<std::string, int>("max_num_frames", 0));
@@ -403,7 +406,7 @@ void Settings::setDefaultSettings() {
 
     // Environment customization settings
     boolSettings.insert(std::pair<std::string, bool>("restricted_action_set", false));
-    intSettings.insert(std::pair<std::string, int>("random_seed", 0));
+    intSettings.insert(std::pair<std::string, int>("random_seed", -1));
     boolSettings.insert(std::pair<std::string, bool>("color_averaging", false));
     boolSettings.insert(std::pair<std::string, bool>("send_rgb", false));
     intSettings.insert(std::pair<std::string, int>("frame_skip", 1));

--- a/src/emucore/System.hxx
+++ b/src/emucore/System.hxx
@@ -25,9 +25,11 @@ class TIA;
 class NullDevice;
 class Serializer;
 class Deserializer;
+class Settings;
 
 #include "emucore/Device.hxx"
 #include "emucore/NullDev.hxx"
+#include "emucore/Random.hxx"
 
 #include <string>
 
@@ -57,7 +59,7 @@ class System
       Create a new system with an addressing space of 2^13 bytes and
       pages of 2^6 bytes.
     */
-    System();
+    System(Settings& settings);
 
     /**
       Destructor
@@ -154,6 +156,15 @@ class System
     TIA& tia()
     {
       return *myTIA;
+    }
+
+    /**
+      Answer the random generator attached to the system.
+      @return The random generator
+    */
+    Random& rng()
+    {
+      return myRandom;
     }
 
     /**
@@ -377,6 +388,10 @@ class System
 
     // TIA device attached to the system or the null pointer
     TIA* myTIA;
+
+    // Many devices need a source of random numbers, usually for emulating
+    // unknown/undefined behaviour
+    Random myRandom;
 
     // Number of system cycles executed since the last reset
     uint32_t myCycles;

--- a/src/environment/ale_state.hpp
+++ b/src/environment/ale_state.hpp
@@ -19,10 +19,12 @@
 #define __ALE_STATE_HPP__
 
 #include <string>
+#include <optional>
 
 #include "common/Constants.h"
 #include "emucore/OSystem.hxx"
 #include "emucore/Event.hxx"
+#include "emucore/Random.hxx"
 #include "common/Log.hpp"
 
 namespace ale {
@@ -98,15 +100,13 @@ class ALEState {
   friend class StellaEnvironment;
 
   // The two methods below are meant to be used by StellaEnvironment.
-  /** Restores the environment to a previously saved state. If load_system == true, we also
-   *  restore system-specific information (such as the RNG state). */
-  void load(OSystem* osystem, RomSettings* settings, std::string md5,
-            const ALEState& rhs, bool load_system);
+  // Restores the environment to a previously saved state.
+  void load(OSystem* osystem, RomSettings* settings, Random* rng, std::string md5,
+            const ALEState& rhs);
 
   /** Returns a "copy" of the current state, including the information necessary to restore
-   *  the emulator. If save_system == true, this includes the RNG state. */
-  ALEState save(OSystem* osystem, RomSettings* settings, std::string md5,
-                bool save_system);
+   *  the emulator. The RNG can optionally be included in the state. */
+  ALEState save(OSystem* osystem, RomSettings* settings, std::optional<Random*> rng, std::string md5);
 
   /** Reset key presses */
   void resetKeys(Event* event_obj);

--- a/src/environment/stella_environment.cpp
+++ b/src/environment/stella_environment.cpp
@@ -19,6 +19,7 @@
 
 #include <sstream>
 #include <cstring>
+#include <optional>
 
 #include "emucore/System.hxx"
 
@@ -46,6 +47,18 @@ StellaEnvironment::StellaEnvironment(OSystem* osystem, RomSettings* settings)
   }
   m_num_reset_steps = 4;
   m_cartridge_md5 = m_osystem->console().properties().get(Cartridge_MD5);
+
+  // Initialize RNG
+  int32_t seed;
+  if (m_osystem->settings().getInt("random_seed") == -1) {
+    seed = time(NULL);
+    m_random.seed((uint32_t)seed);
+  } else {
+    seed = m_osystem->settings().getInt("random_seed");
+    assert(seed >= 0);
+    m_random.seed((uint32_t)seed);
+  }
+  Logger::Info << "Random seed is " << seed << std::endl;
 
   // Set current mode to the ROM's default mode
   m_state.setCurrentMode(settings->getDefaultMode());
@@ -106,36 +119,13 @@ void StellaEnvironment::reset() {
   }
 }
 
-/** Save/restore the environment state. */
-void StellaEnvironment::save() {
-  // Store the current state into a new object
-  ALEState new_state = cloneState();
-  m_saved_states.push(new_state);
-}
-
-void StellaEnvironment::load() {
-  // Get the state on top of the stack
-  ALEState& target_state = m_saved_states.top();
-
-  // Deserialize it into 'm_state'
-  restoreState(target_state);
-  m_saved_states.pop();
-}
-
-ALEState StellaEnvironment::cloneState() {
-  return m_state.save(m_osystem, m_settings, m_cartridge_md5, false);
+ALEState StellaEnvironment::cloneState(bool include_rng) {
+  std::optional<Random*> rng = include_rng ? std::make_optional(&m_random) : std::nullopt;
+  return m_state.save(m_osystem, m_settings, rng, m_cartridge_md5);
 }
 
 void StellaEnvironment::restoreState(const ALEState& target_state) {
-  m_state.load(m_osystem, m_settings, m_cartridge_md5, target_state, false);
-}
-
-ALEState StellaEnvironment::cloneSystemState() {
-  return m_state.save(m_osystem, m_settings, m_cartridge_md5, true);
-}
-
-void StellaEnvironment::restoreSystemState(const ALEState& target_state) {
-  m_state.load(m_osystem, m_settings, m_cartridge_md5, target_state, true);
+  m_state.load(m_osystem, m_settings, &m_random, m_cartridge_md5, target_state);
 }
 
 void StellaEnvironment::noopIllegalActions(Action& player_a_action,
@@ -160,7 +150,7 @@ reward_t StellaEnvironment::act(Action player_a_action,
   // Total reward received as we repeat the action
   reward_t sum_rewards = 0;
 
-  Random& rng = m_osystem->rng();
+  Random& rng = getEnvironmentRNG();
 
   // Apply the same action for a given number of times... note that act() will refuse to emulate
   //  past the terminal state

--- a/src/environment/stella_environment_wrapper.cpp
+++ b/src/environment/stella_environment_wrapper.cpp
@@ -19,8 +19,8 @@ void StellaEnvironmentWrapper::pressSelect(size_t num_steps) {
   m_environment.pressSelect(num_steps);
 }
 
-Random& StellaEnvironmentWrapper::getSystemRng() {
-  return m_environment.getSystemRng();
+Random& StellaEnvironmentWrapper::getEnvironmentRNG() {
+  return m_environment.getEnvironmentRNG();
 }
 
 }  // namespace ale

--- a/src/environment/stella_environment_wrapper.hpp
+++ b/src/environment/stella_environment_wrapper.hpp
@@ -33,7 +33,7 @@ class StellaEnvironmentWrapper {
   reward_t act(Action player_a_action, Action player_b_action);
   void softReset();
   void pressSelect(size_t num_steps = 1);
-  Random& getSystemRng();
+  Random& getEnvironmentRNG();
 
   StellaEnvironment& m_environment;
 };

--- a/src/games/supported/Adventure.cpp
+++ b/src/games/supported/Adventure.cpp
@@ -125,7 +125,7 @@ void AdventureSettings::setMode(
     game_mode_t m, System& system,
     std::unique_ptr<StellaEnvironmentWrapper> environment) {
   if (m < 3) {
-    Random& rng = environment->getSystemRng();
+    Random& rng = environment->getEnvironmentRNG();
     // Read the mode we are currently in.
     unsigned char mode = (readRam(&system, 0xDD) >> 1) & 0x03;
 

--- a/src/python/ale_python_interface.hpp
+++ b/src/python/ale_python_interface.hpp
@@ -188,9 +188,7 @@ PYBIND11_MODULE(_ale_py, m) {
       .def("getRAM", (void (ale::ALEPythonInterface::*)(
                          py::array_t<uint8_t, py::array::c_style>&)) &
                          ale::ALEPythonInterface::getRAM)
-      .def("saveState", &ale::ALEPythonInterface::saveState)
-      .def("loadState", &ale::ALEPythonInterface::loadState)
-      .def("cloneState", &ale::ALEPythonInterface::cloneState)
+      .def("cloneState", &ale::ALEPythonInterface::cloneState, py::kw_only(), py::arg("include_rng") = py::bool_(false))
       .def("restoreState", &ale::ALEPythonInterface::restoreState)
       .def("cloneSystemState", &ale::ALEPythonInterface::cloneSystemState)
       .def("restoreSystemState", &ale::ALEPythonInterface::restoreSystemState)

--- a/src/python/gym/environment.py
+++ b/src/python/gym/environment.py
@@ -332,23 +332,34 @@ class ALGymEnv(gym.Env, utils.EzPickle):
         mapping = dict(zip(keys, values))
         return [mapping[action] for action in self._action_set]
 
-    def clone_state(self) -> ALEState:
+    def clone_state(self, include_rng=False) -> ALEState:
         """Clone emulator state w/o system state. Restoring this state will
         *not* give an identical environment. For complete cloning and restoring
         of the full state, see `{clone,restore}_full_state()`."""
-        return self.ale.cloneState()
+        return self.ale.cloneState(include_rng)
 
-    def restore_state(self, state) -> None:
+    def restore_state(self, state: ALEState) -> None:
         """Restore emulator state w/o system state."""
         self.ale.restoreState(state)
 
     def clone_full_state(self) -> ALEState:
-        """Clone emulator state w/ system state including pseudorandomness.
-        Restoring this state will give an identical environment."""
+        """Deprecated method which would clone the emulator and system state."""
+        logger.warn(
+            "clone_full_state() is deprecated and will be removed in a future release of `ale-py`. "
+            "Please use clone_state() which now returns the full emulator state. "
+            "The only source of stochasticity is `repeat_action_probability` and can be set to `0` "
+            "for fully deterministic emulation."
+        )
         return self.ale.cloneSystemState()
 
-    def restore_full_state(self, state) -> None:
+    def restore_full_state(self, state: ALEState) -> None:
         """Restore emulator state w/ system state including pseudorandomness."""
+        logger.warn(
+            "restore_full_state() is deprecated and will be removed in a future release of `ale-py`. "
+            "Please use restore_state(state) which now restores the full emulator state. "
+            "The only source of stochasticity is `repeat_action_probability` and can be set to `0` "
+            "for fully deterministic emulation."
+        )
         self.ale.restoreSystemState(state)
 
     @property


### PR DESCRIPTION
The ALE is based on v2.4.2 of Stella. Shortly after the 2.4.2 release, the Stella authors moved the RNG from OSystem -> System. This was done to enable cartridges to randomize entries on **reset** instead of construction. This more accurately emulates the hardware and for our purposes allows us to more easily enable full determinism. We can do so by separating the emulator RNG and the environment RNG. Currently, we have two sources of emulator stochasticity

1) Cartridge RAM randomization
2) RAM I/O Timer

Currently, in the ALE, we were using the same RNG for emulator and environment randomness. This has the side effect that `setInt('random_seed', ...)` has a direct effect on some game's behaviour where they wouldn't be fully deterministic. We guarantee that games are deterministic so we should fix the emulator random seed and eventually get rid of these two sources of stochasticity.

With these changes, I thought we'd revisit the cloning API. The distinction between `cloneState` / `cloneSystemState`  has historically been confusing for new users. I propose that we eventually replace `cloneSystemState` by `cloneState(include_rng=True)`. We can include a default of `cloneState(include_rng=False)` for backwards compatibility. In this PR I've implemented the groundwork for `cloneState(include_rng)`. For the time being we've kept `cloneSystemState` / `restoreSystemState` for backwards compatibility. Furthermore, MGB proposed getting rid of the `load` / `save` mechanism in #178. This is now removed.


## Determinism Results

Thanks to @YuhangSong for posting his script in #246.

The following results test if the ALE is deterministic following `loadROM`, i.e.,

```
for each rom
    generate fixed trajectory of actions { A_0, ... A_99 }
    for i = 1 ... 400
        setInt('random_seed', i)
        loadROM( rom )
        replay fixed trajectory
        record observation
    end

    check if all observations are similar
end
```

### Before ~80% deterministic

<details><summary>Show Results</summary>

```
game:name_this_game grouped_num:1 distribution:[400]
game:asteroids grouped_num:1 distribution:[400]
game:chopper_command grouped_num:2 distribution:[383, 17]
game:pitfall2 grouped_num:1 distribution:[400]
game:space_war grouped_num:3 distribution:[201, 107, 92]
game:darkchambers grouped_num:1 distribution:[400]
game:video_cube grouped_num:1 distribution:[400]
game:superman grouped_num:1 distribution:[400]
game:atlantis2 grouped_num:1 distribution:[400]
game:pacman grouped_num:1 distribution:[400]
game:klax grouped_num:1 distribution:[400]
game:demon_attack grouped_num:2 distribution:[341, 59]
game:robotank grouped_num:1 distribution:[400]
game:keystone_kapers grouped_num:1 distribution:[400]
game:pitfall grouped_num:1 distribution:[400]
game:berzerk grouped_num:1 distribution:[400]
game:frostbite grouped_num:2 distribution:[305, 95]
game:battle_zone grouped_num:1 distribution:[400]
game:private_eye grouped_num:2 distribution:[56, 344]
game:qbert grouped_num:1 distribution:[400]
game:seaquest grouped_num:2 distribution:[292, 108]
game:koolaid grouped_num:1 distribution:[400]
game:crossbow grouped_num:1 distribution:[400]
game:tic_tac_toe_3d grouped_num:1 distribution:[400]
game:ms_pacman grouped_num:1 distribution:[400]
game:tetris grouped_num:1 distribution:[400]
game:bowling grouped_num:1 distribution:[400]
game:casino grouped_num:1 distribution:[400]
game:human_cannonball grouped_num:1 distribution:[400]
game:space_invaders grouped_num:1 distribution:[400]
game:star_gunner grouped_num:1 distribution:[400]
game:phoenix grouped_num:1 distribution:[400]
game:hangman grouped_num:4 distribution:[89, 123, 121, 67]
game:fishing_derby grouped_num:2 distribution:[319, 81]
game:basic_math grouped_num:1 distribution:[400]
game:video_chess grouped_num:1 distribution:[400]
game:ice_hockey grouped_num:4 distribution:[68, 107, 49, 176]
game:othello grouped_num:1 distribution:[400]
game:word_zapper grouped_num:1 distribution:[400]
game:trondead grouped_num:1 distribution:[400]
game:alien grouped_num:1 distribution:[400]
game:amidar grouped_num:1 distribution:[400]
game:galaxian grouped_num:1 distribution:[400]
game:adventure grouped_num:1 distribution:[400]
game:turmoil grouped_num:1 distribution:[400]
game:sir_lancelot grouped_num:2 distribution:[112, 288]
game:wizard_of_wor grouped_num:1 distribution:[400]
game:haunted_house grouped_num:2 distribution:[315, 85]
game:crazy_climber grouped_num:1 distribution:[400]
game:centipede grouped_num:1 distribution:[400]
game:mario_bros grouped_num:1 distribution:[400]
game:jamesbond grouped_num:1 distribution:[400]
game:kaboom grouped_num:2 distribution:[90, 310]
game:pong grouped_num:1 distribution:[400]
game:blackjack grouped_num:1 distribution:[400]
game:atlantis grouped_num:1 distribution:[400]
game:asterix grouped_num:1 distribution:[400]
game:lost_luggage grouped_num:1 distribution:[400]
game:frogger grouped_num:1 distribution:[400]
game:video_checkers grouped_num:1 distribution:[400]
game:venture grouped_num:1 distribution:[400]
game:elevator_action grouped_num:48 distribution:[242, 4, 42, 1, 4, 2, 1, 3, 5, 4, 1, 1, 5, 4, 5, 2, 1, 4, 2, 3, 5, 5, 3, 1, 1, 1, 4, 3, 3, 1, 3, 1, 2, 1, 4, 1, 3, 1, 2, 4, 3, 2, 3, 1, 2, 2, 1, 1]
game:montezuma_revenge grouped_num:1 distribution:[400]
game:kangaroo grouped_num:1 distribution:[400]
game:air_raid grouped_num:1 distribution:[400]
game:breakout grouped_num:1 distribution:[400]
game:laser_gates grouped_num:1 distribution:[400]
game:donkey_kong grouped_num:1 distribution:[400]
game:journey_escape grouped_num:1 distribution:[400]
game:entombed grouped_num:1 distribution:[400]
game:video_pinball grouped_num:1 distribution:[400]
game:zaxxon grouped_num:1 distribution:[400]
game:tennis grouped_num:2 distribution:[307, 93]
game:backgammon grouped_num:1 distribution:[400]
game:double_dunk grouped_num:1 distribution:[400]
game:pooyan grouped_num:1 distribution:[400]
game:earthworld grouped_num:1 distribution:[400]
game:carnival grouped_num:1 distribution:[400]
game:beam_rider grouped_num:2 distribution:[354, 46]
game:road_runner grouped_num:1 distribution:[400]
game:flag_capture grouped_num:1 distribution:[400]
game:gravitar grouped_num:1 distribution:[400]
game:miniature_golf grouped_num:1 distribution:[400]
game:et grouped_num:1 distribution:[400]
game:king_kong grouped_num:1 distribution:[400]
game:mr_do grouped_num:1 distribution:[400]
game:hero grouped_num:1 distribution:[400]
game:riverraid grouped_num:1 distribution:[400]
game:solaris grouped_num:49 distribution:[6, 4, 6, 12, 7, 20, 16, 19, 20, 5, 27, 14, 6, 5, 14, 13, 10, 11, 4, 6, 10, 4, 5, 13, 4, 13, 12, 4, 6, 7, 14, 5, 5, 2, 7, 5, 6, 4, 7, 7, 9, 5, 4, 5, 6, 3, 1, 1, 1]
game:surround grouped_num:24 distribution:[36, 13, 25, 10, 23, 15, 14, 10, 10, 14, 19, 27, 10, 16, 12, 25, 19, 14, 20, 17, 10, 13, 19, 9]
game:freeway grouped_num:1 distribution:[400]
game:krull grouped_num:1 distribution:[400]
game:tutankham grouped_num:1 distribution:[400]
game:gopher grouped_num:1 distribution:[400]
game:up_n_down grouped_num:1 distribution:[400]
game:boxing grouped_num:2 distribution:[379, 21]
game:assault grouped_num:53 distribution:[6, 4, 6, 8, 12, 6, 3, 21, 6, 12, 8, 29, 6, 14, 2, 11, 12, 15, 8, 7, 11, 6, 11, 4, 14, 1, 8, 6, 4, 4, 6, 7, 6, 11, 12, 5, 5, 3, 7, 4, 4, 7, 5, 6, 7, 7, 4, 5, 12, 5, 5, 1, 1]
game:skiing grouped_num:1 distribution:[400]
game:defender grouped_num:1 distribution:[400]
game:kung_fu_master grouped_num:1 distribution:[400]
game:time_pilot grouped_num:1 distribution:[400]
game:yars_revenge grouped_num:10 distribution:[117, 47, 32, 116, 31, 18, 8, 16, 13, 2]
game:enduro grouped_num:1 distribution:[400]
game:bank_heist grouped_num:1 distribution:[400]
```

</details>

### After 100% Deterministic

<details><summary>Show Results</summary>

```
game:name_this_game grouped_num:1 distribution:[400]
game:asteroids grouped_num:1 distribution:[400]
game:chopper_command grouped_num:1 distribution:[400]
game:pitfall2 grouped_num:1 distribution:[400]
game:space_war grouped_num:1 distribution:[400]
game:darkchambers grouped_num:1 distribution:[400]
game:video_cube grouped_num:1 distribution:[400]
game:superman grouped_num:1 distribution:[400]
game:atlantis2 grouped_num:1 distribution:[400]
game:pacman grouped_num:1 distribution:[400]
game:klax grouped_num:1 distribution:[400]
game:demon_attack grouped_num:1 distribution:[400]
game:robotank grouped_num:1 distribution:[400]
game:keystone_kapers grouped_num:1 distribution:[400]
game:pitfall grouped_num:1 distribution:[400]
game:berzerk grouped_num:1 distribution:[400]
game:frostbite grouped_num:1 distribution:[400]
game:battle_zone grouped_num:1 distribution:[400]
game:private_eye grouped_num:1 distribution:[400]
game:qbert grouped_num:1 distribution:[400]
game:seaquest grouped_num:1 distribution:[400]
game:koolaid grouped_num:1 distribution:[400]
game:crossbow grouped_num:1 distribution:[400]
game:tic_tac_toe_3d grouped_num:1 distribution:[400]
game:ms_pacman grouped_num:1 distribution:[400]
game:tetris grouped_num:1 distribution:[400]
game:bowling grouped_num:1 distribution:[400]
game:casino grouped_num:1 distribution:[400]
game:human_cannonball grouped_num:1 distribution:[400]
game:space_invaders grouped_num:1 distribution:[400]
game:star_gunner grouped_num:1 distribution:[400]
game:phoenix grouped_num:1 distribution:[400]
game:hangman grouped_num:1 distribution:[400]
game:fishing_derby grouped_num:1 distribution:[400]
game:basic_math grouped_num:1 distribution:[400]
game:video_chess grouped_num:1 distribution:[400]
game:ice_hockey grouped_num:1 distribution:[400]
game:othello grouped_num:1 distribution:[400]
game:word_zapper grouped_num:1 distribution:[400]
game:trondead grouped_num:1 distribution:[400]
game:alien grouped_num:1 distribution:[400]
game:amidar grouped_num:1 distribution:[400]
game:galaxian grouped_num:1 distribution:[400]
game:adventure grouped_num:1 distribution:[400]
game:turmoil grouped_num:1 distribution:[400]
game:sir_lancelot grouped_num:1 distribution:[400]
game:wizard_of_wor grouped_num:1 distribution:[400]
game:haunted_house grouped_num:1 distribution:[400]
game:crazy_climber grouped_num:1 distribution:[400]
game:centipede grouped_num:1 distribution:[400]
game:mario_bros grouped_num:1 distribution:[400]
game:jamesbond grouped_num:1 distribution:[400]
game:kaboom grouped_num:1 distribution:[400]
game:pong grouped_num:1 distribution:[400]
game:blackjack grouped_num:1 distribution:[400]
game:atlantis grouped_num:1 distribution:[400]
game:asterix grouped_num:1 distribution:[400]
game:lost_luggage grouped_num:1 distribution:[400]
game:frogger grouped_num:1 distribution:[400]
game:video_checkers grouped_num:1 distribution:[400]
game:venture grouped_num:1 distribution:[400]
game:elevator_action grouped_num:1 distribution:[400]
game:montezuma_revenge grouped_num:1 distribution:[400]
game:kangaroo grouped_num:1 distribution:[400]
game:air_raid grouped_num:1 distribution:[400]
game:breakout grouped_num:1 distribution:[400]
game:laser_gates grouped_num:1 distribution:[400]
game:donkey_kong grouped_num:1 distribution:[400]
game:journey_escape grouped_num:1 distribution:[400]
game:entombed grouped_num:1 distribution:[400]
game:video_pinball grouped_num:1 distribution:[400]
game:zaxxon grouped_num:1 distribution:[400]
game:tennis grouped_num:1 distribution:[400]
game:backgammon grouped_num:1 distribution:[400]
game:double_dunk grouped_num:1 distribution:[400]
game:pooyan grouped_num:1 distribution:[400]
game:earthworld grouped_num:1 distribution:[400]
game:carnival grouped_num:1 distribution:[400]
game:beam_rider grouped_num:1 distribution:[400]
game:road_runner grouped_num:1 distribution:[400]
game:flag_capture grouped_num:1 distribution:[400]
game:gravitar grouped_num:1 distribution:[400]
game:miniature_golf grouped_num:1 distribution:[400]
game:et grouped_num:1 distribution:[400]
game:king_kong grouped_num:1 distribution:[400]
game:mr_do grouped_num:1 distribution:[400]
game:hero grouped_num:1 distribution:[400]
game:riverraid grouped_num:1 distribution:[400]
game:solaris grouped_num:1 distribution:[400]
game:surround grouped_num:1 distribution:[400]
game:freeway grouped_num:1 distribution:[400]
game:krull grouped_num:1 distribution:[400]
game:tutankham grouped_num:1 distribution:[400]
game:gopher grouped_num:1 distribution:[400]
game:up_n_down grouped_num:1 distribution:[400]
game:boxing grouped_num:1 distribution:[400]
game:assault grouped_num:1 distribution:[400]
game:skiing grouped_num:1 distribution:[400]
game:defender grouped_num:1 distribution:[400]
game:kung_fu_master grouped_num:1 distribution:[400]
game:time_pilot grouped_num:1 distribution:[400]
game:yars_revenge grouped_num:1 distribution:[400]
game:enduro grouped_num:1 distribution:[400]
game:bank_heist grouped_num:1 distribution:[400]
```

</details>