### PR TITLE
Add a missing std namespace qualifier

### DIFF
--- a/src/emucore/OSystem.cxx
+++ b/src/emucore/OSystem.cxx
@@ -190,7 +190,7 @@ bool OSystem::createConsole(const fs::path& romfile)
 #else
     ale::Logger::Info << "Setting `display_screen` is enabled "
                       << "but SDL_SUPPORT is disabled. To display the "
-                      << "screen SDL_SUPPORT must be enabled." << endl;
+                      << "screen SDL_SUPPORT must be enabled." << std::endl;
 #endif
   }
 


### PR DESCRIPTION
This causes a build failure for me when building without SDL support.