### PR TITLE
Process the screen and RAM after restoring a state

### DIFF
--- a/src/environment/stella_environment.cpp
+++ b/src/environment/stella_environment.cpp
@@ -128,6 +128,8 @@ ALEState StellaEnvironment::cloneState() {
 
 void StellaEnvironment::restoreState(const ALEState& target_state) {
   m_state.load(m_osystem, m_settings, m_cartridge_md5, target_state, false);
+  processScreen();
+  processRAM();
 }
 
 ALEState StellaEnvironment::cloneSystemState() {


### PR DESCRIPTION
This commit would make StellaEnvironment::restoreState() update the current screen and RAM to match the restored state. Currently, restoring a state and then calling getScreen() or getRAM() returns stale values until an action is taken, since only pressSelect() and emulate() update the m_screen and m_ram variables within StellaEnvironment. I don't think that behavior was intended, or at least it's not documented anywhere, and it's a bit confusing imo (I finally tracked down a bug in some of my own code to this behavior).