### PR TITLE
ALE Namespace wrapper for emucore

### DIFF
--- a/src/ale_interface.cpp
+++ b/src/ale_interface.cpp
@@ -55,6 +55,7 @@
 namespace fs = std::filesystem;
 
 namespace ale {
+using namespace stella;
 
 // Display ALE welcome message
 std::string ALEInterface::welcomeMessage() {

--- a/src/ale_interface.hpp
+++ b/src/ale_interface.hpp
@@ -193,8 +193,8 @@ class ALEInterface {
   ScreenExporter* createScreenExporter(const std::string& path) const;
 
  public:
-  std::unique_ptr<OSystem> theOSystem;
-  std::unique_ptr<Settings> theSettings;
+  std::unique_ptr<stella::OSystem> theOSystem;
+  std::unique_ptr<stella::Settings> theSettings;
   std::unique_ptr<RomSettings> romSettings;
   std::unique_ptr<StellaEnvironment> environment;
   int max_num_frames; // Maximum number of frames for each episode
@@ -205,10 +205,10 @@ class ALEInterface {
   // Display ALE welcome message
   static std::string welcomeMessage();
   static void disableBufferedIO();
-  static void createOSystem(std::unique_ptr<OSystem>& theOSystem,
-                            std::unique_ptr<Settings>& theSettings);
+  static void createOSystem(std::unique_ptr<stella::OSystem>& theOSystem,
+                            std::unique_ptr<stella::Settings>& theSettings);
   static void loadSettings(const fs::path& romfile,
-                           std::unique_ptr<OSystem>& theOSystem);
+                           std::unique_ptr<stella::OSystem>& theOSystem);
 };
 
 }  // namespace ale

--- a/src/common/ScreenSDL.cpp
+++ b/src/common/ScreenSDL.cpp
@@ -24,6 +24,7 @@
 using namespace std;
 
 namespace ale {
+using namespace stella;
 
 ScreenSDL::ScreenSDL(OSystem* osystem) :
   Screen(osystem),

--- a/src/common/ScreenSDL.hpp
+++ b/src/common/ScreenSDL.hpp
@@ -28,9 +28,9 @@
 
 namespace ale {
 
-class ScreenSDL : public Screen {
+class ScreenSDL : public stella::Screen {
 public:
-    ScreenSDL(OSystem* osystem);
+    ScreenSDL(stella::OSystem* osystem);
     virtual ~ScreenSDL();
 
     // Displays the current frame buffer from the mediasource.
@@ -51,8 +51,8 @@ private:
     uint32_t screenWidth, screenHeight;
 
     // ALE primitives
-    MediaSource* mediaSource;
-    Sound* sound;
+    stella::MediaSource* mediaSource;
+    stella::Sound* sound;
     ColourPalette* colourPalette;
 
     // SDL Primitives

--- a/src/common/SoundNull.cxx
+++ b/src/common/SoundNull.cxx
@@ -23,6 +23,8 @@
 #include "emucore/Settings.hxx"
 #include "common/SoundNull.hxx"
 
+namespace ale {
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 SoundNull::SoundNull(Settings* settings)
     : Sound(settings)
@@ -73,3 +75,5 @@ bool SoundNull::save(Serializer& out)
 
   return true;
 }
+
+}  // namespace ale

--- a/src/common/SoundNull.cxx
+++ b/src/common/SoundNull.cxx
@@ -24,6 +24,7 @@
 #include "common/SoundNull.hxx"
 
 namespace ale {
+using namespace stella;   // Settings, Serializer, Deserializer
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 SoundNull::SoundNull(Settings* settings)

--- a/src/common/SoundNull.hxx
+++ b/src/common/SoundNull.hxx
@@ -19,11 +19,15 @@
 #ifndef SOUND_NULL_HXX
 #define SOUND_NULL_HXX
 
+namespace ale {
 class Settings;
 class Serializer;
 class Deserializer;
+}  // namespace ale
 
 #include "emucore/Sound.hxx"
+
+namespace ale {
 
 /**
   This class implements a Null sound object, where-by sound generation
@@ -157,5 +161,7 @@ public:
     */
     bool save(Serializer& out);
 };
+
+}  // namespace ale
 
 #endif

--- a/src/common/SoundNull.hxx
+++ b/src/common/SoundNull.hxx
@@ -20,9 +20,13 @@
 #define SOUND_NULL_HXX
 
 namespace ale {
+namespace stella {
+
 class Settings;
 class Serializer;
 class Deserializer;
+
+}  // namespace stella
 }  // namespace ale
 
 #include "emucore/Sound.hxx"
@@ -36,14 +40,14 @@ namespace ale {
   @author Stephen Anthony
   @version $Id: SoundNull.hxx,v 1.6 2007/01/01 18:04:40 stephena Exp $
 */
-class SoundNull : public Sound
+class SoundNull : public stella::Sound
 {
   public:
     /**
       Create a new sound object.  The init method must be invoked before
       using the object.
     */
-    SoundNull(Settings* settings);
+    SoundNull(stella::Settings* settings);
 
     /**
       Destructor
@@ -151,7 +155,7 @@ public:
       @param in The deserializer device to load from.
       @return The result of the load.  True on success, false on failure.
     */
-    bool load(Deserializer& in);
+    bool load(stella::Deserializer& in);
 
     /**
       Saves the current state of this device to the given Serializer.
@@ -159,7 +163,7 @@ public:
       @param out The serializer device to save to.
       @return The result of the save.  True on success, false on failure.
     */
-    bool save(Serializer& out);
+    bool save(stella::Serializer& out);
 };
 
 }  // namespace ale

--- a/src/common/SoundSDL.cxx
+++ b/src/common/SoundSDL.cxx
@@ -33,6 +33,8 @@
 #include "common/SoundSDL.hxx"
 #include "common/Log.hpp"
 
+namespace ale {
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 SoundSDL::SoundSDL(Settings* settings)
   : Sound(settings),
@@ -582,5 +584,7 @@ void SoundSDL::RegWriteQueue::grow()
   delete[] myBuffer;
   myBuffer = buffer;
 }
+
+}  // namespace ale
 
 #endif  // SDL_SUPPORT

--- a/src/common/SoundSDL.cxx
+++ b/src/common/SoundSDL.cxx
@@ -34,6 +34,7 @@
 #include "common/Log.hpp"
 
 namespace ale {
+using namespace stella;   // Settings, Serializer, Deserializer
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 SoundSDL::SoundSDL(Settings* settings)

--- a/src/common/SoundSDL.hxx
+++ b/src/common/SoundSDL.hxx
@@ -21,7 +21,9 @@
 
 #ifdef SDL_SUPPORT
 
+namespace ale {
 class Settings;
+}  // namespace ale
 
 #include "emucore/Sound.hxx"
 #include "emucore/MediaSrc.hxx"
@@ -31,6 +33,8 @@ class Settings;
 // If desired, we save sound to disk
 #include "common/SoundExporter.hpp"
 #include <memory>
+
+namespace ale {
 
 /**
   This class implements the sound API for SDL.
@@ -289,6 +293,8 @@ class SoundSDL : public Sound
 
     std::unique_ptr<ale::sound::SoundExporter> mySoundExporter;
 };
+
+}  // namespace ale
 
 #endif  // SDL_SUPPORT
 #endif

--- a/src/common/SoundSDL.hxx
+++ b/src/common/SoundSDL.hxx
@@ -22,7 +22,11 @@
 #ifdef SDL_SUPPORT
 
 namespace ale {
+namespace stella {
+
 class Settings;
+
+}  // namespace stella
 }  // namespace ale
 
 #include "emucore/Sound.hxx"
@@ -42,14 +46,14 @@ namespace ale {
   @author Stephen Anthony and Bradford W. Mott
   @version $Id: SoundSDL.hxx,v 1.18 2007/01/01 18:04:40 stephena Exp $
 */
-class SoundSDL : public Sound
+class SoundSDL : public stella::Sound
 {
   public:
     /**
       Create a new sound object.  The init method must be invoked before
       using the object.
     */
-    SoundSDL(Settings* settings);
+    SoundSDL(stella::Settings* settings);
  
     /**
       Destructor
@@ -156,7 +160,7 @@ class SoundSDL : public Sound
       @param in The deserializer device to load from.
       @return The result of the load.  True on success, false on failure.
     */
-    bool load(Deserializer& in);
+    bool load(stella::Deserializer& in);
 
     /**
       Saves the current state of this device to the given Serializer.
@@ -164,7 +168,7 @@ class SoundSDL : public Sound
       @param out The serializer device to save to.
       @return The result of the save.  True on success, false on failure.
     */
-    bool save(Serializer& out);
+    bool save(stella::Serializer& out);
 
   protected:
     /**
@@ -252,7 +256,7 @@ class SoundSDL : public Sound
 
   private:
     // TIASound emulation object
-    TIASound myTIASound;
+    stella::TIASound myTIASound;
 
     // Indicates if the sound subsystem is to be initialized
     bool myIsEnabled;

--- a/src/emucore/Cart.cxx
+++ b/src/emucore/Cart.cxx
@@ -49,6 +49,8 @@
 #include "emucore/Props.hxx"
 #include "emucore/Settings.hxx"
 
+namespace ale {
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Cartridge* Cartridge::create(const uint8_t* image, uint32_t size,
     const Properties& properties, const Settings& settings)
@@ -471,3 +473,5 @@ Cartridge& Cartridge::operator = (const Cartridge&)
   assert(false);
   return *this;
 }
+
+}  // namespace ale

--- a/src/emucore/Cart.cxx
+++ b/src/emucore/Cart.cxx
@@ -50,6 +50,7 @@
 #include "emucore/Settings.hxx"
 
 namespace ale {
+namespace stella {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Cartridge* Cartridge::create(const uint8_t* image, uint32_t size,
@@ -474,4 +475,5 @@ Cartridge& Cartridge::operator = (const Cartridge&)
   return *this;
 }
 
+}  // namespace stella
 }  // namespace ale

--- a/src/emucore/Cart.hxx
+++ b/src/emucore/Cart.hxx
@@ -20,10 +20,14 @@
 #define CARTRIDGE_HXX
 
 namespace ale {
+namespace stella {
+
 class Cartridge;
 class System;
 class Properties;
 class Settings;
+
+}  // namespace stella
 }  // namespace ale
 
 #include <fstream>
@@ -31,6 +35,7 @@ class Settings;
 #include "common/Log.hpp"
 
 namespace ale {
+namespace stella {
 
 /**
   A cartridge is a device which contains the machine code for a 
@@ -206,6 +211,7 @@ class Cartridge : public Device
     Cartridge& operator = (const Cartridge&);
 };
 
+}  // namespace stella
 }  // namespace ale
 
 #endif

--- a/src/emucore/Cart.hxx
+++ b/src/emucore/Cart.hxx
@@ -19,14 +19,18 @@
 #ifndef CARTRIDGE_HXX
 #define CARTRIDGE_HXX
 
+namespace ale {
 class Cartridge;
 class System;
 class Properties;
 class Settings;
+}  // namespace ale
 
 #include <fstream>
 #include "emucore/Device.hxx"
 #include "common/Log.hpp"
+
+namespace ale {
 
 /**
   A cartridge is a device which contains the machine code for a 
@@ -201,5 +205,7 @@ class Cartridge : public Device
     // Assignment operator isn't supported by cartridges so make it private
     Cartridge& operator = (const Cartridge&);
 };
+
+}  // namespace ale
 
 #endif

--- a/src/emucore/Cart0840.cxx
+++ b/src/emucore/Cart0840.cxx
@@ -23,6 +23,8 @@
 #include "emucore/Deserializer.hxx"
 #include "emucore/Cart0840.hxx"
 
+namespace ale {
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Cartridge0840::Cartridge0840(const uint8_t* image)
 {
@@ -101,3 +103,5 @@ uint8_t* Cartridge0840::getImage(int& size)
   size = 0;
   return 0;
 }
+
+}  // namespace ale

--- a/src/emucore/Cart0840.cxx
+++ b/src/emucore/Cart0840.cxx
@@ -24,6 +24,7 @@
 #include "emucore/Cart0840.hxx"
 
 namespace ale {
+namespace stella {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Cartridge0840::Cartridge0840(const uint8_t* image)
@@ -104,4 +105,5 @@ uint8_t* Cartridge0840::getImage(int& size)
   return 0;
 }
 
+}  // namespace stella
 }  // namespace ale

--- a/src/emucore/Cart0840.hxx
+++ b/src/emucore/Cart0840.hxx
@@ -19,11 +19,15 @@
 #ifndef CARTRIDGE0840_HXX
 #define CARTRIDGE0840_HXX
 
+namespace ale {
 class System;
 class Serializer;
 class Deserializer;
+}  // namespace ale
 
 #include "emucore/Cart.hxx"
+
+namespace ale {
 
 /**
   Cartridge class used for 0840 "Econobanking" 8K bankswitched games.  There
@@ -135,5 +139,7 @@ class Cartridge0840 : public Cartridge
     */
     virtual void poke(uint16_t address, uint8_t value);
 };
+
+}  // namespace ale
 
 #endif

--- a/src/emucore/Cart0840.hxx
+++ b/src/emucore/Cart0840.hxx
@@ -20,14 +20,19 @@
 #define CARTRIDGE0840_HXX
 
 namespace ale {
+namespace stella {
+
 class System;
 class Serializer;
 class Deserializer;
+
+}  // namespace stella
 }  // namespace ale
 
 #include "emucore/Cart.hxx"
 
 namespace ale {
+namespace stella {
 
 /**
   Cartridge class used for 0840 "Econobanking" 8K bankswitched games.  There
@@ -140,6 +145,7 @@ class Cartridge0840 : public Cartridge
     virtual void poke(uint16_t address, uint8_t value);
 };
 
+}  // namespace stella
 }  // namespace ale
 
 #endif

--- a/src/emucore/Cart2K.cxx
+++ b/src/emucore/Cart2K.cxx
@@ -23,6 +23,8 @@
 #include "emucore/Deserializer.hxx"
 #include "emucore/Cart2K.hxx"
 
+namespace ale {
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Cartridge2K::Cartridge2K(const uint8_t* image)
 {
@@ -162,3 +164,5 @@ uint8_t* Cartridge2K::getImage(int& size)
   size = 2048;
   return &myImage[0];
 }
+
+}  // namespace ale

--- a/src/emucore/Cart2K.cxx
+++ b/src/emucore/Cart2K.cxx
@@ -24,6 +24,7 @@
 #include "emucore/Cart2K.hxx"
 
 namespace ale {
+namespace stella {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Cartridge2K::Cartridge2K(const uint8_t* image)
@@ -165,4 +166,5 @@ uint8_t* Cartridge2K::getImage(int& size)
   return &myImage[0];
 }
 
+}  // namespace stella
 }  // namespace ale

--- a/src/emucore/Cart2K.hxx
+++ b/src/emucore/Cart2K.hxx
@@ -20,14 +20,19 @@
 #define CARTRIDGE2K_HXX
 
 namespace ale {
+namespace stella {
+
 class System;
 class Serializer;
 class Deserializer;
+
+}  // namespace stella
 }  // namespace ale
 
 #include "emucore/Cart.hxx"
 
 namespace ale {
+namespace stella {
 
 /**
   This is the standard Atari 2K cartridge.  These cartridges 
@@ -146,6 +151,7 @@ class Cartridge2K : public Cartridge
     uint8_t myImage[2048];
 };
 
+}  // namespace stella
 }  // namespace ale
 
 #endif

--- a/src/emucore/Cart2K.hxx
+++ b/src/emucore/Cart2K.hxx
@@ -19,11 +19,15 @@
 #ifndef CARTRIDGE2K_HXX
 #define CARTRIDGE2K_HXX
 
+namespace ale {
 class System;
 class Serializer;
 class Deserializer;
+}  // namespace ale
 
 #include "emucore/Cart.hxx"
+
+namespace ale {
 
 /**
   This is the standard Atari 2K cartridge.  These cartridges 
@@ -141,5 +145,7 @@ class Cartridge2K : public Cartridge
     // The 2k ROM image for the cartridge
     uint8_t myImage[2048];
 };
+
+}  // namespace ale
 
 #endif

--- a/src/emucore/Cart3E.cxx
+++ b/src/emucore/Cart3E.cxx
@@ -25,6 +25,7 @@
 #include "emucore/Cart3E.hxx"
 
 namespace ale {
+namespace stella {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Cartridge3E::Cartridge3E(const uint8_t* image, uint32_t size)
@@ -306,4 +307,5 @@ uint8_t* Cartridge3E::getImage(int& size)
   return &myImage[0];
 }
 
+}  // namespace stella
 }  // namespace ale

--- a/src/emucore/Cart3E.cxx
+++ b/src/emucore/Cart3E.cxx
@@ -24,6 +24,8 @@
 #include "emucore/Deserializer.hxx"
 #include "emucore/Cart3E.hxx"
 
+namespace ale {
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Cartridge3E::Cartridge3E(const uint8_t* image, uint32_t size)
   : mySize(size)
@@ -303,3 +305,5 @@ uint8_t* Cartridge3E::getImage(int& size)
   size = mySize;
   return &myImage[0];
 }
+
+}  // namespace ale

--- a/src/emucore/Cart3E.hxx
+++ b/src/emucore/Cart3E.hxx
@@ -19,11 +19,15 @@
 #ifndef CARTRIDGE3E_HXX
 #define CARTRIDGE3E_HXX
 
+namespace ale {
 class System;
 class Serializer;
 class Deserializer;
+}  // namespace ale
 
 #include "emucore/Cart.hxx"
+
+namespace ale {
 
 /**
   This is the cartridge class for Tigervision's bankswitched
@@ -179,5 +183,7 @@ class Cartridge3E : public Cartridge
     // Size of the ROM image
     uint32_t mySize;
 };
+
+}  // namespace ale
 
 #endif

--- a/src/emucore/Cart3E.hxx
+++ b/src/emucore/Cart3E.hxx
@@ -20,14 +20,19 @@
 #define CARTRIDGE3E_HXX
 
 namespace ale {
+namespace stella {
+
 class System;
 class Serializer;
 class Deserializer;
+
+}  // namespace stella
 }  // namespace ale
 
 #include "emucore/Cart.hxx"
 
 namespace ale {
+namespace stella {
 
 /**
   This is the cartridge class for Tigervision's bankswitched
@@ -184,6 +189,7 @@ class Cartridge3E : public Cartridge
     uint32_t mySize;
 };
 
+}  // namespace stella
 }  // namespace ale
 
 #endif

--- a/src/emucore/Cart3F.cxx
+++ b/src/emucore/Cart3F.cxx
@@ -24,6 +24,8 @@
 #include "emucore/Deserializer.hxx"
 #include "emucore/Cart3F.hxx"
 
+namespace ale {
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Cartridge3F::Cartridge3F(const uint8_t* image, uint32_t size)
   : mySize(size)
@@ -241,3 +243,5 @@ uint8_t* Cartridge3F::getImage(int& size)
   size = mySize;
   return &myImage[0];
 }
+
+}  // namespace ale

--- a/src/emucore/Cart3F.cxx
+++ b/src/emucore/Cart3F.cxx
@@ -25,6 +25,7 @@
 #include "emucore/Cart3F.hxx"
 
 namespace ale {
+namespace stella {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Cartridge3F::Cartridge3F(const uint8_t* image, uint32_t size)
@@ -244,4 +245,5 @@ uint8_t* Cartridge3F::getImage(int& size)
   return &myImage[0];
 }
 
+}  // namespace stella
 }  // namespace ale

--- a/src/emucore/Cart3F.hxx
+++ b/src/emucore/Cart3F.hxx
@@ -20,14 +20,19 @@
 #define CARTRIDGE3F_HXX
 
 namespace ale {
+namespace stella {
+
 class System;
 class Serializer;
 class Deserializer;
+
+}  // namespace stella
 }  // namespace ale
 
 #include "emucore/Cart.hxx"
 
 namespace ale {
+namespace stella {
 
 /**
   This is the cartridge class for Tigervision's bankswitched 
@@ -158,6 +163,7 @@ class Cartridge3F : public Cartridge
     uint32_t mySize;
 };
 
+}  // namespace stella
 }  // namespace ale
 
 #endif

--- a/src/emucore/Cart3F.hxx
+++ b/src/emucore/Cart3F.hxx
@@ -19,11 +19,15 @@
 #ifndef CARTRIDGE3F_HXX
 #define CARTRIDGE3F_HXX
 
+namespace ale {
 class System;
 class Serializer;
 class Deserializer;
+}  // namespace ale
 
 #include "emucore/Cart.hxx"
+
+namespace ale {
 
 /**
   This is the cartridge class for Tigervision's bankswitched 
@@ -153,5 +157,7 @@ class Cartridge3F : public Cartridge
     // Size of the ROM image
     uint32_t mySize;
 };
+
+}  // namespace ale
 
 #endif

--- a/src/emucore/Cart4A50.cxx
+++ b/src/emucore/Cart4A50.cxx
@@ -24,6 +24,7 @@
 #include "emucore/Cart4A50.hxx"
 
 namespace ale {
+namespace stella {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Cartridge4A50::Cartridge4A50(const uint8_t* image)
@@ -104,4 +105,5 @@ uint8_t* Cartridge4A50::getImage(int& size)
   return 0;
 }
 
+}  // namespace stella
 }  // namespace ale

--- a/src/emucore/Cart4A50.cxx
+++ b/src/emucore/Cart4A50.cxx
@@ -23,6 +23,8 @@
 #include "emucore/Deserializer.hxx"
 #include "emucore/Cart4A50.hxx"
 
+namespace ale {
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Cartridge4A50::Cartridge4A50(const uint8_t* image)
 {
@@ -101,3 +103,5 @@ uint8_t* Cartridge4A50::getImage(int& size)
   size = 0;
   return 0;
 }
+
+}  // namespace ale

--- a/src/emucore/Cart4A50.hxx
+++ b/src/emucore/Cart4A50.hxx
@@ -20,14 +20,19 @@
 #define CARTRIDGE4A50_HXX
 
 namespace ale {
+namespace stella {
+
 class System;
 class Serializer;
 class Deserializer;
+
+}  // namespace stella
 }  // namespace ale
 
 #include "emucore/Cart.hxx"
 
 namespace ale {
+namespace stella {
 
 /**
   This is the standard Atari 4K cartridge.  These cartridges are 
@@ -141,6 +146,7 @@ class Cartridge4A50 : public Cartridge
     virtual void poke(uint16_t address, uint8_t value);
 };
 
+}  // namespace stella
 }  // namespace ale
 
 #endif

--- a/src/emucore/Cart4A50.hxx
+++ b/src/emucore/Cart4A50.hxx
@@ -19,11 +19,15 @@
 #ifndef CARTRIDGE4A50_HXX
 #define CARTRIDGE4A50_HXX
 
+namespace ale {
 class System;
 class Serializer;
 class Deserializer;
+}  // namespace ale
 
 #include "emucore/Cart.hxx"
+
+namespace ale {
 
 /**
   This is the standard Atari 4K cartridge.  These cartridges are 
@@ -136,5 +140,7 @@ class Cartridge4A50 : public Cartridge
     */
     virtual void poke(uint16_t address, uint8_t value);
 };
+
+}  // namespace ale
 
 #endif

--- a/src/emucore/Cart4K.cxx
+++ b/src/emucore/Cart4K.cxx
@@ -24,6 +24,7 @@
 #include "emucore/Cart4K.hxx"
 
 namespace ale {
+namespace stella {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Cartridge4K::Cartridge4K(const uint8_t* image)
@@ -165,4 +166,5 @@ uint8_t* Cartridge4K::getImage(int& size)
   return &myImage[0];
 }
 
+}  // namespace stella
 }  // namespace ale

--- a/src/emucore/Cart4K.cxx
+++ b/src/emucore/Cart4K.cxx
@@ -23,6 +23,8 @@
 #include "emucore/Deserializer.hxx"
 #include "emucore/Cart4K.hxx"
 
+namespace ale {
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Cartridge4K::Cartridge4K(const uint8_t* image)
 {
@@ -162,3 +164,5 @@ uint8_t* Cartridge4K::getImage(int& size)
   size = 4096;
   return &myImage[0];
 }
+
+}  // namespace ale

--- a/src/emucore/Cart4K.hxx
+++ b/src/emucore/Cart4K.hxx
@@ -19,11 +19,15 @@
 #ifndef CARTRIDGE4K_HXX
 #define CARTRIDGE4K_HXX
 
+namespace ale {
 class System;
 class Serializer;
 class Deserializer;
+}  // namespace ale
 
 #include "emucore/Cart.hxx"
+
+namespace ale {
 
 /**
   This is the standard Atari 4K cartridge.  These cartridges are 
@@ -140,5 +144,7 @@ class Cartridge4K : public Cartridge
     // The 4K ROM image for the cartridge
     uint8_t myImage[4096];
 };
+
+}  // namespace ale
 
 #endif

--- a/src/emucore/Cart4K.hxx
+++ b/src/emucore/Cart4K.hxx
@@ -20,14 +20,19 @@
 #define CARTRIDGE4K_HXX
 
 namespace ale {
+namespace stella {
+
 class System;
 class Serializer;
 class Deserializer;
+
+}  // namespace stella
 }  // namespace ale
 
 #include "emucore/Cart.hxx"
 
 namespace ale {
+namespace stella {
 
 /**
   This is the standard Atari 4K cartridge.  These cartridges are 
@@ -145,6 +150,7 @@ class Cartridge4K : public Cartridge
     uint8_t myImage[4096];
 };
 
+}  // namespace stella
 }  // namespace ale
 
 #endif

--- a/src/emucore/CartAR.cxx
+++ b/src/emucore/CartAR.cxx
@@ -27,6 +27,7 @@
 #include "emucore/CartAR.hxx"
 
 namespace ale {
+namespace stella {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 CartridgeAR::CartridgeAR(const uint8_t* image, uint32_t size, bool fastbios)
@@ -595,4 +596,5 @@ uint8_t* CartridgeAR::getImage(int& size)
   return &myLoadImages[0];
 }
 
+}  // namespace stella
 }  // namespace ale

--- a/src/emucore/CartAR.cxx
+++ b/src/emucore/CartAR.cxx
@@ -26,6 +26,8 @@
 #include "emucore/Deserializer.hxx"
 #include "emucore/CartAR.hxx"
 
+namespace ale {
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 CartridgeAR::CartridgeAR(const uint8_t* image, uint32_t size, bool fastbios)
   : my6502(0)
@@ -592,3 +594,5 @@ uint8_t* CartridgeAR::getImage(int& size)
   size = myNumberOfLoadImages * 8448;
   return &myLoadImages[0];
 }
+
+}  // namespace ale

--- a/src/emucore/CartAR.hxx
+++ b/src/emucore/CartAR.hxx
@@ -20,15 +20,20 @@
 #define CARTRIDGEAR_HXX
 
 namespace ale {
+namespace stella {
+
 class M6502High;
 class System;
 class Serializer;
 class Deserializer;
+
+}  // namespace stella
 }  // namespace ale
 
 #include "emucore/Cart.hxx"
 
 namespace ale {
+namespace stella {
 
 /**
   This is the cartridge class for Arcadia (aka Starpath) Supercharger 
@@ -208,6 +213,7 @@ class CartridgeAR : public Cartridge
     uint16_t myCurrentBank;
 };
 
+}  // namespace stella
 }  // namespace ale
 
 #endif

--- a/src/emucore/CartAR.hxx
+++ b/src/emucore/CartAR.hxx
@@ -19,12 +19,16 @@
 #ifndef CARTRIDGEAR_HXX
 #define CARTRIDGEAR_HXX
 
+namespace ale {
 class M6502High;
 class System;
 class Serializer;
 class Deserializer;
+}  // namespace ale
 
 #include "emucore/Cart.hxx"
+
+namespace ale {
 
 /**
   This is the cartridge class for Arcadia (aka Starpath) Supercharger 
@@ -203,5 +207,7 @@ class CartridgeAR : public Cartridge
 
     uint16_t myCurrentBank;
 };
+
+}  // namespace ale
 
 #endif

--- a/src/emucore/CartCV.cxx
+++ b/src/emucore/CartCV.cxx
@@ -25,6 +25,7 @@
 #include "emucore/CartCV.hxx"
 
 namespace ale {
+namespace stella { 
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 CartridgeCV::CartridgeCV(const uint8_t* image, uint32_t size)
@@ -220,4 +221,5 @@ uint8_t* CartridgeCV::getImage(int& size)
   return &myImage[0];
 }
 
+}  // namespace stella
 }  // namespace ale

--- a/src/emucore/CartCV.cxx
+++ b/src/emucore/CartCV.cxx
@@ -24,6 +24,8 @@
 #include "emucore/Deserializer.hxx"
 #include "emucore/CartCV.hxx"
 
+namespace ale {
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 CartridgeCV::CartridgeCV(const uint8_t* image, uint32_t size)
 {
@@ -217,3 +219,5 @@ uint8_t* CartridgeCV::getImage(int& size)
   size = 2048;
   return &myImage[0];
 }
+
+}  // namespace ale

--- a/src/emucore/CartCV.hxx
+++ b/src/emucore/CartCV.hxx
@@ -20,14 +20,19 @@
 #define CARTRIDGECV_HXX
 
 namespace ale {
+namespace stella {
+
 class System;
 class Serializer;
 class Deserializer;
+
+}  // namespace stella
 }  // namespace ale
 
 #include "emucore/Cart.hxx"
 
 namespace ale {
+namespace stella {
 
 /**
   Cartridge class used for Commavid's extra-RAM games.
@@ -155,6 +160,7 @@ class CartridgeCV : public Cartridge
     uint8_t* myInitialRAM;
 };
 
+}  // namespace stella
 }  // namespace ale
 
 #endif

--- a/src/emucore/CartCV.hxx
+++ b/src/emucore/CartCV.hxx
@@ -19,11 +19,15 @@
 #ifndef CARTRIDGECV_HXX
 #define CARTRIDGECV_HXX
 
+namespace ale {
 class System;
 class Serializer;
 class Deserializer;
+}  // namespace ale
 
 #include "emucore/Cart.hxx"
+
+namespace ale {
 
 /**
   Cartridge class used for Commavid's extra-RAM games.
@@ -150,5 +154,7 @@ class CartridgeCV : public Cartridge
     // This doesn't always exist, so we don't pre-allocate it
     uint8_t* myInitialRAM;
 };
+
+}  // namespace ale
 
 #endif

--- a/src/emucore/CartDPC.cxx
+++ b/src/emucore/CartDPC.cxx
@@ -24,6 +24,7 @@
 #include "emucore/Deserializer.hxx"
 
 namespace ale {
+namespace stella {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 CartridgeDPC::CartridgeDPC(const uint8_t* image, uint32_t size)
@@ -612,4 +613,5 @@ uint8_t* CartridgeDPC::getImage(int& size)
   return &myImageCopy[0];
 }
 
+}  // namespace stella
 }  // namespace ale

--- a/src/emucore/CartDPC.cxx
+++ b/src/emucore/CartDPC.cxx
@@ -23,6 +23,8 @@
 #include "emucore/Serializer.hxx"
 #include "emucore/Deserializer.hxx"
 
+namespace ale {
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 CartridgeDPC::CartridgeDPC(const uint8_t* image, uint32_t size)
 {
@@ -609,3 +611,5 @@ uint8_t* CartridgeDPC::getImage(int& size)
 
   return &myImageCopy[0];
 }
+
+}  // namespace ale

--- a/src/emucore/CartDPC.hxx
+++ b/src/emucore/CartDPC.hxx
@@ -20,14 +20,19 @@
 #define CARTRIDGEDCP_HXX
 
 namespace ale {
+namespace stella {
+
 class System;
 class Serializer;
 class Deserializer;
+
+}  // namespace stella
 }  // namespace ale
 
 #include "emucore/Cart.hxx"
 
 namespace ale {
+namespace stella {
 
 /**
   Cartridge class used for Pitfall II.  There are two 4K program banks, a 
@@ -198,6 +203,7 @@ class CartridgeDPC : public Cartridge
     double myFractionalClocks;
 };
 
+}  // namespace stella
 }  // namespace ale
 
 #endif

--- a/src/emucore/CartDPC.hxx
+++ b/src/emucore/CartDPC.hxx
@@ -19,11 +19,15 @@
 #ifndef CARTRIDGEDCP_HXX
 #define CARTRIDGEDCP_HXX
 
+namespace ale {
 class System;
 class Serializer;
 class Deserializer;
+}  // namespace ale
 
 #include "emucore/Cart.hxx"
+
+namespace ale {
 
 /**
   Cartridge class used for Pitfall II.  There are two 4K program banks, a 
@@ -193,5 +197,7 @@ class CartridgeDPC : public Cartridge
     // Fractional DPC music OSC clocks unused during the last update
     double myFractionalClocks;
 };
+
+}  // namespace ale
 
 #endif

--- a/src/emucore/CartE0.cxx
+++ b/src/emucore/CartE0.cxx
@@ -24,6 +24,7 @@
 #include "emucore/CartE0.hxx"
 
 namespace ale {
+namespace stella {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 CartridgeE0::CartridgeE0(const uint8_t* image)
@@ -288,4 +289,5 @@ uint8_t* CartridgeE0::getImage(int& size)
   return &myImage[0];
 }
 
+}  // namespace stella
 }  // namespace ale

--- a/src/emucore/CartE0.cxx
+++ b/src/emucore/CartE0.cxx
@@ -23,6 +23,8 @@
 #include "emucore/Deserializer.hxx"
 #include "emucore/CartE0.hxx"
 
+namespace ale {
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 CartridgeE0::CartridgeE0(const uint8_t* image)
 {
@@ -285,3 +287,5 @@ uint8_t* CartridgeE0::getImage(int& size)
   size = 8192;
   return &myImage[0];
 }
+
+}  // namespace ale

--- a/src/emucore/CartE0.hxx
+++ b/src/emucore/CartE0.hxx
@@ -20,14 +20,19 @@
 #define CARTRIDGEE0_HXX
 
 namespace ale {
+namespace stella { 
+
 class System;
 class Serializer;
 class Deserializer;
+
+}  // namespace stella
 }  // namespace ale
 
 #include "emucore/Cart.hxx"
 
 namespace ale {
+namespace stella {
 
 /**
   This is the cartridge class for Parker Brothers' 8K games.  In 
@@ -175,6 +180,7 @@ class CartridgeE0 : public Cartridge
     uint8_t myImage[8192];
 };
 
+}  // namespace stella
 }  // namespace ale
 
 #endif

--- a/src/emucore/CartE0.hxx
+++ b/src/emucore/CartE0.hxx
@@ -19,11 +19,15 @@
 #ifndef CARTRIDGEE0_HXX
 #define CARTRIDGEE0_HXX
 
+namespace ale {
 class System;
 class Serializer;
 class Deserializer;
+}  // namespace ale
 
 #include "emucore/Cart.hxx"
+
+namespace ale {
 
 /**
   This is the cartridge class for Parker Brothers' 8K games.  In 
@@ -170,5 +174,7 @@ class CartridgeE0 : public Cartridge
     // The 8K ROM image of the cartridge
     uint8_t myImage[8192];
 };
+
+}  // namespace ale
 
 #endif

--- a/src/emucore/CartE7.cxx
+++ b/src/emucore/CartE7.cxx
@@ -23,6 +23,8 @@
 #include "emucore/Deserializer.hxx"
 #include "emucore/CartE7.hxx"
 
+namespace ale {
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 CartridgeE7::CartridgeE7(const uint8_t* image)
 {
@@ -317,3 +319,5 @@ uint8_t* CartridgeE7::getImage(int& size)
   size = 16384;
   return &myImage[0];
 }
+
+}  // namespace ale

--- a/src/emucore/CartE7.cxx
+++ b/src/emucore/CartE7.cxx
@@ -24,6 +24,7 @@
 #include "emucore/CartE7.hxx"
 
 namespace ale {
+namespace stella {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 CartridgeE7::CartridgeE7(const uint8_t* image)
@@ -320,4 +321,5 @@ uint8_t* CartridgeE7::getImage(int& size)
   return &myImage[0];
 }
 
+}  // namespace stella
 }  // namespace ale

--- a/src/emucore/CartE7.hxx
+++ b/src/emucore/CartE7.hxx
@@ -20,14 +20,19 @@
 #define CARTRIDGEE7_HXX
 
 namespace ale {
+namespace stella {
+
 class System;
 class Serializer;
 class Deserializer;
+
+}  // namespace stella
 }  // namespace ale
 
 #include "emucore/Cart.hxx"
 
 namespace ale {
+namespace stella {
 
 /**
   This is the cartridge class for M-Network bankswitched games.  
@@ -184,6 +189,7 @@ class CartridgeE7 : public Cartridge
     uint8_t myRAM[2048];
 };
 
+}  // namespace stella
 }  // namespace ale
 
 #endif

--- a/src/emucore/CartE7.hxx
+++ b/src/emucore/CartE7.hxx
@@ -19,11 +19,15 @@
 #ifndef CARTRIDGEE7_HXX
 #define CARTRIDGEE7_HXX
 
+namespace ale {
 class System;
 class Serializer;
 class Deserializer;
+}  // namespace ale
 
 #include "emucore/Cart.hxx"
+
+namespace ale {
 
 /**
   This is the cartridge class for M-Network bankswitched games.  
@@ -179,5 +183,7 @@ class CartridgeE7 : public Cartridge
     // The 2048 bytes of RAM
     uint8_t myRAM[2048];
 };
+
+}  // namespace ale
 
 #endif

--- a/src/emucore/CartF4.cxx
+++ b/src/emucore/CartF4.cxx
@@ -24,6 +24,7 @@
 #include "emucore/CartF4.hxx"
 
 namespace ale {
+namespace stella {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 CartridgeF4::CartridgeF4(const uint8_t* image)
@@ -210,4 +211,5 @@ uint8_t* CartridgeF4::getImage(int& size)
   return &myImage[0];
 }
 
+}  // namespace stella
 }  // namespace ale

--- a/src/emucore/CartF4.cxx
+++ b/src/emucore/CartF4.cxx
@@ -23,6 +23,8 @@
 #include "emucore/Deserializer.hxx"
 #include "emucore/CartF4.hxx"
 
+namespace ale {
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 CartridgeF4::CartridgeF4(const uint8_t* image)
 {
@@ -207,3 +209,5 @@ uint8_t* CartridgeF4::getImage(int& size)
   size = 32768;
   return &myImage[0];
 }
+
+}  // namespace ale

--- a/src/emucore/CartF4.hxx
+++ b/src/emucore/CartF4.hxx
@@ -19,11 +19,15 @@
 #ifndef CARTRIDGEF4_HXX
 #define CARTRIDGEF4_HXX
 
+namespace ale {
 class System;
 class Serializer;
 class Deserializer;
+}  // namespace ale
 
 #include "emucore/Cart.hxx"
+
+namespace ale {
 
 /**
   Cartridge class used for Atari's 32K bankswitched games.  There
@@ -143,5 +147,7 @@ class CartridgeF4 : public Cartridge
     // The 16K ROM image of the cartridge
     uint8_t myImage[32768];
 };
+
+}  // namespace ale
 
 #endif

--- a/src/emucore/CartF4.hxx
+++ b/src/emucore/CartF4.hxx
@@ -20,14 +20,19 @@
 #define CARTRIDGEF4_HXX
 
 namespace ale {
+namespace stella {
+
 class System;
 class Serializer;
 class Deserializer;
+
+}  // namespace stella
 }  // namespace ale
 
 #include "emucore/Cart.hxx"
 
 namespace ale {
+namespace stella {
 
 /**
   Cartridge class used for Atari's 32K bankswitched games.  There
@@ -148,6 +153,7 @@ class CartridgeF4 : public Cartridge
     uint8_t myImage[32768];
 };
 
+}  // namespace stella
 }  // namespace ale
 
 #endif

--- a/src/emucore/CartF4SC.cxx
+++ b/src/emucore/CartF4SC.cxx
@@ -24,6 +24,8 @@
 #include "emucore/Deserializer.hxx"
 #include "emucore/CartF4SC.hxx"
 
+namespace ale {
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 CartridgeF4SC::CartridgeF4SC(const uint8_t* image)
 {
@@ -243,3 +245,5 @@ uint8_t* CartridgeF4SC::getImage(int& size)
   size = 32768;
   return &myImage[0];
 }
+
+}  // namespace ale

--- a/src/emucore/CartF4SC.cxx
+++ b/src/emucore/CartF4SC.cxx
@@ -25,6 +25,7 @@
 #include "emucore/CartF4SC.hxx"
 
 namespace ale {
+namespace stella {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 CartridgeF4SC::CartridgeF4SC(const uint8_t* image)
@@ -246,4 +247,5 @@ uint8_t* CartridgeF4SC::getImage(int& size)
   return &myImage[0];
 }
 
+}  // namespace stella
 }  // namespace ale

--- a/src/emucore/CartF4SC.hxx
+++ b/src/emucore/CartF4SC.hxx
@@ -20,14 +20,19 @@
 #define CARTRIDGEF4SC_HXX
 
 namespace ale {
+namespace stella {
+
 class System;
 class Serializer;
 class Deserializer;
+
+}  // namespace stella
 }  // namespace ale
 
 #include "emucore/Cart.hxx"
 
 namespace ale {
+namespace stella {
 
 /**
   Cartridge class used for Atari's 32K bankswitched games with
@@ -151,6 +156,7 @@ class CartridgeF4SC : public Cartridge
     uint8_t myRAM[128];
 };
 
+}  // namespace stella
 }  // namespace ale
 
 #endif

--- a/src/emucore/CartF4SC.hxx
+++ b/src/emucore/CartF4SC.hxx
@@ -19,11 +19,15 @@
 #ifndef CARTRIDGEF4SC_HXX
 #define CARTRIDGEF4SC_HXX
 
+namespace ale {
 class System;
 class Serializer;
 class Deserializer;
+}  // namespace ale
 
 #include "emucore/Cart.hxx"
+
+namespace ale {
 
 /**
   Cartridge class used for Atari's 32K bankswitched games with
@@ -146,5 +150,7 @@ class CartridgeF4SC : public Cartridge
     // The 128 bytes of RAM
     uint8_t myRAM[128];
 };
+
+}  // namespace ale
 
 #endif

--- a/src/emucore/CartF6.cxx
+++ b/src/emucore/CartF6.cxx
@@ -23,6 +23,8 @@
 #include "emucore/Deserializer.hxx"
 #include "emucore/CartF6.hxx"
 
+namespace ale {
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 CartridgeF6::CartridgeF6(const uint8_t* image)
 {
@@ -248,3 +250,5 @@ uint8_t* CartridgeF6::getImage(int& size)
   size = 16384;
   return &myImage[0];
 }
+
+}  // namespace ale

--- a/src/emucore/CartF6.cxx
+++ b/src/emucore/CartF6.cxx
@@ -24,6 +24,7 @@
 #include "emucore/CartF6.hxx"
 
 namespace ale {
+namespace stella {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 CartridgeF6::CartridgeF6(const uint8_t* image)
@@ -251,4 +252,5 @@ uint8_t* CartridgeF6::getImage(int& size)
   return &myImage[0];
 }
 
+}  // namespace stella
 }  // namespace ale

--- a/src/emucore/CartF6.hxx
+++ b/src/emucore/CartF6.hxx
@@ -19,11 +19,15 @@
 #ifndef CARTRIDGEF6_HXX
 #define CARTRIDGEF6_HXX
 
+namespace ale {
 class System;
 class Serializer;
 class Deserializer;
+}  // namespace ale
 
 #include "emucore/Cart.hxx"
+
+namespace ale {
 
 /**
   Cartridge class used for Atari's 16K bankswitched games.  There
@@ -143,5 +147,7 @@ class CartridgeF6 : public Cartridge
     // The 16K ROM image of the cartridge
     uint8_t myImage[16384];
 };
+
+}  // namespace ale
 
 #endif

--- a/src/emucore/CartF6.hxx
+++ b/src/emucore/CartF6.hxx
@@ -20,14 +20,19 @@
 #define CARTRIDGEF6_HXX
 
 namespace ale {
+namespace stella {
+
 class System;
 class Serializer;
 class Deserializer;
+
+}  // namespace stella
 }  // namespace ale
 
 #include "emucore/Cart.hxx"
 
 namespace ale {
+namespace stella {
 
 /**
   Cartridge class used for Atari's 16K bankswitched games.  There
@@ -148,6 +153,7 @@ class CartridgeF6 : public Cartridge
     uint8_t myImage[16384];
 };
 
+}  // namespace stella
 }  // namespace ale
 
 #endif

--- a/src/emucore/CartF6SC.cxx
+++ b/src/emucore/CartF6SC.cxx
@@ -24,6 +24,7 @@
 #include "emucore/CartF6SC.hxx"
 
 namespace ale {
+namespace stella {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 CartridgeF6SC::CartridgeF6SC(const uint8_t* image)
@@ -291,4 +292,5 @@ uint8_t* CartridgeF6SC::getImage(int& size)
   return &myImage[0];
 }
 
+}  // namespace stella
 }  // namespace ale

--- a/src/emucore/CartF6SC.cxx
+++ b/src/emucore/CartF6SC.cxx
@@ -23,6 +23,8 @@
 #include "emucore/Deserializer.hxx"
 #include "emucore/CartF6SC.hxx"
 
+namespace ale {
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 CartridgeF6SC::CartridgeF6SC(const uint8_t* image)
 {
@@ -288,3 +290,5 @@ uint8_t* CartridgeF6SC::getImage(int& size)
   size = 16384;
   return &myImage[0];
 }
+
+}  // namespace ale

--- a/src/emucore/CartF6SC.hxx
+++ b/src/emucore/CartF6SC.hxx
@@ -20,14 +20,19 @@
 #define CARTRIDGEF6SC_HXX
 
 namespace ale {
+namespace stella {
+
 class System;
 class Serializer;
 class Deserializer;
+
+}  // namespace stella
 }  // namespace ale
 
 #include "emucore/Cart.hxx"
 
 namespace ale {
+namespace stella {
 
 /**
   Cartridge class used for Atari's 16K bankswitched games with
@@ -151,6 +156,7 @@ class CartridgeF6SC : public Cartridge
     uint8_t myRAM[128];
 };
 
+}  // namespace stella
 }  // namespace ale
 
 #endif

--- a/src/emucore/CartF6SC.hxx
+++ b/src/emucore/CartF6SC.hxx
@@ -19,11 +19,15 @@
 #ifndef CARTRIDGEF6SC_HXX
 #define CARTRIDGEF6SC_HXX
 
+namespace ale {
 class System;
 class Serializer;
 class Deserializer;
+}  // namespace ale
 
 #include "emucore/Cart.hxx"
+
+namespace ale {
 
 /**
   Cartridge class used for Atari's 16K bankswitched games with
@@ -146,5 +150,7 @@ class CartridgeF6SC : public Cartridge
     // The 128 bytes of RAM
     uint8_t myRAM[128];
 };
+
+}  // namespace ale
 
 #endif

--- a/src/emucore/CartF8.cxx
+++ b/src/emucore/CartF8.cxx
@@ -24,6 +24,7 @@
 #include "emucore/CartF8.hxx"
 
 namespace ale {
+namespace stella {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 CartridgeF8::CartridgeF8(const uint8_t* image, bool swapbanks)
@@ -236,4 +237,5 @@ uint8_t* CartridgeF8::getImage(int& size)
   return &myImage[0];
 }
 
+}  // namespace stella
 }  // namespace ale

--- a/src/emucore/CartF8.cxx
+++ b/src/emucore/CartF8.cxx
@@ -23,6 +23,8 @@
 #include "emucore/Deserializer.hxx"
 #include "emucore/CartF8.hxx"
 
+namespace ale {
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 CartridgeF8::CartridgeF8(const uint8_t* image, bool swapbanks)
 {
@@ -233,3 +235,5 @@ uint8_t* CartridgeF8::getImage(int& size)
   size = 8192;
   return &myImage[0];
 }
+
+}  // namespace ale

--- a/src/emucore/CartF8.hxx
+++ b/src/emucore/CartF8.hxx
@@ -20,14 +20,19 @@
 #define CARTRIDGEF8_HXX
 
 namespace ale {
+namespace stella {
+
 class System;
 class Serializer;
 class Deserializer;
+
+}  // namespace stella
 }  // namespace ale
 
 #include "emucore/Cart.hxx"
 
 namespace ale {
+namespace stella {
 
 /**
   Cartridge class used for Atari's 8K bankswitched games.  There
@@ -152,6 +157,7 @@ class CartridgeF8 : public Cartridge
     uint8_t myImage[8192];
 };
 
+}  // namespace stella
 }  // namespace ale
 
 #endif

--- a/src/emucore/CartF8.hxx
+++ b/src/emucore/CartF8.hxx
@@ -19,11 +19,15 @@
 #ifndef CARTRIDGEF8_HXX
 #define CARTRIDGEF8_HXX
 
+namespace ale {
 class System;
 class Serializer;
 class Deserializer;
+}  // namespace ale
 
 #include "emucore/Cart.hxx"
+
+namespace ale {
 
 /**
   Cartridge class used for Atari's 8K bankswitched games.  There
@@ -147,5 +151,7 @@ class CartridgeF8 : public Cartridge
     // The 8K ROM image of the cartridge
     uint8_t myImage[8192];
 };
+
+}  // namespace ale
 
 #endif

--- a/src/emucore/CartF8SC.cxx
+++ b/src/emucore/CartF8SC.cxx
@@ -23,6 +23,8 @@
 #include "emucore/Deserializer.hxx"
 #include "emucore/CartF8SC.hxx"
 
+namespace ale {
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 CartridgeF8SC::CartridgeF8SC(const uint8_t* image)
 {
@@ -270,3 +272,5 @@ uint8_t* CartridgeF8SC::getImage(int& size)
   size = 8192;
   return &myImage[0];
 }
+
+}  // namespace ale

--- a/src/emucore/CartF8SC.cxx
+++ b/src/emucore/CartF8SC.cxx
@@ -24,6 +24,7 @@
 #include "emucore/CartF8SC.hxx"
 
 namespace ale {
+namespace stella {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 CartridgeF8SC::CartridgeF8SC(const uint8_t* image)
@@ -273,4 +274,5 @@ uint8_t* CartridgeF8SC::getImage(int& size)
   return &myImage[0];
 }
 
+}  // namespace stella
 }  // namespace ale

--- a/src/emucore/CartF8SC.hxx
+++ b/src/emucore/CartF8SC.hxx
@@ -20,14 +20,19 @@
 #define CARTRIDGEF8SC_HXX
 
 namespace ale {
+namespace stella {
+
 class System;
 class Serializer;
 class Deserializer;
+
+}  // namespace stella
 }  // namespace ale
 
 #include "emucore/Cart.hxx"
 
 namespace ale {
+namespace stella {
 
 /**
   Cartridge class used for Atari's 8K bankswitched games with
@@ -151,6 +156,7 @@ class CartridgeF8SC : public Cartridge
     uint8_t myRAM[128];
 };
 
+}  // namespace stella
 }  // namespace ale
 
 #endif

--- a/src/emucore/CartF8SC.hxx
+++ b/src/emucore/CartF8SC.hxx
@@ -19,11 +19,15 @@
 #ifndef CARTRIDGEF8SC_HXX
 #define CARTRIDGEF8SC_HXX
 
+namespace ale {
 class System;
 class Serializer;
 class Deserializer;
+}  // namespace ale
 
 #include "emucore/Cart.hxx"
+
+namespace ale {
 
 /**
   Cartridge class used for Atari's 8K bankswitched games with
@@ -146,5 +150,7 @@ class CartridgeF8SC : public Cartridge
     // The 128 bytes of RAM
     uint8_t myRAM[128];
 };
+
+}  // namespace ale
 
 #endif

--- a/src/emucore/CartFASC.cxx
+++ b/src/emucore/CartFASC.cxx
@@ -23,6 +23,8 @@
 #include "emucore/Deserializer.hxx"
 #include "emucore/CartFASC.hxx"
 
+namespace ale {
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 CartridgeFASC::CartridgeFASC(const uint8_t* image)
 {
@@ -276,3 +278,5 @@ uint8_t* CartridgeFASC::getImage(int& size)
   size = 12288;
   return &myImage[0];
 }
+
+}  // namespace ale

--- a/src/emucore/CartFASC.cxx
+++ b/src/emucore/CartFASC.cxx
@@ -24,6 +24,7 @@
 #include "emucore/CartFASC.hxx"
 
 namespace ale {
+namespace stella {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 CartridgeFASC::CartridgeFASC(const uint8_t* image)
@@ -279,4 +280,5 @@ uint8_t* CartridgeFASC::getImage(int& size)
   return &myImage[0];
 }
 
+}  // namespace stella
 }  // namespace ale

--- a/src/emucore/CartFASC.hxx
+++ b/src/emucore/CartFASC.hxx
@@ -19,11 +19,15 @@
 #ifndef CARTRIDGEFASC_HXX
 #define CARTRIDGEFASC_HXX
 
+namespace ale {
 class System;
 class Serializer;
 class Deserializer;
+}  // namespace ale
 
 #include "emucore/Cart.hxx"
+
+namespace ale {
 
 /**
   Cartridge class used for CBS' RAM Plus cartridges.  There are
@@ -146,5 +150,7 @@ class CartridgeFASC : public Cartridge
     // The 256 bytes of RAM on the cartridge
     uint8_t myRAM[256];
 };
+
+}  // namespace ale
 
 #endif

--- a/src/emucore/CartFASC.hxx
+++ b/src/emucore/CartFASC.hxx
@@ -20,14 +20,19 @@
 #define CARTRIDGEFASC_HXX
 
 namespace ale {
+namespace stella {
+
 class System;
 class Serializer;
 class Deserializer;
+
+}  // namespace stella
 }  // namespace ale
 
 #include "emucore/Cart.hxx"
 
 namespace ale {
+namespace stella {
 
 /**
   Cartridge class used for CBS' RAM Plus cartridges.  There are
@@ -151,6 +156,7 @@ class CartridgeFASC : public Cartridge
     uint8_t myRAM[256];
 };
 
+}  // namespace stella
 }  // namespace ale
 
 #endif

--- a/src/emucore/CartFE.cxx
+++ b/src/emucore/CartFE.cxx
@@ -23,6 +23,8 @@
 #include "emucore/Deserializer.hxx"
 #include "emucore/CartFE.hxx"
 
+namespace ale {
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 CartridgeFE::CartridgeFE(const uint8_t* image)
 {
@@ -161,3 +163,5 @@ uint8_t* CartridgeFE::getImage(int& size)
   size = 8192;
   return &myImage[0];
 }
+
+}  // namespace ale

--- a/src/emucore/CartFE.cxx
+++ b/src/emucore/CartFE.cxx
@@ -24,6 +24,7 @@
 #include "emucore/CartFE.hxx"
 
 namespace ale {
+namespace stella {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 CartridgeFE::CartridgeFE(const uint8_t* image)
@@ -164,4 +165,5 @@ uint8_t* CartridgeFE::getImage(int& size)
   return &myImage[0];
 }
 
+}  // namespace stella
 }  // namespace ale

--- a/src/emucore/CartFE.hxx
+++ b/src/emucore/CartFE.hxx
@@ -20,14 +20,19 @@
 #define CARTRIDGEFE_HXX
 
 namespace ale {
+namespace stella {
+
 class System;
 class Serializer;
 class Deserializer;
+
+}  // namespace stella
 }  // namespace ale
 
 #include "emucore/Cart.hxx"
 
 namespace ale {
+namespace stella {
 
 /**
   Bankswitching method used by Activison's Robot Tank and Decathlon.
@@ -157,6 +162,7 @@ class CartridgeFE : public Cartridge
     uint8_t myImage[8192];
 };
 
+}  // namespace stella
 }  // namespace ale
 
 #endif

--- a/src/emucore/CartFE.hxx
+++ b/src/emucore/CartFE.hxx
@@ -19,11 +19,15 @@
 #ifndef CARTRIDGEFE_HXX
 #define CARTRIDGEFE_HXX
 
+namespace ale {
 class System;
 class Serializer;
 class Deserializer;
+}  // namespace ale
 
 #include "emucore/Cart.hxx"
+
+namespace ale {
 
 /**
   Bankswitching method used by Activison's Robot Tank and Decathlon.
@@ -152,5 +156,7 @@ class CartridgeFE : public Cartridge
     // The 8K ROM image of the cartridge
     uint8_t myImage[8192];
 };
+
+}  // namespace ale
 
 #endif

--- a/src/emucore/CartMB.cxx
+++ b/src/emucore/CartMB.cxx
@@ -23,6 +23,8 @@
 #include "emucore/Deserializer.hxx"
 #include "emucore/CartMB.hxx"
 
+namespace ale {
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 CartridgeMB::CartridgeMB(const uint8_t* image)
 {
@@ -213,3 +215,5 @@ uint8_t* CartridgeMB::getImage(int& size)
   size = 65536;
   return &myImage[0];
 }
+
+}  // namespace ale

--- a/src/emucore/CartMB.cxx
+++ b/src/emucore/CartMB.cxx
@@ -24,6 +24,7 @@
 #include "emucore/CartMB.hxx"
 
 namespace ale {
+namespace stella {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 CartridgeMB::CartridgeMB(const uint8_t* image)
@@ -216,4 +217,5 @@ uint8_t* CartridgeMB::getImage(int& size)
   return &myImage[0];
 }
 
+}  // namespace stella
 }  // namespace ale

--- a/src/emucore/CartMB.hxx
+++ b/src/emucore/CartMB.hxx
@@ -20,14 +20,19 @@
 #define CARTRIDGEMB_HXX
 
 namespace ale {
+namespace stella {
+
 class System;
 class Serializer;
 class Deserializer;
+
+}  // namespace stella
 }  // namespace ale
 
 #include "emucore/Cart.hxx"
 
 namespace ale {
+namespace stella {
 
 /**
   Cartridge class used for Dynacom Megaboy
@@ -155,6 +160,7 @@ class CartridgeMB : public Cartridge
     uint8_t myImage[65536];
 };
 
+}  // namespace stella
 }  // namespace ale
 
 #endif

--- a/src/emucore/CartMB.hxx
+++ b/src/emucore/CartMB.hxx
@@ -19,11 +19,15 @@
 #ifndef CARTRIDGEMB_HXX
 #define CARTRIDGEMB_HXX
 
+namespace ale {
 class System;
 class Serializer;
 class Deserializer;
+}  // namespace ale
 
 #include "emucore/Cart.hxx"
+
+namespace ale {
 
 /**
   Cartridge class used for Dynacom Megaboy
@@ -150,5 +154,7 @@ class CartridgeMB : public Cartridge
     // The 64K ROM image of the cartridge
     uint8_t myImage[65536];
 };
+
+}  // namespace ale
 
 #endif

--- a/src/emucore/CartMC.cxx
+++ b/src/emucore/CartMC.cxx
@@ -24,6 +24,7 @@
 #include "emucore/CartMC.hxx"
 
 namespace ale {
+namespace stella {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 CartridgeMC::CartridgeMC(const uint8_t* image, uint32_t size)
@@ -319,4 +320,5 @@ uint8_t* CartridgeMC::getImage(int& size)
   return &myImage[0];
 }
 
+}  // namespace stella
 }  // namespace ale

--- a/src/emucore/CartMC.cxx
+++ b/src/emucore/CartMC.cxx
@@ -23,6 +23,8 @@
 #include "emucore/Deserializer.hxx"
 #include "emucore/CartMC.hxx"
 
+namespace ale {
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 CartridgeMC::CartridgeMC(const uint8_t* image, uint32_t size)
   : mySlot3Locked(false)
@@ -316,3 +318,5 @@ uint8_t* CartridgeMC::getImage(int& size)
   size = 128 * 1024; // FIXME: keep track of original size
   return &myImage[0];
 }
+
+}  // namespace ale

--- a/src/emucore/CartMC.hxx
+++ b/src/emucore/CartMC.hxx
@@ -19,11 +19,15 @@
 #ifndef CARTRIDGEMC_HXX
 #define CARTRIDGEMC_HXX
 
+namespace ale {
 class System;
 class Serializer;
 class Deserializer;
+}  // namespace ale
 
 #include "emucore/Cart.hxx"
+
+namespace ale {
 
 /**
   This is the cartridge class for Chris Wilkson's Megacart.  It does not 
@@ -256,5 +260,7 @@ class CartridgeMC : public Cartridge
     // Pointer to the 128K bytes of ROM for the cartridge
     uint8_t* myImage;
 };
+
+}  // namespace ale
 
 #endif

--- a/src/emucore/CartMC.hxx
+++ b/src/emucore/CartMC.hxx
@@ -20,14 +20,19 @@
 #define CARTRIDGEMC_HXX
 
 namespace ale {
+namespace stella {
+
 class System;
 class Serializer;
 class Deserializer;
+
+}  // namespace stella
 }  // namespace ale
 
 #include "emucore/Cart.hxx"
 
 namespace ale {
+namespace stella {
 
 /**
   This is the cartridge class for Chris Wilkson's Megacart.  It does not 
@@ -261,6 +266,7 @@ class CartridgeMC : public Cartridge
     uint8_t* myImage;
 };
 
+}  // namespace stella
 }  // namespace ale
 
 #endif

--- a/src/emucore/CartUA.cxx
+++ b/src/emucore/CartUA.cxx
@@ -24,6 +24,7 @@
 #include "emucore/CartUA.hxx"
 
 namespace ale {
+namespace stella {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 CartridgeUA::CartridgeUA(const uint8_t* image)
@@ -243,4 +244,5 @@ uint8_t* CartridgeUA::getImage(int& size)
   return &myImage[0];
 }
 
+}  // namespace stella
 }  // namespace ale

--- a/src/emucore/CartUA.cxx
+++ b/src/emucore/CartUA.cxx
@@ -23,6 +23,8 @@
 #include "emucore/Deserializer.hxx"
 #include "emucore/CartUA.hxx"
 
+namespace ale {
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 CartridgeUA::CartridgeUA(const uint8_t* image)
 {
@@ -240,3 +242,5 @@ uint8_t* CartridgeUA::getImage(int& size)
   size = 8192;
   return &myImage[0];
 }
+
+}  // namespace ale

--- a/src/emucore/CartUA.hxx
+++ b/src/emucore/CartUA.hxx
@@ -19,12 +19,16 @@
 #ifndef CARTRIDGEUA_HXX
 #define CARTRIDGEUA_HXX
 
+namespace ale {
 class System;
 class Serializer;
 class Deserializer;
+}  // namespace ale
 
 #include "emucore/Cart.hxx"
 #include "emucore/System.hxx"
+
+namespace ale {
 
 /**
   Cartridge class used for UA Limited's 8K bankswitched games.  There
@@ -147,5 +151,7 @@ class CartridgeUA : public Cartridge
     // Previous Device's page access
     System::PageAccess myHotSpotPageAccess;
 };
+
+}  // namespace ale
 
 #endif

--- a/src/emucore/CartUA.hxx
+++ b/src/emucore/CartUA.hxx
@@ -20,15 +20,20 @@
 #define CARTRIDGEUA_HXX
 
 namespace ale {
+namespace stella {
+
 class System;
 class Serializer;
 class Deserializer;
+
+}  // namespace stella
 }  // namespace ale
 
 #include "emucore/Cart.hxx"
 #include "emucore/System.hxx"
 
 namespace ale {
+namespace stella {
 
 /**
   Cartridge class used for UA Limited's 8K bankswitched games.  There
@@ -152,6 +157,7 @@ class CartridgeUA : public Cartridge
     System::PageAccess myHotSpotPageAccess;
 };
 
+}  // namespace stella
 }  // namespace ale
 
 #endif

--- a/src/emucore/Console.cxx
+++ b/src/emucore/Console.cxx
@@ -43,6 +43,8 @@
 
 #include "common/Log.hpp"
 
+namespace ale {
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Console::Console(OSystem* osystem, Cartridge* cart, const Properties& props)
   : myOSystem(osystem),
@@ -220,3 +222,5 @@ Console& Console::operator = (const Console&)
 
   return *this;
 }
+
+}  // namespace ale

--- a/src/emucore/Console.cxx
+++ b/src/emucore/Console.cxx
@@ -44,6 +44,7 @@
 #include "common/Log.hpp"
 
 namespace ale {
+namespace stella {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Console::Console(OSystem* osystem, Cartridge* cart, const Properties& props)
@@ -223,4 +224,5 @@ Console& Console::operator = (const Console&)
   return *this;
 }
 
+}  // namespace stella
 }  // namespace ale

--- a/src/emucore/Console.hxx
+++ b/src/emucore/Console.hxx
@@ -20,6 +20,8 @@
 #define CONSOLE_HXX
 
 namespace ale {
+namespace stella {
+
 class OSystem;
 class Console;
 class Controller;
@@ -27,6 +29,8 @@ class Event;
 class MediaSource;
 class Switches;
 class System;
+
+}  // namespace stella
 }  // namespace ale
 
 #include "emucore/Control.hxx"
@@ -35,6 +39,7 @@ class System;
 #include "emucore/Cart.hxx"
 
 namespace ale {
+namespace stella {
 
 /**
   This class represents the entire game console.
@@ -176,6 +181,7 @@ class Console
 
 };
 
+}  // namespace stella
 }  // namespace ale
 
 #endif

--- a/src/emucore/Console.hxx
+++ b/src/emucore/Console.hxx
@@ -19,6 +19,7 @@
 #ifndef CONSOLE_HXX
 #define CONSOLE_HXX
 
+namespace ale {
 class OSystem;
 class Console;
 class Controller;
@@ -26,11 +27,14 @@ class Event;
 class MediaSource;
 class Switches;
 class System;
+}  // namespace ale
 
 #include "emucore/Control.hxx"
 #include "emucore/Props.hxx"
 #include "emucore/TIA.hxx"
 #include "emucore/Cart.hxx"
+
+namespace ale {
 
 /**
   This class represents the entire game console.
@@ -171,5 +175,7 @@ class Console
     std::string myAboutString;
 
 };
+
+}  // namespace ale
 
 #endif

--- a/src/emucore/Control.cxx
+++ b/src/emucore/Control.cxx
@@ -19,6 +19,8 @@
 #include <cassert>
 #include "emucore/Control.hxx"
 
+namespace ale {
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Controller::Controller(Jack jack, const Event& event, Type type)
   : myJack(jack),
@@ -59,3 +61,5 @@ Controller& Controller::operator = (const Controller&)
   assert(false);
   return *this;
 }
+
+}  // namespace ale

--- a/src/emucore/Control.cxx
+++ b/src/emucore/Control.cxx
@@ -20,6 +20,7 @@
 #include "emucore/Control.hxx"
 
 namespace ale {
+namespace stella {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Controller::Controller(Jack jack, const Event& event, Type type)
@@ -62,4 +63,5 @@ Controller& Controller::operator = (const Controller&)
   return *this;
 }
 
+}  // namespace stella
 }  // namespace ale

--- a/src/emucore/Control.hxx
+++ b/src/emucore/Control.hxx
@@ -19,6 +19,8 @@
 #ifndef CONTROLLER_HXX
 #define CONTROLLER_HXX
 
+namespace ale {
+
 class Controller;
 class Event;
 class System;
@@ -173,5 +175,7 @@ class Controller
     // Assignment operator isn't supported by controllers so make it private
     Controller& operator = (const Controller&);
 };
+
+}  // namespace ale
 
 #endif

--- a/src/emucore/Control.hxx
+++ b/src/emucore/Control.hxx
@@ -20,6 +20,7 @@
 #define CONTROLLER_HXX
 
 namespace ale {
+namespace stella {
 
 class Controller;
 class Event;
@@ -176,6 +177,7 @@ class Controller
     Controller& operator = (const Controller&);
 };
 
+}  // namespace stella
 }  // namespace ale
 
 #endif

--- a/src/emucore/DefProps.hxx
+++ b/src/emucore/DefProps.hxx
@@ -2,6 +2,7 @@
 #define DEF_PROPS_HXX
 
 namespace ale {
+namespace stella {
 
 /**
   This code is generated using the 'create_props.pl' script,
@@ -2691,6 +2692,7 @@ static const char* DefProps[DEF_PROPS_SIZE][21] = {
   { "ffebb0070689b9d322687edd9c0a2bae", "", "", "Spitfire Attack (1983) (Milton Bradley) [h1]", "", "", "", "", "", "", "", "", "", "", "", "", "28", "", "", "", "" }
 };
 
+}  // namespace stella
 }  // namespace ale
 
 #endif

--- a/src/emucore/DefProps.hxx
+++ b/src/emucore/DefProps.hxx
@@ -1,6 +1,8 @@
 #ifndef DEF_PROPS_HXX
 #define DEF_PROPS_HXX
 
+namespace ale {
+
 /**
   This code is generated using the 'create_props.pl' script,
   located in the src/tools directory.  All properties changes
@@ -2688,5 +2690,7 @@ static const char* DefProps[DEF_PROPS_SIZE][21] = {
   { "ffe51989ba6da2c6ae5a12d277862e16", "Atari", "CX2627 / 6699841", "Human Cannonball (AKA Cannon Man) (1978) (Atari) [o1]", "", "Uncommon", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" }, 
   { "ffebb0070689b9d322687edd9c0a2bae", "", "", "Spitfire Attack (1983) (Milton Bradley) [h1]", "", "", "", "", "", "", "", "", "", "", "", "", "28", "", "", "", "" }
 };
+
+}  // namespace ale
 
 #endif

--- a/src/emucore/Deserializer.cxx
+++ b/src/emucore/Deserializer.cxx
@@ -19,6 +19,8 @@
 #include "emucore/Deserializer.hxx"
 #include <sstream>
 
+namespace ale {
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Deserializer::Deserializer(const std::string stream_str):
 myStream(stream_str) {
@@ -80,3 +82,5 @@ bool Deserializer::getBool(void)
 
   return result;
 }
+
+}  // namespace ale

--- a/src/emucore/Deserializer.cxx
+++ b/src/emucore/Deserializer.cxx
@@ -20,6 +20,7 @@
 #include <sstream>
 
 namespace ale {
+namespace stella {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Deserializer::Deserializer(const std::string stream_str):
@@ -83,4 +84,5 @@ bool Deserializer::getBool(void)
   return result;
 }
 
+}  // namespace stella
 }  // namespace ale

--- a/src/emucore/Deserializer.hxx
+++ b/src/emucore/Deserializer.hxx
@@ -22,6 +22,7 @@
 #include <sstream>
 
 namespace ale {
+namespace stella {
 
 /**
  This class implements a Deserializer device, whereby data is
@@ -80,6 +81,7 @@ class Deserializer {
         };
     };
 
+}  // namespace stella
 }  // namespace ale
 
 #endif

--- a/src/emucore/Deserializer.hxx
+++ b/src/emucore/Deserializer.hxx
@@ -21,6 +21,8 @@
 
 #include <sstream>
 
+namespace ale {
+
 /**
  This class implements a Deserializer device, whereby data is
  deserialized from an input binary file in a system-independent
@@ -77,5 +79,7 @@ class Deserializer {
             FalsePattern = 0xbad1bad2
         };
     };
+
+}  // namespace ale
 
 #endif

--- a/src/emucore/Device.cxx
+++ b/src/emucore/Device.cxx
@@ -19,6 +19,7 @@
 #include "emucore/Device.hxx"
 
 namespace ale {
+namespace stella {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Device::Device()
@@ -37,5 +38,6 @@ void Device::systemCyclesReset()
   // By default I do nothing when my system resets its cycle counter
 }
 
+}  // namespace stella
 }  // namespace ale
 

--- a/src/emucore/Device.cxx
+++ b/src/emucore/Device.cxx
@@ -18,6 +18,8 @@
 
 #include "emucore/Device.hxx"
 
+namespace ale {
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Device::Device()
     : mySystem(0)
@@ -34,4 +36,6 @@ void Device::systemCyclesReset()
 {
   // By default I do nothing when my system resets its cycle counter
 }
+
+}  // namespace ale
 

--- a/src/emucore/Device.hxx
+++ b/src/emucore/Device.hxx
@@ -20,14 +20,19 @@
 #define DEVICE_HXX
 
 namespace ale {
+namespace stella {
+
 class System;
 class Serializer;
 class Deserializer;
+
+}  // namespace stella
 }  // namespace ale
 
 #include <cstdint>
 
 namespace ale {
+namespace stella {
 
 /**
   Abstract base class for devices which can be attached to a 6502
@@ -114,6 +119,7 @@ class Device
     System* mySystem;
 };
 
+}  // namespace stella
 }  // namespace ale
 
 #endif

--- a/src/emucore/Device.hxx
+++ b/src/emucore/Device.hxx
@@ -19,11 +19,15 @@
 #ifndef DEVICE_HXX
 #define DEVICE_HXX
 
+namespace ale {
 class System;
 class Serializer;
 class Deserializer;
+}  // namespace ale
 
 #include <cstdint>
+
+namespace ale {
 
 /**
   Abstract base class for devices which can be attached to a 6502
@@ -109,5 +113,7 @@ class Device
     /// Pointer to the system the device is installed in or the null pointer
     System* mySystem;
 };
+
+}  // namespace ale
 
 #endif

--- a/src/emucore/Event.cxx
+++ b/src/emucore/Event.cxx
@@ -18,6 +18,8 @@
 
 #include "emucore/Event.hxx"
 
+namespace ale {
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Event::Event()
   : myNumberOfTypes(Event::LastType)
@@ -60,3 +62,5 @@ void Event::clear()
       myValues[i] = 0;
   }
 }
+
+}  // namespace ale

--- a/src/emucore/Event.cxx
+++ b/src/emucore/Event.cxx
@@ -19,6 +19,7 @@
 #include "emucore/Event.hxx"
 
 namespace ale {
+namespace stella {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Event::Event()
@@ -63,4 +64,5 @@ void Event::clear()
   }
 }
 
+}  // namespace stella
 }  // namespace ale

--- a/src/emucore/Event.hxx
+++ b/src/emucore/Event.hxx
@@ -19,6 +19,7 @@
 #ifndef EVENT_HXX
 #define EVENT_HXX
 
+namespace ale {
 
 class Event;
 
@@ -92,5 +93,7 @@ class Event
     // Array of values associated with each event type
     int myValues[LastType];
 };
+
+}  // namespace ale
 
 #endif

--- a/src/emucore/Event.hxx
+++ b/src/emucore/Event.hxx
@@ -20,6 +20,7 @@
 #define EVENT_HXX
 
 namespace ale {
+namespace stella {
 
 class Event;
 
@@ -94,6 +95,7 @@ class Event
     int myValues[LastType];
 };
 
+}  // namespace stella
 }  // namespace ale
 
 #endif

--- a/src/emucore/Joystick.cxx
+++ b/src/emucore/Joystick.cxx
@@ -20,6 +20,8 @@
 #include "emucore/Event.hxx"
 #include "emucore/Joystick.hxx"
 
+namespace ale {
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Joystick::Joystick(Jack jack, const Event& event)
   : Controller(jack, event, Controller::Joystick)
@@ -73,3 +75,5 @@ void Joystick::write(DigitalPin, bool)
 {
   // Writing doesn't do anything to the joystick...
 }
+
+}  // namespace ale

--- a/src/emucore/Joystick.cxx
+++ b/src/emucore/Joystick.cxx
@@ -21,6 +21,7 @@
 #include "emucore/Joystick.hxx"
 
 namespace ale {
+namespace stella {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Joystick::Joystick(Jack jack, const Event& event)
@@ -76,4 +77,5 @@ void Joystick::write(DigitalPin, bool)
   // Writing doesn't do anything to the joystick...
 }
 
+}  // namespace stella
 }  // namespace ale

--- a/src/emucore/Joystick.hxx
+++ b/src/emucore/Joystick.hxx
@@ -22,6 +22,7 @@
 #include "emucore/Control.hxx"
 
 namespace ale {
+namespace stella {
 
 /**
   The standard Atari 2600 joystick controller.
@@ -74,6 +75,7 @@ class Joystick : public Controller
     virtual void write(DigitalPin pin, bool value);
 };
 
+}  // namespace stella
 }  // namespace ale
 
 #endif

--- a/src/emucore/Joystick.hxx
+++ b/src/emucore/Joystick.hxx
@@ -21,6 +21,8 @@
 
 #include "emucore/Control.hxx"
 
+namespace ale {
+
 /**
   The standard Atari 2600 joystick controller.
 
@@ -71,5 +73,7 @@ class Joystick : public Controller
     */
     virtual void write(DigitalPin pin, bool value);
 };
+
+}  // namespace ale
 
 #endif

--- a/src/emucore/M6502.cxx
+++ b/src/emucore/M6502.cxx
@@ -24,6 +24,8 @@
 
 static std::once_flag bcd_table_init_once;
 
+namespace ale {
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 M6502::M6502(uint32_t systemCyclesPerProcessorCycle)
     : myExecutionStatus(0),
@@ -343,3 +345,5 @@ const char* M6502::ourInstructionMnemonicTable[256] = {
   "BEQ",  "SBC",  "n/a",  "isb",  "nop",  "SBC",  "INC",  "isb",    // 0xF?
   "SED",  "SBC",  "nop",  "isb",  "nop",  "SBC",  "INC",  "isb"
 };
+
+}  // namespace ale

--- a/src/emucore/M6502.cxx
+++ b/src/emucore/M6502.cxx
@@ -25,6 +25,7 @@
 static std::once_flag bcd_table_init_once;
 
 namespace ale {
+namespace stella {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 M6502::M6502(uint32_t systemCyclesPerProcessorCycle)
@@ -346,4 +347,5 @@ const char* M6502::ourInstructionMnemonicTable[256] = {
   "SED",  "SBC",  "nop",  "isb",  "nop",  "SBC",  "INC",  "isb"
 };
 
+}  // namespace stella
 }  // namespace ale

--- a/src/emucore/M6502.hxx
+++ b/src/emucore/M6502.hxx
@@ -20,15 +20,20 @@
 #define M6502_HXX
 
 namespace ale {
+namespace stella {
+
 class M6502;
 class Serializer;
 class Deserializer;
+
+}  // namespace stella
 }  // namespace ale
 
 #include "emucore/System.hxx"
 #include <cstdint>
 
 namespace ale {
+namespace stella {
 
 /**
   This is an abstract base class for classes that emulate the
@@ -256,6 +261,7 @@ class M6502
     int myTotalInstructionCount;
 };
 
+}  // namespace stella
 }  // namespace ale
 
 #endif

--- a/src/emucore/M6502.hxx
+++ b/src/emucore/M6502.hxx
@@ -19,12 +19,16 @@
 #ifndef M6502_HXX
 #define M6502_HXX
 
+namespace ale {
 class M6502;
 class Serializer;
 class Deserializer;
+}  // namespace ale
 
 #include "emucore/System.hxx"
 #include <cstdint>
+
+namespace ale {
 
 /**
   This is an abstract base class for classes that emulate the
@@ -251,5 +255,7 @@ class M6502
 
     int myTotalInstructionCount;
 };
+
+}  // namespace ale
 
 #endif

--- a/src/emucore/M6502Hi.cxx
+++ b/src/emucore/M6502Hi.cxx
@@ -22,6 +22,8 @@
 
 #include "common/Log.hpp"
 
+namespace ale {
+
 #define debugStream ale::Logger::Info
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -275,3 +277,5 @@ const char* M6502High::name() const
 {
   return "M6502High";
 }
+
+}  // namespace ale

--- a/src/emucore/M6502Hi.cxx
+++ b/src/emucore/M6502Hi.cxx
@@ -23,6 +23,7 @@
 #include "common/Log.hpp"
 
 namespace ale {
+namespace stella {
 
 #define debugStream ale::Logger::Info
 
@@ -278,4 +279,5 @@ const char* M6502High::name() const
   return "M6502High";
 }
 
+}  // namespace stella
 }  // namespace ale

--- a/src/emucore/M6502Hi.hxx
+++ b/src/emucore/M6502Hi.hxx
@@ -20,14 +20,19 @@
 #define M6502HIGH_HXX
 
 namespace ale {
+namespace stella {
+
 class M6502High;
 class Serializer;
 class Deserializer;
+
+}  // namespace stella
 }  // namespace ale
 
 #include "emucore/M6502.hxx"
 
 namespace ale {
+namespace stella {
 
 /**
   This class provides a high compatibility 6502 microprocessor emulator.  
@@ -133,6 +138,7 @@ class M6502High : public M6502
     uint16_t myLastAddress;
 };
 
+}  // namespace stella
 }  // namespace ale
 
 #endif

--- a/src/emucore/M6502Hi.hxx
+++ b/src/emucore/M6502Hi.hxx
@@ -19,11 +19,15 @@
 #ifndef M6502HIGH_HXX
 #define M6502HIGH_HXX
 
+namespace ale {
 class M6502High;
 class Serializer;
 class Deserializer;
+}  // namespace ale
 
 #include "emucore/M6502.hxx"
+
+namespace ale {
 
 /**
   This class provides a high compatibility 6502 microprocessor emulator.  
@@ -128,5 +132,8 @@ class M6502High : public M6502
     // Indicates the last address which was accessed
     uint16_t myLastAddress;
 };
+
+}  // namespace ale
+
 #endif
 

--- a/src/emucore/M6502Low.cxx
+++ b/src/emucore/M6502Low.cxx
@@ -22,6 +22,8 @@
 
 #include <iostream>
 
+namespace ale {
+
 #define debugStream std::cerr
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -250,3 +252,5 @@ const char* M6502Low::name() const
 {
   return "M6502Low";
 }
+
+}  // namespace ale

--- a/src/emucore/M6502Low.cxx
+++ b/src/emucore/M6502Low.cxx
@@ -23,6 +23,7 @@
 #include <iostream>
 
 namespace ale {
+namespace stella {
 
 #define debugStream std::cerr
 
@@ -253,4 +254,5 @@ const char* M6502Low::name() const
   return "M6502Low";
 }
 
+}  // namespace stella
 }  // namespace ale

--- a/src/emucore/M6502Low.hxx
+++ b/src/emucore/M6502Low.hxx
@@ -19,11 +19,15 @@
 #ifndef M6502LOW_HXX
 #define M6502LOW_HXX
 
+namespace ale {
 class M6502Low;
 class Serializer;
 class Deserializer;
+}  // namespace ale
 
 #include "emucore/M6502.hxx"
+
+namespace ale {
 
 /**
   This class provides a low compatibility 6502 microprocessor emulator.  
@@ -114,5 +118,8 @@ class M6502Low : public M6502
     */
     inline void poke(uint16_t address, uint8_t value);
 };
+
+}  // namespace ale
+
 #endif
 

--- a/src/emucore/M6502Low.hxx
+++ b/src/emucore/M6502Low.hxx
@@ -20,14 +20,19 @@
 #define M6502LOW_HXX
 
 namespace ale {
+namespace stella {
+
 class M6502Low;
 class Serializer;
 class Deserializer;
+
+}  // namespace stella
 }  // namespace ale
 
 #include "emucore/M6502.hxx"
 
 namespace ale {
+namespace stella {
 
 /**
   This class provides a low compatibility 6502 microprocessor emulator.  
@@ -119,6 +124,7 @@ class M6502Low : public M6502
     inline void poke(uint16_t address, uint8_t value);
 };
 
+}  // namespace stella
 }  // namespace ale
 
 #endif

--- a/src/emucore/M6532.cxx
+++ b/src/emucore/M6532.cxx
@@ -29,6 +29,7 @@
 #include "common/Log.hpp"
 
 namespace ale {
+namespace stella {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 M6532::M6532(const Console& console)
@@ -385,5 +386,6 @@ M6532& M6532::operator = (const M6532&)
   return *this;
 }
 
+}  // namespace stella
 }  // namespace ale
  

--- a/src/emucore/M6532.cxx
+++ b/src/emucore/M6532.cxx
@@ -28,6 +28,8 @@
 #include "emucore/OSystem.hxx"
 #include "common/Log.hpp"
 
+namespace ale {
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 M6532::M6532(const Console& console)
     : myConsole(console)
@@ -382,4 +384,6 @@ M6532& M6532::operator = (const M6532&)
 
   return *this;
 }
+
+}  // namespace ale
  

--- a/src/emucore/M6532.hxx
+++ b/src/emucore/M6532.hxx
@@ -19,13 +19,17 @@
 #ifndef M6532_HXX
 #define M6532_HXX
 
+namespace ale {
 class Console;
 class System;
 class Serializer;
 class Deserializer;
+}  // namespace ale
 
 #include "emucore/Device.hxx"
 #include "emucore/Random.hxx"
+
+namespace ale {
 
 /**
   RIOT
@@ -143,5 +147,8 @@ class M6532 : public Device
     // Assignment operator isn't supported by this class so make it private
     M6532& operator = (const M6532&);
 };
+
+}  // namespace ale
+
 #endif
 

--- a/src/emucore/M6532.hxx
+++ b/src/emucore/M6532.hxx
@@ -20,16 +20,21 @@
 #define M6532_HXX
 
 namespace ale {
+namespace stella {
+
 class Console;
 class System;
 class Serializer;
 class Deserializer;
+
+}  // namespace stella
 }  // namespace ale
 
 #include "emucore/Device.hxx"
 #include "emucore/Random.hxx"
 
 namespace ale {
+namespace stella {
 
 /**
   RIOT
@@ -148,6 +153,7 @@ class M6532 : public Device
     M6532& operator = (const M6532&);
 };
 
+}  // namespace stella
 }  // namespace ale
 
 #endif

--- a/src/emucore/MD5.cxx
+++ b/src/emucore/MD5.cxx
@@ -44,6 +44,8 @@
  documentation and/or software.
 */
 
+namespace ale {
+
 // Setup the types used by the MD5 routines
 typedef unsigned char* POINTER;
 typedef uint16_t UINT2;
@@ -344,3 +346,5 @@ std::string MD5(const uint8_t* buffer, uint32_t length)
 
   return result;
 }
+
+}  // namespace ale

--- a/src/emucore/MD5.cxx
+++ b/src/emucore/MD5.cxx
@@ -45,6 +45,7 @@
 */
 
 namespace ale {
+namespace stella {
 
 // Setup the types used by the MD5 routines
 typedef unsigned char* POINTER;
@@ -347,4 +348,5 @@ std::string MD5(const uint8_t* buffer, uint32_t length)
   return result;
 }
 
+}  // namespace stella
 }  // namespace ale

--- a/src/emucore/MD5.hxx
+++ b/src/emucore/MD5.hxx
@@ -21,6 +21,8 @@
 
 #include <string>
 
+namespace ale {
+
 /**
   Get the MD5 Message-Digest of the specified message with the 
   given length.  The digest consists of 32 hexadecimal digits.
@@ -30,5 +32,7 @@
   @return The message-digest
 */
 std::string MD5(const uint8_t* buffer, uint32_t length);
+
+}  // namespace ale
 
 #endif

--- a/src/emucore/MD5.hxx
+++ b/src/emucore/MD5.hxx
@@ -22,6 +22,7 @@
 #include <string>
 
 namespace ale {
+namespace stella {
 
 /**
   Get the MD5 Message-Digest of the specified message with the 
@@ -33,6 +34,7 @@ namespace ale {
 */
 std::string MD5(const uint8_t* buffer, uint32_t length);
 
+}  // namespace stella
 }  // namespace ale
 
 #endif

--- a/src/emucore/MediaSrc.cxx
+++ b/src/emucore/MediaSrc.cxx
@@ -19,6 +19,8 @@
 #include <cassert>
 #include "emucore/MediaSrc.hxx"
 
+namespace ale {
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 MediaSource::MediaSource()
 {
@@ -42,3 +44,4 @@ MediaSource& MediaSource::operator = (const MediaSource&)
   return *this;
 }
 
+}  // namespace ale

--- a/src/emucore/MediaSrc.cxx
+++ b/src/emucore/MediaSrc.cxx
@@ -20,6 +20,7 @@
 #include "emucore/MediaSrc.hxx"
 
 namespace ale {
+namespace stella {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 MediaSource::MediaSource()
@@ -44,4 +45,5 @@ MediaSource& MediaSource::operator = (const MediaSource&)
   return *this;
 }
 
+}  // namespace stella
 }  // namespace ale

--- a/src/emucore/MediaSrc.hxx
+++ b/src/emucore/MediaSrc.hxx
@@ -20,11 +20,14 @@
 #define MEDIASOURCE_HXX
 
 
+namespace ale {
 class MediaSource;
 class Sound;
+}  // namespace ale
 
 #include <cstdint>
 
+namespace ale {
 
 /**
   This class provides an interface for accessing graphics and audio data.
@@ -104,5 +107,7 @@ class MediaSource
     // Assignment operator isn't supported by this class so make it private
     MediaSource& operator = (const MediaSource&);
 };
+
+}  // namespace ale
 
 #endif

--- a/src/emucore/MediaSrc.hxx
+++ b/src/emucore/MediaSrc.hxx
@@ -21,13 +21,18 @@
 
 
 namespace ale {
+namespace stella {
+
 class MediaSource;
 class Sound;
+
+}  // namespace stella
 }  // namespace ale
 
 #include <cstdint>
 
 namespace ale {
+namespace stella {
 
 /**
   This class provides an interface for accessing graphics and audio data.
@@ -108,6 +113,7 @@ class MediaSource
     MediaSource& operator = (const MediaSource&);
 };
 
+}  // namespace stella
 }  // namespace ale
 
 #endif

--- a/src/emucore/NullDev.cxx
+++ b/src/emucore/NullDev.cxx
@@ -23,6 +23,7 @@
 #include <iostream>
 
 namespace ale {
+namespace stella {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 NullDevice::NullDevice()
@@ -76,4 +77,5 @@ bool NullDevice::load(Deserializer& in)
   return true;
 }
 
+}  // namespace stella
 }  // namespace ale

--- a/src/emucore/NullDev.cxx
+++ b/src/emucore/NullDev.cxx
@@ -22,6 +22,8 @@
 
 #include <iostream>
 
+namespace ale {
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 NullDevice::NullDevice()
 {
@@ -73,3 +75,5 @@ bool NullDevice::load(Deserializer& in)
 {
   return true;
 }
+
+}  // namespace ale

--- a/src/emucore/NullDev.hxx
+++ b/src/emucore/NullDev.hxx
@@ -20,14 +20,19 @@
 #define NULLDEVICE_HXX
 
 namespace ale {
+namespace stella {
+
 class System;
 class Serializer;
 class Deserializer;
+
+}  // namespace stella
 }  // namespace ale
 
 #include "emucore/Device.hxx"
 
 namespace ale {
+namespace stella {
 
 /**
   Class that represents a "null" device.  The basic idea is that a
@@ -105,5 +110,6 @@ class NullDevice : public Device
 };
 #endif
 
+}  // namespace stella
 }  // namespace ale
 

--- a/src/emucore/NullDev.hxx
+++ b/src/emucore/NullDev.hxx
@@ -19,11 +19,15 @@
 #ifndef NULLDEVICE_HXX
 #define NULLDEVICE_HXX
 
+namespace ale {
 class System;
 class Serializer;
 class Deserializer;
+}  // namespace ale
 
 #include "emucore/Device.hxx"
+
+namespace ale {
 
 /**
   Class that represents a "null" device.  The basic idea is that a
@@ -100,4 +104,6 @@ class NullDevice : public Device
     virtual void poke(uint16_t address, uint8_t value);
 };
 #endif
- 
+
+}  // namespace ale
+

--- a/src/emucore/OSystem.cxx
+++ b/src/emucore/OSystem.cxx
@@ -44,6 +44,7 @@
 namespace fs = std::filesystem;
 
 namespace ale {
+namespace stella {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 OSystem::OSystem()
@@ -317,4 +318,5 @@ OSystem& OSystem::operator = (const OSystem&)
   return *this;
 }
 
+}  // namespace stella
 }  // namespace ale

--- a/src/emucore/OSystem.cxx
+++ b/src/emucore/OSystem.cxx
@@ -43,6 +43,8 @@
 
 namespace fs = std::filesystem;
 
+namespace ale {
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 OSystem::OSystem()
   : 
@@ -314,3 +316,5 @@ OSystem& OSystem::operator = (const OSystem&)
 
   return *this;
 }
+
+}  // namespace ale

--- a/src/emucore/OSystem.hxx
+++ b/src/emucore/OSystem.hxx
@@ -20,7 +20,11 @@
 #define OSYSTEM_HXX
 
 namespace ale {
+namespace stella {
+
 class PropertiesSet;
+
+}  // namespace stella
 }  // namespace ale
 
 #include <filesystem>
@@ -37,6 +41,7 @@ class PropertiesSet;
 namespace fs = std::filesystem;
 
 namespace ale {
+namespace stella {
 
 /**
   This class provides an interface for accessing operating system specific
@@ -209,6 +214,7 @@ class OSystem
     OSystem& operator = (const OSystem&);
 };
 
+}  // namespace stella
 }  // namespace ale
 
 #endif

--- a/src/emucore/OSystem.hxx
+++ b/src/emucore/OSystem.hxx
@@ -19,7 +19,9 @@
 #ifndef OSYSTEM_HXX
 #define OSYSTEM_HXX
 
+namespace ale {
 class PropertiesSet;
+}  // namespace ale
 
 #include <filesystem>
 
@@ -33,6 +35,8 @@ class PropertiesSet;
 #include "common/Log.hpp"
 
 namespace fs = std::filesystem;
+
+namespace ale {
 
 /**
   This class provides an interface for accessing operating system specific
@@ -204,5 +208,7 @@ class OSystem
     // Assignment operator isn't supported by this class so make it private
     OSystem& operator = (const OSystem&);
 };
+
+}  // namespace ale
 
 #endif

--- a/src/emucore/Paddles.cxx
+++ b/src/emucore/Paddles.cxx
@@ -19,6 +19,8 @@
 #include "emucore/Event.hxx"
 #include "emucore/Paddles.hxx"
 
+namespace ale {
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Paddles::Paddles(Jack jack, const Event& event, bool swap)
   : Controller(jack, event, Controller::Paddles)
@@ -109,3 +111,5 @@ void Paddles::write(DigitalPin, bool)
 {
   // Writing doesn't do anything to the paddles...
 }
+
+}  // namespace ale

--- a/src/emucore/Paddles.cxx
+++ b/src/emucore/Paddles.cxx
@@ -20,6 +20,7 @@
 #include "emucore/Paddles.hxx"
 
 namespace ale {
+namespace stella {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Paddles::Paddles(Jack jack, const Event& event, bool swap)
@@ -112,4 +113,5 @@ void Paddles::write(DigitalPin, bool)
   // Writing doesn't do anything to the paddles...
 }
 
+}  // namespace stella
 }  // namespace ale

--- a/src/emucore/Paddles.hxx
+++ b/src/emucore/Paddles.hxx
@@ -23,6 +23,7 @@
 #include "emucore/Event.hxx"
 
 namespace ale {
+namespace stella {
 
 /**
   The standard Atari 2600 pair of paddle controllers.
@@ -81,6 +82,7 @@ class Paddles : public Controller
     Event::Type myPinEvents[4][2];
 };
 
+}  // namespace stella
 }  // namespace ale
 
 #endif

--- a/src/emucore/Paddles.hxx
+++ b/src/emucore/Paddles.hxx
@@ -22,6 +22,8 @@
 #include "emucore/Control.hxx"
 #include "emucore/Event.hxx"
 
+namespace ale {
+
 /**
   The standard Atari 2600 pair of paddle controllers.
 
@@ -78,5 +80,7 @@ class Paddles : public Controller
     // testing at runtime
     Event::Type myPinEvents[4][2];
 };
+
+}  // namespace ale
 
 #endif

--- a/src/emucore/Props.cxx
+++ b/src/emucore/Props.cxx
@@ -25,6 +25,7 @@
 #include "emucore/Props.hxx"
 
 namespace ale {
+namespace stella {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Properties::Properties()
@@ -332,4 +333,5 @@ const char* Properties::ourPropertyNames[LastPropType] = {
   "Emulation.HmoveBlanks"
 };
 
+}  // namespace stella
 }  // namespace ale

--- a/src/emucore/Props.cxx
+++ b/src/emucore/Props.cxx
@@ -24,6 +24,8 @@
 
 #include "emucore/Props.hxx"
 
+namespace ale {
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Properties::Properties()
 {
@@ -329,3 +331,5 @@ const char* Properties::ourPropertyNames[LastPropType] = {
   "Display.PPBlend",
   "Emulation.HmoveBlanks"
 };
+
+}  // namespace ale

--- a/src/emucore/Props.hxx
+++ b/src/emucore/Props.hxx
@@ -23,6 +23,7 @@
 #include <iostream>
 
 namespace ale {
+namespace stella {
 
 enum PropertyType {
   Cartridge_MD5,
@@ -180,6 +181,7 @@ class Properties
     static const char* ourPropertyNames[LastPropType];
 };
 
+}  // namespace stella
 }  // namespace ale
 
 #endif

--- a/src/emucore/Props.hxx
+++ b/src/emucore/Props.hxx
@@ -22,6 +22,8 @@
 #include <string>
 #include <iostream>
 
+namespace ale {
+
 enum PropertyType {
   Cartridge_MD5,
   Cartridge_Manufacturer,
@@ -177,5 +179,7 @@ class Properties
     // The text strings associated with each property type
     static const char* ourPropertyNames[LastPropType];
 };
+
+}  // namespace ale
 
 #endif

--- a/src/emucore/PropsSet.cxx
+++ b/src/emucore/PropsSet.cxx
@@ -26,6 +26,7 @@
 #include "emucore/PropsSet.hxx"
 
 namespace ale {
+namespace stella {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 PropertiesSet::PropertiesSet()
@@ -198,4 +199,5 @@ uint32_t PropertiesSet::size() const
   return mySize;
 }
 
+}  // namespace stella
 }  // namespace ale

--- a/src/emucore/PropsSet.cxx
+++ b/src/emucore/PropsSet.cxx
@@ -25,6 +25,8 @@
 #include "emucore/Props.hxx"
 #include "emucore/PropsSet.hxx"
 
+namespace ale {
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 PropertiesSet::PropertiesSet()
   : myRoot(NULL),
@@ -195,3 +197,5 @@ uint32_t PropertiesSet::size() const
 {
   return mySize;
 }
+
+}  // namespace ale

--- a/src/emucore/PropsSet.hxx
+++ b/src/emucore/PropsSet.hxx
@@ -19,6 +19,8 @@
 #ifndef PROPERTIES_SET_HXX
 #define PROPERTIES_SET_HXX
 
+namespace ale {
+
 
 class Properties;
 
@@ -127,5 +129,7 @@ class PropertiesSet
     // The size of the properties bst (i.e. the number of properties in it)
     uint32_t mySize;
 };
+
+}  // namespace ale
 
 #endif

--- a/src/emucore/PropsSet.hxx
+++ b/src/emucore/PropsSet.hxx
@@ -20,6 +20,7 @@
 #define PROPERTIES_SET_HXX
 
 namespace ale {
+namespace stella {
 
 
 class Properties;
@@ -130,6 +131,7 @@ class PropertiesSet
     uint32_t mySize;
 };
 
+}  // namespace stella
 }  // namespace ale
 
 #endif

--- a/src/emucore/Random.cxx
+++ b/src/emucore/Random.cxx
@@ -26,6 +26,7 @@
 #include <sstream>
 
 namespace ale {
+namespace stella {
 
 // Implementation of Random's random number generator wrapper. 
 class Random::Impl {
@@ -127,4 +128,5 @@ bool Random::loadState(Deserializer& deser) {
   return true;
 }
 
+}  // namespace stella
 }  // namespace ale

--- a/src/emucore/Random.cxx
+++ b/src/emucore/Random.cxx
@@ -25,6 +25,8 @@
 #include <random>
 #include <sstream>
 
+namespace ale {
+
 // Implementation of Random's random number generator wrapper. 
 class Random::Impl {
   
@@ -124,3 +126,5 @@ bool Random::loadState(Deserializer& deser) {
 
   return true;
 }
+
+}  // namespace ale

--- a/src/emucore/Random.hxx
+++ b/src/emucore/Random.hxx
@@ -21,13 +21,18 @@
 
 
 namespace ale {
+namespace stella {
+
 class Serializer;
 class Deserializer;
+
+}  // namespace stella
 }  // namespace ale
 
 #include <cstdint>
 
 namespace ale {
+namespace stella {
 
 /**
   This Random class uses a Mersenne Twister to provide pseudorandom numbers.
@@ -83,6 +88,7 @@ class Random
     Impl *m_pimpl;
 };
 
+}  // namespace stella
 }  // namespace ale
 
 #endif

--- a/src/emucore/Random.hxx
+++ b/src/emucore/Random.hxx
@@ -20,10 +20,14 @@
 #define RANDOM_HXX
 
 
+namespace ale {
 class Serializer;
 class Deserializer;
+}  // namespace ale
 
 #include <cstdint>
+
+namespace ale {
 
 /**
   This Random class uses a Mersenne Twister to provide pseudorandom numbers.
@@ -78,5 +82,8 @@ class Random
     class Impl;
     Impl *m_pimpl;
 };
+
+}  // namespace ale
+
 #endif
 

--- a/src/emucore/Screen.hxx
+++ b/src/emucore/Screen.hxx
@@ -16,6 +16,8 @@
 #ifndef SCREEN_HXX
 #define SCREEN_HXX
 
+namespace ale {
+
 class OSystem;
 
 class Screen
@@ -30,5 +32,7 @@ class Screen
   protected:
     OSystem* myOSystem;
 };
+
+}  // namespace ale
 
 #endif

--- a/src/emucore/Screen.hxx
+++ b/src/emucore/Screen.hxx
@@ -17,6 +17,7 @@
 #define SCREEN_HXX
 
 namespace ale {
+namespace stella {
 
 class OSystem;
 
@@ -33,6 +34,7 @@ class Screen
     OSystem* myOSystem;
 };
 
+}  // namespace stella
 }  // namespace ale
 
 #endif

--- a/src/emucore/Serializer.cxx
+++ b/src/emucore/Serializer.cxx
@@ -19,6 +19,8 @@
 #include "emucore/Serializer.hxx"
 
 
+namespace ale {
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Serializer::Serializer(void) {
     myStream.clear();
@@ -67,4 +69,6 @@ void Serializer::putBool(bool b)
 {
     putInt(b ? TruePattern: FalsePattern);
 }
+
+}  // namespace ale
 

--- a/src/emucore/Serializer.cxx
+++ b/src/emucore/Serializer.cxx
@@ -20,6 +20,7 @@
 
 
 namespace ale {
+namespace stella {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Serializer::Serializer(void) {
@@ -70,5 +71,6 @@ void Serializer::putBool(bool b)
     putInt(b ? TruePattern: FalsePattern);
 }
 
+}  // namespace stella
 }  // namespace ale
 

--- a/src/emucore/Serializer.hxx
+++ b/src/emucore/Serializer.hxx
@@ -22,6 +22,7 @@
 #include <sstream>
 
 namespace ale {
+namespace stella {
 
 /**
   This class implements a Serializer device, whereby data is
@@ -96,6 +97,7 @@ class Serializer
     };
 };
 
+}  // namespace stella
 }  // namespace ale
 
 #endif

--- a/src/emucore/Serializer.hxx
+++ b/src/emucore/Serializer.hxx
@@ -21,6 +21,8 @@
 
 #include <sstream>
 
+namespace ale {
+
 /**
   This class implements a Serializer device, whereby data is
   serialized and sent to an output binary file in a system-
@@ -93,5 +95,7 @@ class Serializer
       FalsePattern = 0xbad1bad2
     };
 };
+
+}  // namespace ale
 
 #endif

--- a/src/emucore/Settings.cxx
+++ b/src/emucore/Settings.cxx
@@ -26,6 +26,7 @@
 #include "emucore/Settings.hxx"
 
 namespace ale {
+namespace stella {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Settings::Settings(OSystem* osystem) : myOSystem(osystem) {
@@ -448,4 +449,5 @@ void Settings::verifyVariableExistence(std::map<std::string, ValueType> dict, st
     }
 }
 
+}  // namespace stella
 }  // namespace ale

--- a/src/emucore/Settings.cxx
+++ b/src/emucore/Settings.cxx
@@ -25,6 +25,8 @@
 #include "emucore/OSystem.hxx"
 #include "emucore/Settings.hxx"
 
+namespace ale {
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Settings::Settings(OSystem* osystem) : myOSystem(osystem) {
     // Add this settings object to the OSystem
@@ -445,3 +447,5 @@ void Settings::verifyVariableExistence(std::map<std::string, ValueType> dict, st
       throw std::runtime_error("The key " + key + " you are trying to set does not exist or has incorrect value type.\n");
     }
 }
+
+}  // namespace ale

--- a/src/emucore/Settings.hxx
+++ b/src/emucore/Settings.hxx
@@ -19,12 +19,16 @@
 #ifndef SETTINGS_HXX
 #define SETTINGS_HXX
 
+namespace ale {
 class OSystem;
+}  // namespace ale
 
 #include <map>
 #include <vector>
 #include <stdexcept>
 
+
+namespace ale {
 
 /**
   This class provides an interface for accessing frontend specific settings.
@@ -202,5 +206,7 @@ class Settings
     // program exit.
     SettingsArray myExternalSettings;
 };
+
+}  // namespace ale
 
 #endif

--- a/src/emucore/Settings.hxx
+++ b/src/emucore/Settings.hxx
@@ -20,7 +20,11 @@
 #define SETTINGS_HXX
 
 namespace ale {
+namespace stella {
+
 class OSystem;
+
+}  // namespace stella
 }  // namespace ale
 
 #include <map>
@@ -29,6 +33,7 @@ class OSystem;
 
 
 namespace ale {
+namespace stella {
 
 /**
   This class provides an interface for accessing frontend specific settings.
@@ -207,6 +212,7 @@ class Settings
     SettingsArray myExternalSettings;
 };
 
+}  // namespace stella
 }  // namespace ale
 
 #endif

--- a/src/emucore/Sound.hxx
+++ b/src/emucore/Sound.hxx
@@ -19,6 +19,8 @@
 #ifndef SOUND_HXX
 #define SOUND_HXX
 
+namespace ale {
+  
 class Settings;
 class Serializer;
 class Deserializer;
@@ -159,5 +161,7 @@ public:
     // The emulator Settings
     Settings* mySettings;
 };
+
+}  // namespace ale
 
 #endif

--- a/src/emucore/Sound.hxx
+++ b/src/emucore/Sound.hxx
@@ -20,6 +20,7 @@
 #define SOUND_HXX
 
 namespace ale {
+namespace stella {
   
 class Settings;
 class Serializer;
@@ -162,6 +163,7 @@ public:
     Settings* mySettings;
 };
 
+}  // namespace stella
 }  // namespace ale
 
 #endif

--- a/src/emucore/Switches.cxx
+++ b/src/emucore/Switches.cxx
@@ -21,6 +21,7 @@
 #include "emucore/Switches.hxx"
 
 namespace ale {
+namespace stella {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 Switches::Switches(const Event& event, const Properties& properties)
@@ -111,5 +112,6 @@ uint8_t Switches::read()
   return mySwitches;
 }
 
+}  // namespace stella
 }  // namespace ale
 

--- a/src/emucore/Switches.cxx
+++ b/src/emucore/Switches.cxx
@@ -20,6 +20,8 @@
 #include "emucore/Props.hxx"
 #include "emucore/Switches.hxx"
 
+namespace ale {
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 Switches::Switches(const Event& event, const Properties& properties)
     : myEvent(event),
@@ -108,4 +110,6 @@ uint8_t Switches::read()
 
   return mySwitches;
 }
+
+}  // namespace ale
 

--- a/src/emucore/Switches.hxx
+++ b/src/emucore/Switches.hxx
@@ -20,6 +20,7 @@
 #define SWITCHES_HXX
 
 namespace ale {
+namespace stella {
 
 class Event;
 class Properties;
@@ -64,6 +65,7 @@ class Switches
     uint8_t mySwitches;
 };
 
+}  // namespace stella
 }  // namespace ale
 
 #endif

--- a/src/emucore/Switches.hxx
+++ b/src/emucore/Switches.hxx
@@ -19,6 +19,8 @@
 #ifndef SWITCHES_HXX
 #define SWITCHES_HXX
 
+namespace ale {
+
 class Event;
 class Properties;
 class Switches;
@@ -61,5 +63,8 @@ class Switches
     // State of the console switches
     uint8_t mySwitches;
 };
+
+}  // namespace ale
+
 #endif
 

--- a/src/emucore/System.cxx
+++ b/src/emucore/System.cxx
@@ -28,6 +28,7 @@
 #include "emucore/Settings.hxx"
 
 namespace ale {
+namespace stella {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 System::System(Settings& settings)
@@ -310,4 +311,5 @@ void System::unlockDataBus()
   myDataBusLocked = false;
 }
 
+}  // namespace stella
 }  // namespace ale

--- a/src/emucore/System.cxx
+++ b/src/emucore/System.cxx
@@ -27,6 +27,8 @@
 #include "emucore/Deserializer.hxx"
 #include "emucore/Settings.hxx"
 
+namespace ale {
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 System::System(Settings& settings)
   : myNumberOfDevices(0),
@@ -307,3 +309,5 @@ void System::unlockDataBus()
 {
   myDataBusLocked = false;
 }
+
+}  // namespace ale

--- a/src/emucore/System.hxx
+++ b/src/emucore/System.hxx
@@ -19,6 +19,7 @@
 #ifndef SYSTEM_HXX
 #define SYSTEM_HXX
 
+namespace ale {
 class Device;
 class M6502;
 class TIA;
@@ -26,12 +27,15 @@ class NullDevice;
 class Serializer;
 class Deserializer;
 class Settings;
+}  // namespace ale
 
 #include "emucore/Device.hxx"
 #include "emucore/NullDev.hxx"
 #include "emucore/Random.hxx"
 
 #include <string>
+
+namespace ale {
 
 /**
   This class represents a system consisting of a 6502 microprocessor
@@ -420,5 +424,7 @@ inline uint8_t System::getDataBusState() const
 {
   return myDataBusState;
 }
+
+}  // namespace ale
 
 #endif

--- a/src/emucore/System.hxx
+++ b/src/emucore/System.hxx
@@ -20,6 +20,8 @@
 #define SYSTEM_HXX
 
 namespace ale {
+namespace stella {
+
 class Device;
 class M6502;
 class TIA;
@@ -27,6 +29,8 @@ class NullDevice;
 class Serializer;
 class Deserializer;
 class Settings;
+
+}  // namespace stella
 }  // namespace ale
 
 #include "emucore/Device.hxx"
@@ -36,6 +40,7 @@ class Settings;
 #include <string>
 
 namespace ale {
+namespace stella {
 
 /**
   This class represents a system consisting of a 6502 microprocessor
@@ -425,6 +430,7 @@ inline uint8_t System::getDataBusState() const
   return myDataBusState;
 }
 
+}  // namespace stella
 }  // namespace ale
 
 #endif

--- a/src/emucore/TIA.cxx
+++ b/src/emucore/TIA.cxx
@@ -36,6 +36,8 @@
 
 static std::once_flag tia_init_once;
 
+namespace ale {
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TIA::TIA(const Console& console, Settings& settings)
     : myConsole(console),
@@ -3557,3 +3559,4 @@ inline void TIA::updateFrameScanlineFast(uint32_t clocksToUpdate, uint32_t hpos)
   myFramePointer = ending;
 }
 
+}  // namespace ale

--- a/src/emucore/TIA.cxx
+++ b/src/emucore/TIA.cxx
@@ -37,6 +37,7 @@
 static std::once_flag tia_init_once;
 
 namespace ale {
+namespace stella {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TIA::TIA(const Console& console, Settings& settings)
@@ -3559,4 +3560,5 @@ inline void TIA::updateFrameScanlineFast(uint32_t clocksToUpdate, uint32_t hpos)
   myFramePointer = ending;
 }
 
+}  // namespace stella
 }  // namespace ale

--- a/src/emucore/TIA.hxx
+++ b/src/emucore/TIA.hxx
@@ -20,11 +20,15 @@
 #define TIA_HXX
 
 namespace ale {
+namespace stella {
+
 class Console;
 class System;
 class Serializer;
 class Deserializer;
 class Settings;
+
+}  // namespace stella
 }  // namespace ale
 
 #include "emucore/Sound.hxx"
@@ -32,6 +36,7 @@ class Settings;
 #include "emucore/MediaSrc.hxx"
 
 namespace ale {
+namespace stella {
 
 /**
   This class is a device that emulates the Television Interface Adapator 
@@ -543,6 +548,7 @@ class TIA : public Device , public MediaSource
 
 };
 
+}  // namespace stella
 }  // namespace ale
 
 #endif

--- a/src/emucore/TIA.hxx
+++ b/src/emucore/TIA.hxx
@@ -19,15 +19,19 @@
 #ifndef TIA_HXX
 #define TIA_HXX
 
+namespace ale {
 class Console;
 class System;
 class Serializer;
 class Deserializer;
 class Settings;
+}  // namespace ale
 
 #include "emucore/Sound.hxx"
 #include "emucore/Device.hxx"
 #include "emucore/MediaSrc.hxx"
+
+namespace ale {
 
 /**
   This class is a device that emulates the Television Interface Adapator 
@@ -538,5 +542,7 @@ class TIA : public Device , public MediaSource
     void updateFrameScanlineFast(uint32_t clocksToUpdate, uint32_t hpos);
 
 };
+
+}  // namespace ale
 
 #endif

--- a/src/emucore/TIASnd.cxx
+++ b/src/emucore/TIASnd.cxx
@@ -21,6 +21,7 @@
 #include <cassert>
 
 namespace ale {
+namespace stella {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TIASound::TIASound(int outputFrequency, int tiaFrequency, uint32_t channels)
@@ -385,4 +386,5 @@ void TIASound::process(uint8_t* buffer, uint32_t samples)
   }
 }
 
+}  // namespace stella
 }  // namespace ale

--- a/src/emucore/TIASnd.cxx
+++ b/src/emucore/TIASnd.cxx
@@ -20,6 +20,8 @@
 #include "emucore/TIASnd.hxx"
 #include <cassert>
 
+namespace ale {
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 TIASound::TIASound(int outputFrequency, int tiaFrequency, uint32_t channels)
   : myOutputFrequency(outputFrequency),
@@ -382,3 +384,5 @@ void TIASound::process(uint8_t* buffer, uint32_t samples)
     }
   }
 }
+
+}  // namespace ale

--- a/src/emucore/TIASnd.hxx
+++ b/src/emucore/TIASnd.hxx
@@ -19,6 +19,7 @@
 #ifndef TIASOUND_HXX
 #define TIASOUND_HXX
 
+namespace ale {
 
 /**
   This class implements a fairly accurate emulation of the TIA sound
@@ -147,5 +148,7 @@ class TIASound
     uint32_t myVolumePercentage;
     uint8_t  myVolumeClip;
 };
+
+}  // namespace ale
 
 #endif

--- a/src/emucore/TIASnd.hxx
+++ b/src/emucore/TIASnd.hxx
@@ -20,6 +20,7 @@
 #define TIASOUND_HXX
 
 namespace ale {
+namespace stella {
 
 /**
   This class implements a fairly accurate emulation of the TIA sound
@@ -149,6 +150,7 @@ class TIASound
     uint8_t  myVolumeClip;
 };
 
+}  // namespace stella
 }  // namespace ale
 
 #endif

--- a/src/environment/ale_state.cpp
+++ b/src/environment/ale_state.cpp
@@ -26,6 +26,7 @@
 #include "games/RomSettings.hpp"
 
 namespace ale {
+using namespace stella;   // System, Event, Deserializer, Serializer, Random
 
 /** Default constructor - loads settings from system */
 ALEState::ALEState()

--- a/src/environment/ale_state.hpp
+++ b/src/environment/ale_state.hpp
@@ -55,17 +55,17 @@ class ALEState {
   /** Returns true if the two states contain the same saved information */
   bool equals(ALEState& state);
 
-  void resetPaddles(Event*);
+  void resetPaddles(stella::Event*);
 
   //Apply the special select action
-  void pressSelect(Event* event_obj);
+  void pressSelect(stella::Event* event_obj);
 
   /** Applies paddle actions. This actually modifies the game state by updating the paddle
       *  resistances. */
-  void applyActionPaddles(Event* event_obj, int player_a_action,
+  void applyActionPaddles(stella::Event* event_obj, int player_a_action,
                           int player_b_action);
   /** Sets the joystick events. No effect until the emulator is run forward. */
-  void setActionJoysticks(Event* event_obj, int player_a_action,
+  void setActionJoysticks(stella::Event* event_obj, int player_a_action,
                           int player_b_action);
 
   void incrementFrame(int steps = 1);
@@ -101,30 +101,30 @@ class ALEState {
 
   // The two methods below are meant to be used by StellaEnvironment.
   // Restores the environment to a previously saved state.
-  void load(OSystem* osystem, RomSettings* settings, Random* rng, std::string md5,
+  void load(stella::OSystem* osystem, RomSettings* settings, stella::Random* rng, std::string md5,
             const ALEState& rhs);
 
   /** Returns a "copy" of the current state, including the information necessary to restore
    *  the emulator. The RNG can optionally be included in the state. */
-  ALEState save(OSystem* osystem, RomSettings* settings, std::optional<Random*> rng, std::string md5);
+  ALEState save(stella::OSystem* osystem, RomSettings* settings, std::optional<stella::Random*> rng, std::string md5);
 
   /** Reset key presses */
-  void resetKeys(Event* event_obj);
+  void resetKeys(stella::Event* event_obj);
 
   /** Sets the paddle to a given position */
-  void setPaddles(Event* event_obj, int left, int right);
+  void setPaddles(stella::Event* event_obj, int left, int right);
 
   /** Set the paddle min/max values */
   void setPaddleLimits(int paddle_min_val, int paddle_max_val);
 
   /** Updates the paddle position by a delta amount. */
-  void updatePaddlePositions(Event* event_obj, int delta_x, int delta_y);
+  void updatePaddlePositions(stella::Event* event_obj, int delta_x, int delta_y);
 
   /** Calculates the Paddle resistance, based on the given x val */
   int calcPaddleResistance(int x_val);
 
   /** Applies the current difficulty setting, which is effectively part of the action */
-  void setDifficultySwitches(Event* event_obj, unsigned int value);
+  void setDifficultySwitches(stella::Event* event_obj, unsigned int value);
 
  private:
   int m_left_paddle;               // Current value for the left-paddle

--- a/src/environment/phosphor_blend.cpp
+++ b/src/environment/phosphor_blend.cpp
@@ -19,6 +19,7 @@
 #include "emucore/Console.hxx"
 
 namespace ale {
+using namespace stella;   // OSystem
 
 PhosphorBlend::PhosphorBlend(OSystem* osystem) : m_osystem(osystem) {
   // Taken from default Stella settings

--- a/src/environment/phosphor_blend.hpp
+++ b/src/environment/phosphor_blend.hpp
@@ -24,7 +24,7 @@ namespace ale {
 
 class PhosphorBlend {
  public:
-  PhosphorBlend(OSystem*);
+  PhosphorBlend(stella::OSystem*);
 
   void process(ALEScreen& screen);
 
@@ -36,7 +36,7 @@ class PhosphorBlend {
   uint8_t rgbToNTSC(uint32_t rgb);
 
  private:
-  OSystem* m_osystem;
+  stella::OSystem* m_osystem;
 
   uint8_t m_rgb_ntsc[64][64][64];
 

--- a/src/environment/stella_environment.cpp
+++ b/src/environment/stella_environment.cpp
@@ -24,6 +24,7 @@
 #include "emucore/System.hxx"
 
 namespace ale {
+using namespace stella;   // OSystem, Random
 
 StellaEnvironment::StellaEnvironment(OSystem* osystem, RomSettings* settings)
     : m_osystem(osystem),

--- a/src/environment/stella_environment.hpp
+++ b/src/environment/stella_environment.hpp
@@ -39,7 +39,7 @@ namespace ale {
 
 class StellaEnvironment {
  public:
-  StellaEnvironment(OSystem* system, RomSettings* settings);
+  StellaEnvironment(stella::OSystem* system, RomSettings* settings);
 
   /** Resets the system to its start state. */
   void reset();
@@ -96,7 +96,7 @@ class StellaEnvironment {
   int getFrameNumber() const { return m_state.getFrameNumber(); }
   int getEpisodeFrameNumber() const { return m_state.getEpisodeFrameNumber(); }
 
-  Random& getEnvironmentRNG() { return m_random; }
+  stella::Random& getEnvironmentRNG() { return m_random; }
 
   // Returns the current difficulty switch setting in use by the environment.
   difficulty_t getDifficulty() const { return m_state.getDifficulty(); }
@@ -127,10 +127,10 @@ class StellaEnvironment {
   void processRAM();
 
  private:
-  OSystem* m_osystem;
+  stella::OSystem* m_osystem;
   RomSettings* m_settings;
   PhosphorBlend m_phosphor_blend; // For performing phosphor colour averaging, if so desired
-  Random m_random; // Environment random number generator, used for sticky actions
+  stella::Random m_random; // Environment random number generator, used for sticky actions
   std::string m_cartridge_md5; // Necessary for saving and loading emulator state
 
   ALEState m_state;   // Current environment state

--- a/src/environment/stella_environment_wrapper.cpp
+++ b/src/environment/stella_environment_wrapper.cpp
@@ -3,6 +3,7 @@
 #include "environment/stella_environment.hpp"
 
 namespace ale {
+using namespace stella;   // Random
 
 StellaEnvironmentWrapper::StellaEnvironmentWrapper(
     StellaEnvironment& environment)

--- a/src/environment/stella_environment_wrapper.hpp
+++ b/src/environment/stella_environment_wrapper.hpp
@@ -33,7 +33,7 @@ class StellaEnvironmentWrapper {
   reward_t act(Action player_a_action, Action player_b_action);
   void softReset();
   void pressSelect(size_t num_steps = 1);
-  Random& getEnvironmentRNG();
+  stella::Random& getEnvironmentRNG();
 
   StellaEnvironment& m_environment;
 };

--- a/src/games/RomSettings.cpp
+++ b/src/games/RomSettings.cpp
@@ -21,6 +21,7 @@
 #include <algorithm>
 
 namespace ale {
+using namespace stella;   // System
 
 RomSettings::RomSettings() {}
 

--- a/src/games/RomSettings.hpp
+++ b/src/games/RomSettings.hpp
@@ -46,7 +46,9 @@
 
 namespace ale {
 
+namespace stella{
 class System;
+}
 
 // rom support interface
 class RomSettings {
@@ -61,7 +63,7 @@ class RomSettings {
   // This method is called with the collection of settings that will be used to
   // create the Stella emulator for the environment. Overriders may modify these
   // settings when this is needed for the correct behavior of the ROM in Stella.
-  virtual void modifyEnvironmentSettings(Settings& settings) {}
+  virtual void modifyEnvironmentSettings(stella::Settings& settings) {}
 
   // is end of game
   virtual bool isTerminal() const = 0;
@@ -82,13 +84,13 @@ class RomSettings {
   virtual bool isMinimal(const Action& a) const = 0;
 
   // process the latest information from ALE
-  virtual void step(const System& system) = 0;
+  virtual void step(const stella::System& system) = 0;
 
   // saves the state of the rom settings
-  virtual void saveState(Serializer& ser) = 0;
+  virtual void saveState(stella::Serializer& ser) = 0;
 
   // loads the state of the rom settings
-  virtual void loadState(Deserializer& ser) = 0;
+  virtual void loadState(stella::Deserializer& ser) = 0;
 
   // is an action legal (default: yes)
   virtual bool isLegal(const Action& a) const;
@@ -115,7 +117,7 @@ class RomSettings {
   // Set the mode of the game. The given mode must be
   // one returned by the previous function.
   virtual void setMode(
-      game_mode_t, System& system,
+      game_mode_t, stella::System& system,
       std::unique_ptr<StellaEnvironmentWrapper> environment);
 
   // Return the default mode for the game.

--- a/src/games/RomSettings.hpp
+++ b/src/games/RomSettings.hpp
@@ -44,9 +44,9 @@
 #include "emucore/Settings.hxx"
 #include "environment/stella_environment_wrapper.hpp"
 
-class System;
-
 namespace ale {
+
+class System;
 
 // rom support interface
 class RomSettings {

--- a/src/games/RomUtils.cpp
+++ b/src/games/RomUtils.cpp
@@ -20,6 +20,7 @@
 #include "emucore/System.hxx"
 
 namespace ale {
+using namespace stella;   // System
 
 /* reads a byte at a memory location between 0 and 128 */
 int readRam(const System* system, int offset) {

--- a/src/games/RomUtils.hpp
+++ b/src/games/RomUtils.hpp
@@ -20,18 +20,20 @@
 
 namespace ale {
 
+namespace stella{
 class System;
+}
 
 // reads a byte at a RAM location between 0 and 0x7f also mapped to [0x80, 0xff]
-extern int readRam(const System* system, int offset);
+extern int readRam(const stella::System* system, int offset);
 
 // reads a byte from anywhere in the memory map between 0x0000 and 0xffff.
-extern int readMappedRam(const System* system, int offset);
+extern int readMappedRam(const stella::System* system, int offset);
 
 // extracts a decimal value from 1, 2, and 3 bytes respectively
-extern int getDecimalScore(int idx, const System* system);
-extern int getDecimalScore(int lo, int hi, const System* system);
-extern int getDecimalScore(int lo, int mid, int hi, const System* system);
+extern int getDecimalScore(int idx, const stella::System* system);
+extern int getDecimalScore(int lo, int hi, const stella::System* system);
+extern int getDecimalScore(int lo, int mid, int hi, const stella::System* system);
 
 }  // namespace ale
 

--- a/src/games/RomUtils.hpp
+++ b/src/games/RomUtils.hpp
@@ -18,9 +18,9 @@
 #ifndef __ROMUTILS_HPP__
 #define __ROMUTILS_HPP__
 
-class System;
-
 namespace ale {
+
+class System;
 
 // reads a byte at a RAM location between 0 and 0x7f also mapped to [0x80, 0xff]
 extern int readRam(const System* system, int offset);

--- a/src/games/supported/Adventure.cpp
+++ b/src/games/supported/Adventure.cpp
@@ -29,6 +29,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 AdventureSettings::AdventureSettings() { reset(); }
 

--- a/src/games/supported/Adventure.hpp
+++ b/src/games/supported/Adventure.hpp
@@ -58,13 +58,13 @@ class AdventureSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return 1; }
 
@@ -73,7 +73,7 @@ class AdventureSettings : public RomSettings {
 
   // Set the game mode.
   // The given mode must be one returned by the previous function.
-  void setMode(game_mode_t, System& system,
+  void setMode(game_mode_t, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
   // Return the supported difficulty settings for the game.

--- a/src/games/supported/AirRaid.cpp
+++ b/src/games/supported/AirRaid.cpp
@@ -15,6 +15,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 AirRaidSettings::AirRaidSettings() { reset(); }
 

--- a/src/games/supported/AirRaid.hpp
+++ b/src/games/supported/AirRaid.hpp
@@ -47,13 +47,13 @@ class AirRaidSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   ActionVect getStartingActions() override;
 
@@ -63,7 +63,7 @@ class AirRaidSettings : public RomSettings {
 
   // set the mode of the game
   // the given mode must be one returned by the previous function
-  void setMode(game_mode_t, System& system,
+  void setMode(game_mode_t, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
  private:

--- a/src/games/supported/Alien.cpp
+++ b/src/games/supported/Alien.cpp
@@ -30,6 +30,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 AlienSettings::AlienSettings() { reset(); }
 

--- a/src/games/supported/Alien.hpp
+++ b/src/games/supported/Alien.hpp
@@ -62,13 +62,13 @@ class AlienSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return m_lives; }
 
@@ -78,7 +78,7 @@ class AlienSettings : public RomSettings {
 
   // set the mode of the game
   // the given mode must be one returned by the previous function
-  void setMode(game_mode_t, System& system,
+  void setMode(game_mode_t, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
   // returns a list of difficulties that the game can be played in
@@ -87,7 +87,7 @@ class AlienSettings : public RomSettings {
 
  private:
   // special code to read digits for Alien
-  int getDigit(const System& system, int address) const;
+  int getDigit(const stella::System& system, int address) const;
 
   bool m_terminal;
   reward_t m_reward;

--- a/src/games/supported/Amidar.cpp
+++ b/src/games/supported/Amidar.cpp
@@ -30,6 +30,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 AmidarSettings::AmidarSettings() { reset(); }
 

--- a/src/games/supported/Amidar.hpp
+++ b/src/games/supported/Amidar.hpp
@@ -59,13 +59,13 @@ class AmidarSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return isTerminal() ? 0 : m_lives; }
 

--- a/src/games/supported/Assault.cpp
+++ b/src/games/supported/Assault.cpp
@@ -30,6 +30,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 AssaultSettings::AssaultSettings() { reset(); }
 

--- a/src/games/supported/Assault.hpp
+++ b/src/games/supported/Assault.hpp
@@ -59,13 +59,13 @@ class AssaultSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return isTerminal() ? 0 : m_lives; }
 

--- a/src/games/supported/Asterix.cpp
+++ b/src/games/supported/Asterix.cpp
@@ -30,6 +30,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 AsterixSettings::AsterixSettings() { reset(); }
 

--- a/src/games/supported/Asterix.hpp
+++ b/src/games/supported/Asterix.hpp
@@ -59,13 +59,13 @@ class AsterixSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   // Asterix requires the fire action to start the game
   ActionVect getStartingActions() override;

--- a/src/games/supported/Asteroids.cpp
+++ b/src/games/supported/Asteroids.cpp
@@ -30,6 +30,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 AsteroidsSettings::AsteroidsSettings() { reset(); }
 

--- a/src/games/supported/Asteroids.hpp
+++ b/src/games/supported/Asteroids.hpp
@@ -62,13 +62,13 @@ class AsteroidsSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return isTerminal() ? 0 : m_lives; }
 
@@ -78,7 +78,7 @@ class AsteroidsSettings : public RomSettings {
 
   // set the mode of the game
   // the given mode must be one returned by the previous function
-  void setMode(game_mode_t, System& system,
+  void setMode(game_mode_t, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
   // returns a list of difficulties that the game can be played in

--- a/src/games/supported/Atlantis.cpp
+++ b/src/games/supported/Atlantis.cpp
@@ -30,6 +30,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 AtlantisSettings::AtlantisSettings() { reset(); }
 

--- a/src/games/supported/Atlantis.hpp
+++ b/src/games/supported/Atlantis.hpp
@@ -62,13 +62,13 @@ class AtlantisSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return isTerminal() ? 0 : m_lives; }
 
@@ -78,7 +78,7 @@ class AtlantisSettings : public RomSettings {
 
   // set the mode of the game
   // the given mode must be one returned by the previous function
-  void setMode(game_mode_t, System& system,
+  void setMode(game_mode_t, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
  private:

--- a/src/games/supported/Atlantis2.cpp
+++ b/src/games/supported/Atlantis2.cpp
@@ -33,6 +33,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 Atlantis2Settings::Atlantis2Settings() { reset(); }
 

--- a/src/games/supported/Atlantis2.hpp
+++ b/src/games/supported/Atlantis2.hpp
@@ -62,13 +62,13 @@ class Atlantis2Settings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return isTerminal() ? 0 : m_lives; }
 

--- a/src/games/supported/Backgammon.cpp
+++ b/src/games/supported/Backgammon.cpp
@@ -30,6 +30,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 std::int8_t readPieces(const System* system, int offset) {
   int value = readRam(system, offset);

--- a/src/games/supported/Backgammon.hpp
+++ b/src/games/supported/Backgammon.hpp
@@ -38,7 +38,7 @@ class BackgammonSettings : public RomSettings {
 
   void reset() override;
 
-  void modifyEnvironmentSettings(Settings& settings) override;
+  void modifyEnvironmentSettings(stella::Settings& settings) override;
 
   bool isTerminal() const override;
 
@@ -53,17 +53,17 @@ class BackgammonSettings : public RomSettings {
 
   bool isMinimal(const Action& a) const override;
 
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return isTerminal() ? 0 : 1; }
 
   ModeVect getAvailableModes() override;
 
-  void setMode(game_mode_t, System& system,
+  void setMode(game_mode_t, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
   DifficultyVect getAvailableDifficulties() override;

--- a/src/games/supported/BankHeist.cpp
+++ b/src/games/supported/BankHeist.cpp
@@ -30,6 +30,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 BankHeistSettings::BankHeistSettings() { reset(); }
 

--- a/src/games/supported/BankHeist.hpp
+++ b/src/games/supported/BankHeist.hpp
@@ -62,13 +62,13 @@ class BankHeistSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return isTerminal() ? 0 : m_lives; }
 
@@ -78,7 +78,7 @@ class BankHeistSettings : public RomSettings {
 
   // set the mode of the game
   // the given mode must be one returned by the previous function
-  void setMode(game_mode_t, System& system,
+  void setMode(game_mode_t, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
   // returns a list of difficulties that the game can be played in

--- a/src/games/supported/BasicMath.cpp
+++ b/src/games/supported/BasicMath.cpp
@@ -28,6 +28,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 BasicMathSettings::BasicMathSettings() { reset(); }
 

--- a/src/games/supported/BasicMath.hpp
+++ b/src/games/supported/BasicMath.hpp
@@ -49,15 +49,15 @@ class BasicMathSettings : public RomSettings {
 
   bool isMinimal(const Action& a) const override;
 
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   ModeVect getAvailableModes() override;
 
-  void setMode(game_mode_t m, System& system,
+  void setMode(game_mode_t m, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
   DifficultyVect getAvailableDifficulties() override;

--- a/src/games/supported/BattleZone.cpp
+++ b/src/games/supported/BattleZone.cpp
@@ -30,6 +30,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 BattleZoneSettings::BattleZoneSettings() { reset(); }
 

--- a/src/games/supported/BattleZone.hpp
+++ b/src/games/supported/BattleZone.hpp
@@ -62,13 +62,13 @@ class BattleZoneSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return isTerminal() ? 0 : m_lives; }
 
@@ -78,7 +78,7 @@ class BattleZoneSettings : public RomSettings {
 
   // set the mode of the game
   // the given mode must be one returned by the previous function
-  void setMode(game_mode_t, System& system,
+  void setMode(game_mode_t, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
  private:

--- a/src/games/supported/BeamRider.cpp
+++ b/src/games/supported/BeamRider.cpp
@@ -30,6 +30,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 BeamRiderSettings::BeamRiderSettings() { reset(); }
 

--- a/src/games/supported/BeamRider.hpp
+++ b/src/games/supported/BeamRider.hpp
@@ -59,13 +59,13 @@ class BeamRiderSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   ActionVect getStartingActions() override;
 

--- a/src/games/supported/Berzerk.cpp
+++ b/src/games/supported/Berzerk.cpp
@@ -30,6 +30,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 BerzerkSettings::BerzerkSettings() { reset(); }
 

--- a/src/games/supported/Berzerk.hpp
+++ b/src/games/supported/Berzerk.hpp
@@ -62,13 +62,13 @@ class BerzerkSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return isTerminal() ? 0 : m_lives; }
 
@@ -78,7 +78,7 @@ class BerzerkSettings : public RomSettings {
 
   // set the mode of the game
   // the given mode must be one returned by the previous function
-  void setMode(game_mode_t, System& system,
+  void setMode(game_mode_t, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
  private:

--- a/src/games/supported/Blackjack.cpp
+++ b/src/games/supported/Blackjack.cpp
@@ -28,6 +28,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 BlackjackSettings::BlackjackSettings() { reset(); }
 

--- a/src/games/supported/Blackjack.hpp
+++ b/src/games/supported/Blackjack.hpp
@@ -36,7 +36,7 @@ class BlackjackSettings : public RomSettings {
 
   void reset() override;
 
-  void modifyEnvironmentSettings(Settings& settings) override;
+  void modifyEnvironmentSettings(stella::Settings& settings) override;
 
   bool isTerminal() const override;
 
@@ -51,11 +51,11 @@ class BlackjackSettings : public RomSettings {
 
   bool isMinimal(const Action& a) const override;
 
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   DifficultyVect getAvailableDifficulties() override;
 

--- a/src/games/supported/Bowling.cpp
+++ b/src/games/supported/Bowling.cpp
@@ -15,6 +15,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 BowlingSettings::BowlingSettings() { reset(); }
 

--- a/src/games/supported/Bowling.hpp
+++ b/src/games/supported/Bowling.hpp
@@ -62,13 +62,13 @@ class BowlingSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   // No lives in bowling!
   int lives() override { return 0; }
@@ -79,7 +79,7 @@ class BowlingSettings : public RomSettings {
 
   // set the mode of the game
   // the given mode must be one returned by the previous function
-  void setMode(game_mode_t, System& system,
+  void setMode(game_mode_t, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
   // returns a list of difficulties that the game can be played in

--- a/src/games/supported/Boxing.cpp
+++ b/src/games/supported/Boxing.cpp
@@ -15,6 +15,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 BoxingSettings::BoxingSettings() { reset(); }
 

--- a/src/games/supported/Boxing.hpp
+++ b/src/games/supported/Boxing.hpp
@@ -59,13 +59,13 @@ class BoxingSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return 0; }
 

--- a/src/games/supported/Breakout.cpp
+++ b/src/games/supported/Breakout.cpp
@@ -30,6 +30,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 BreakoutSettings::BreakoutSettings() { reset(); }
 

--- a/src/games/supported/Breakout.hpp
+++ b/src/games/supported/Breakout.hpp
@@ -62,13 +62,13 @@ class BreakoutSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   // remaining lives
   int lives() override { return isTerminal() ? 0 : m_lives; }
@@ -79,7 +79,7 @@ class BreakoutSettings : public RomSettings {
 
   // set the mode of the game
   // the given mode must be one returned by the previous function
-  void setMode(game_mode_t, System& system,
+  void setMode(game_mode_t, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
   // returns a list of difficulties that the game can be played in

--- a/src/games/supported/Carnival.cpp
+++ b/src/games/supported/Carnival.cpp
@@ -15,6 +15,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 CarnivalSettings::CarnivalSettings() { reset(); }
 

--- a/src/games/supported/Carnival.hpp
+++ b/src/games/supported/Carnival.hpp
@@ -59,13 +59,13 @@ class CarnivalSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return 0; }
 

--- a/src/games/supported/Casino.cpp
+++ b/src/games/supported/Casino.cpp
@@ -29,6 +29,7 @@
 #include "common/Constants.h"
 
 namespace ale {
+using namespace stella;
 
 CasinoSettings::CasinoSettings() { reset(); }
 

--- a/src/games/supported/Casino.hpp
+++ b/src/games/supported/Casino.hpp
@@ -49,15 +49,15 @@ class CasinoSettings : public RomSettings {
 
   bool isMinimal(const Action& a) const override;
 
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   ModeVect getAvailableModes() override;
 
-  void setMode(game_mode_t m, System& system,
+  void setMode(game_mode_t m, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
   DifficultyVect getAvailableDifficulties() override;

--- a/src/games/supported/Centipede.cpp
+++ b/src/games/supported/Centipede.cpp
@@ -30,6 +30,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 CentipedeSettings::CentipedeSettings() { reset(); }
 

--- a/src/games/supported/Centipede.hpp
+++ b/src/games/supported/Centipede.hpp
@@ -62,13 +62,13 @@ class CentipedeSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return isTerminal() ? 0 : m_lives; }
 
@@ -78,7 +78,7 @@ class CentipedeSettings : public RomSettings {
 
   // set the mode of the game
   // the given mode must be one returned by the previous function
-  void setMode(game_mode_t, System& system,
+  void setMode(game_mode_t, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
  private:

--- a/src/games/supported/ChopperCommand.cpp
+++ b/src/games/supported/ChopperCommand.cpp
@@ -30,6 +30,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 ChopperCommandSettings::ChopperCommandSettings() { reset(); }
 

--- a/src/games/supported/ChopperCommand.hpp
+++ b/src/games/supported/ChopperCommand.hpp
@@ -62,13 +62,13 @@ class ChopperCommandSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return m_lives; }
 
@@ -78,7 +78,7 @@ class ChopperCommandSettings : public RomSettings {
 
   // set the mode of the game
   // the given mode must be one returned by the previous function
-  void setMode(game_mode_t, System& system,
+  void setMode(game_mode_t, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
   // returns a list of difficulties that the game can be played in

--- a/src/games/supported/CrazyClimber.cpp
+++ b/src/games/supported/CrazyClimber.cpp
@@ -30,6 +30,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 CrazyClimberSettings::CrazyClimberSettings() { reset(); }
 

--- a/src/games/supported/CrazyClimber.hpp
+++ b/src/games/supported/CrazyClimber.hpp
@@ -62,13 +62,13 @@ class CrazyClimberSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return isTerminal() ? 0 : m_lives; }
 
@@ -78,7 +78,7 @@ class CrazyClimberSettings : public RomSettings {
 
   // set the mode of the game
   // the given mode must be one returned by the previous function
-  void setMode(game_mode_t, System& system,
+  void setMode(game_mode_t, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
   // returns a list of difficulties that the game can be played in

--- a/src/games/supported/Crossbow.cpp
+++ b/src/games/supported/Crossbow.cpp
@@ -28,6 +28,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 CrossbowSettings::CrossbowSettings() { reset(); }
 

--- a/src/games/supported/Crossbow.hpp
+++ b/src/games/supported/Crossbow.hpp
@@ -49,15 +49,15 @@ class CrossbowSettings : public RomSettings {
 
   bool isMinimal(const Action& a) const override;
 
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   ModeVect getAvailableModes() override;
 
-  void setMode(game_mode_t m, System& system,
+  void setMode(game_mode_t m, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
   DifficultyVect getAvailableDifficulties() override;

--- a/src/games/supported/DarkChambers.cpp
+++ b/src/games/supported/DarkChambers.cpp
@@ -28,6 +28,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 DarkChambersSettings::DarkChambersSettings() { reset(); }
 

--- a/src/games/supported/DarkChambers.hpp
+++ b/src/games/supported/DarkChambers.hpp
@@ -50,11 +50,11 @@ public:
 
   bool isMinimal(const Action& a) const override;
 
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   ModeVect getAvailableModes() override;
 

--- a/src/games/supported/Defender.cpp
+++ b/src/games/supported/Defender.cpp
@@ -30,6 +30,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 DefenderSettings::DefenderSettings() { reset(); }
 

--- a/src/games/supported/Defender.hpp
+++ b/src/games/supported/Defender.hpp
@@ -62,13 +62,13 @@ class DefenderSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return isTerminal() ? 0 : m_lives; }
 
@@ -78,7 +78,7 @@ class DefenderSettings : public RomSettings {
 
   // set the mode of the game
   // the given mode must be one returned by the previous function
-  void setMode(game_mode_t, System& system,
+  void setMode(game_mode_t, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
   // returns a list of difficulties that the game can be played in

--- a/src/games/supported/DemonAttack.cpp
+++ b/src/games/supported/DemonAttack.cpp
@@ -30,6 +30,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 DemonAttackSettings::DemonAttackSettings() { reset(); }
 

--- a/src/games/supported/DemonAttack.hpp
+++ b/src/games/supported/DemonAttack.hpp
@@ -62,13 +62,13 @@ class DemonAttackSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return isTerminal() ? 0 : m_lives; }
 
@@ -78,7 +78,7 @@ class DemonAttackSettings : public RomSettings {
 
   // set the mode of the game
   // the given mode must be one returned by the previous function
-  void setMode(game_mode_t, System& system,
+  void setMode(game_mode_t, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
   // returns a list of difficulties that the game can be played in

--- a/src/games/supported/DonkeyKong.cpp
+++ b/src/games/supported/DonkeyKong.cpp
@@ -15,6 +15,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 DonkeyKongSettings::DonkeyKongSettings() { reset(); }
 

--- a/src/games/supported/DonkeyKong.hpp
+++ b/src/games/supported/DonkeyKong.hpp
@@ -45,13 +45,13 @@ class DonkeyKongSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return isTerminal() ? 0 : m_lives; }
 

--- a/src/games/supported/DoubleDunk.cpp
+++ b/src/games/supported/DoubleDunk.cpp
@@ -15,6 +15,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 DoubleDunkSettings::DoubleDunkSettings() { reset(); }
 

--- a/src/games/supported/DoubleDunk.hpp
+++ b/src/games/supported/DoubleDunk.hpp
@@ -62,13 +62,13 @@ class DoubleDunkSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   ActionVect getStartingActions() override;
 
@@ -80,7 +80,7 @@ class DoubleDunkSettings : public RomSettings {
 
   // set the mode of the game
   // the given mode must be one returned by the previous function
-  void setMode(game_mode_t, System& system,
+  void setMode(game_mode_t, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
  private:
@@ -90,17 +90,17 @@ class DoubleDunkSettings : public RomSettings {
 
   // this game has a menu that allows to define various yes/no options
   // this function goes to the next option in the menu
-  void goDown(System& system,
+  void goDown(stella::System& system,
               std::unique_ptr<StellaEnvironmentWrapper>& environment);
 
   // once we are at the proper option in the menu,
   // if we want to enable it all we have to do is to go right
-  void activateOption(System& system, unsigned int bitOfInterest,
+  void activateOption(stella::System& system, unsigned int bitOfInterest,
                       std::unique_ptr<StellaEnvironmentWrapper>& environment);
 
   // once we are at the proper optio in the menu,
   // if we want to disable it all we have to do is to go left
-  void deactivateOption(System& system, unsigned int bitOfInterest,
+  void deactivateOption(stella::System& system, unsigned int bitOfInterest,
                         std::unique_ptr<StellaEnvironmentWrapper>& environment);
 };
 

--- a/src/games/supported/Earthworld.cpp
+++ b/src/games/supported/Earthworld.cpp
@@ -28,6 +28,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 EarthworldSettings::EarthworldSettings() { reset(); }
 

--- a/src/games/supported/Earthworld.hpp
+++ b/src/games/supported/Earthworld.hpp
@@ -49,11 +49,11 @@ class EarthworldSettings : public RomSettings {
 
   bool isMinimal(const Action& a) const override;
 
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
  private:
   bool m_terminal;

--- a/src/games/supported/ElevatorAction.cpp
+++ b/src/games/supported/ElevatorAction.cpp
@@ -30,6 +30,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 ElevatorActionSettings::ElevatorActionSettings() { reset(); }
 

--- a/src/games/supported/ElevatorAction.hpp
+++ b/src/games/supported/ElevatorAction.hpp
@@ -59,13 +59,13 @@ class ElevatorActionSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   ActionVect getStartingActions() override;
 

--- a/src/games/supported/Enduro.cpp
+++ b/src/games/supported/Enduro.cpp
@@ -17,6 +17,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 EnduroSettings::EnduroSettings() { reset(); }
 

--- a/src/games/supported/Enduro.hpp
+++ b/src/games/supported/Enduro.hpp
@@ -59,13 +59,13 @@ class EnduroSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   ActionVect getStartingActions() override;
 

--- a/src/games/supported/Entombed.cpp
+++ b/src/games/supported/Entombed.cpp
@@ -28,6 +28,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 EntombedSettings::EntombedSettings() { reset(); }
 

--- a/src/games/supported/Entombed.hpp
+++ b/src/games/supported/Entombed.hpp
@@ -49,11 +49,11 @@ class EntombedSettings : public RomSettings {
 
   bool isMinimal(const Action& a) const override;
 
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   DifficultyVect getAvailableDifficulties() override;
 

--- a/src/games/supported/Et.cpp
+++ b/src/games/supported/Et.cpp
@@ -28,6 +28,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 EtSettings::EtSettings() { reset(); }
 

--- a/src/games/supported/Et.hpp
+++ b/src/games/supported/Et.hpp
@@ -49,17 +49,17 @@ class EtSettings : public RomSettings {
 
   bool isMinimal(const Action& a) const override;
 
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   int lives() override { return isTerminal() ? 0 : m_lives; }
 
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   ModeVect getAvailableModes() override;
 
-  void setMode(game_mode_t m, System& system,
+  void setMode(game_mode_t m, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
   DifficultyVect getAvailableDifficulties() override;

--- a/src/games/supported/FishingDerby.cpp
+++ b/src/games/supported/FishingDerby.cpp
@@ -17,6 +17,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 FishingDerbySettings::FishingDerbySettings() { reset(); }
 

--- a/src/games/supported/FishingDerby.hpp
+++ b/src/games/supported/FishingDerby.hpp
@@ -59,13 +59,13 @@ class FishingDerbySettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return 0; }
 

--- a/src/games/supported/FlagCapture.cpp
+++ b/src/games/supported/FlagCapture.cpp
@@ -28,6 +28,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 FlagCaptureSettings::FlagCaptureSettings() { reset(); }
 

--- a/src/games/supported/FlagCapture.hpp
+++ b/src/games/supported/FlagCapture.hpp
@@ -49,15 +49,15 @@ class FlagCaptureSettings : public RomSettings {
 
   bool isMinimal(const Action& a) const override;
 
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   ModeVect getAvailableModes() override;
 
-  void setMode(game_mode_t m, System& system,
+  void setMode(game_mode_t m, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
  private:

--- a/src/games/supported/Freeway.cpp
+++ b/src/games/supported/Freeway.cpp
@@ -17,6 +17,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 FreewaySettings::FreewaySettings() {
   m_reward = 0;

--- a/src/games/supported/Freeway.hpp
+++ b/src/games/supported/Freeway.hpp
@@ -63,13 +63,13 @@ class FreewaySettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return 0; }
 
@@ -79,7 +79,7 @@ class FreewaySettings : public RomSettings {
 
   // set the mode of the game
   // the given mode must be one returned by the previous function
-  void setMode(game_mode_t, System& system,
+  void setMode(game_mode_t, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
   // returns a list of difficulties that the game can be played in

--- a/src/games/supported/Frogger.cpp
+++ b/src/games/supported/Frogger.cpp
@@ -15,6 +15,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 FroggerSettings::FroggerSettings() { reset(); }
 

--- a/src/games/supported/Frogger.hpp
+++ b/src/games/supported/Frogger.hpp
@@ -45,19 +45,19 @@ class FroggerSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return isTerminal() ? 0 : m_lives; }
 
   ModeVect getAvailableModes() override;
 
-  void setMode(game_mode_t m, System& system,
+  void setMode(game_mode_t m, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
   DifficultyVect getAvailableDifficulties() override;

--- a/src/games/supported/Frostbite.cpp
+++ b/src/games/supported/Frostbite.cpp
@@ -30,6 +30,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 FrostbiteSettings::FrostbiteSettings() { reset(); }
 

--- a/src/games/supported/Frostbite.hpp
+++ b/src/games/supported/Frostbite.hpp
@@ -62,13 +62,13 @@ class FrostbiteSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return isTerminal() ? 0 : m_lives; }
 
@@ -78,7 +78,7 @@ class FrostbiteSettings : public RomSettings {
 
   // set the mode of the game
   // the given mode must be one returned by the previous function
-  void setMode(game_mode_t, System& system,
+  void setMode(game_mode_t, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
  private:

--- a/src/games/supported/Galaxian.cpp
+++ b/src/games/supported/Galaxian.cpp
@@ -29,6 +29,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 ActionVect GalaxianSettings::actions;
 

--- a/src/games/supported/Galaxian.hpp
+++ b/src/games/supported/Galaxian.hpp
@@ -58,13 +58,13 @@ class GalaxianSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return isTerminal() ? 0 : m_lives; }
 
@@ -76,7 +76,7 @@ class GalaxianSettings : public RomSettings {
 
   // set the mode of the game
   // the given mode must be one returned by the previous function
-  void setMode(game_mode_t mode, System& system,
+  void setMode(game_mode_t mode, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
   // Returns a list of difficulties that the game can be played in.

--- a/src/games/supported/Gopher.cpp
+++ b/src/games/supported/Gopher.cpp
@@ -30,6 +30,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 GopherSettings::GopherSettings() { reset(); }
 

--- a/src/games/supported/Gopher.hpp
+++ b/src/games/supported/Gopher.hpp
@@ -62,13 +62,13 @@ class GopherSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   // Gopher requires the fire action to start the game
   ActionVect getStartingActions() override;
@@ -81,7 +81,7 @@ class GopherSettings : public RomSettings {
 
   // set the mode of the game
   // the given mode must be one returned by the previous function
-  void setMode(game_mode_t, System& system,
+  void setMode(game_mode_t, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
   // returns a list of difficulties that the game can be played in

--- a/src/games/supported/Gravitar.cpp
+++ b/src/games/supported/Gravitar.cpp
@@ -30,6 +30,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 GravitarSettings::GravitarSettings() { reset(); }
 

--- a/src/games/supported/Gravitar.hpp
+++ b/src/games/supported/Gravitar.hpp
@@ -62,13 +62,13 @@ class GravitarSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   // Gravitar requires the fire action to start the game
   ActionVect getStartingActions() override;
@@ -81,7 +81,7 @@ class GravitarSettings : public RomSettings {
 
   // set the mode of the game
   // the given mode must be one returned by the previous function
-  void setMode(game_mode_t, System& system,
+  void setMode(game_mode_t, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
  private:

--- a/src/games/supported/Hangman.cpp
+++ b/src/games/supported/Hangman.cpp
@@ -28,6 +28,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 HangmanSettings::HangmanSettings() { reset(); }
 

--- a/src/games/supported/Hangman.hpp
+++ b/src/games/supported/Hangman.hpp
@@ -58,17 +58,17 @@ class HangmanSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   ModeVect getAvailableModes() override;
 
-  void setMode(game_mode_t m, System& system,
+  void setMode(game_mode_t m, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
   // returns a list of difficulties that the game can be played in

--- a/src/games/supported/HauntedHouse.cpp
+++ b/src/games/supported/HauntedHouse.cpp
@@ -28,6 +28,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 HauntedHouseSettings::HauntedHouseSettings() { reset(); }
 

--- a/src/games/supported/HauntedHouse.hpp
+++ b/src/games/supported/HauntedHouse.hpp
@@ -49,17 +49,17 @@ class HauntedHouseSettings : public RomSettings {
 
   bool isMinimal(const Action& a) const override;
 
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return isTerminal() ? 0 : m_lives; }
 
   ModeVect getAvailableModes() override;
 
-  void setMode(game_mode_t m, System& system,
+  void setMode(game_mode_t m, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
   DifficultyVect getAvailableDifficulties() override;

--- a/src/games/supported/Hero.cpp
+++ b/src/games/supported/Hero.cpp
@@ -30,6 +30,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 HeroSettings::HeroSettings() { reset(); }
 

--- a/src/games/supported/Hero.hpp
+++ b/src/games/supported/Hero.hpp
@@ -62,13 +62,13 @@ class HeroSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return isTerminal() ? 0 : m_lives; }
 
@@ -78,7 +78,7 @@ class HeroSettings : public RomSettings {
 
   // set the mode of the game
   // the given mode must be one returned by the previous function
-  void setMode(game_mode_t, System& system,
+  void setMode(game_mode_t, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
  private:

--- a/src/games/supported/HumanCannonball.cpp
+++ b/src/games/supported/HumanCannonball.cpp
@@ -28,6 +28,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 HumanCannonballSettings::HumanCannonballSettings() { reset(); }
 

--- a/src/games/supported/HumanCannonball.hpp
+++ b/src/games/supported/HumanCannonball.hpp
@@ -49,15 +49,15 @@ class HumanCannonballSettings : public RomSettings {
 
   bool isMinimal(const Action& a) const override;
 
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   ModeVect getAvailableModes() override;
 
-  void setMode(game_mode_t m, System& system,
+  void setMode(game_mode_t m, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
   DifficultyVect getAvailableDifficulties() override;

--- a/src/games/supported/IceHockey.cpp
+++ b/src/games/supported/IceHockey.cpp
@@ -17,6 +17,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 IceHockeySettings::IceHockeySettings() { reset(); }
 

--- a/src/games/supported/IceHockey.hpp
+++ b/src/games/supported/IceHockey.hpp
@@ -62,13 +62,13 @@ class IceHockeySettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return 0; }
 
@@ -78,7 +78,7 @@ class IceHockeySettings : public RomSettings {
 
   // set the mode of the game
   // the given mode must be one returned by the previous function
-  void setMode(game_mode_t, System& system,
+  void setMode(game_mode_t, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
   // returns a list of difficulties that the game can be played in

--- a/src/games/supported/JamesBond.cpp
+++ b/src/games/supported/JamesBond.cpp
@@ -30,6 +30,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 JamesBondSettings::JamesBondSettings() { reset(); }
 

--- a/src/games/supported/JamesBond.hpp
+++ b/src/games/supported/JamesBond.hpp
@@ -62,13 +62,13 @@ class JamesBondSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return isTerminal() ? 0 : m_lives; }
 
@@ -78,7 +78,7 @@ class JamesBondSettings : public RomSettings {
 
   // set the mode of the game
   // the given mode must be one returned by the previous function
-  void setMode(game_mode_t, System& system,
+  void setMode(game_mode_t, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
  private:

--- a/src/games/supported/JourneyEscape.cpp
+++ b/src/games/supported/JourneyEscape.cpp
@@ -17,6 +17,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 JourneyEscapeSettings::JourneyEscapeSettings() { reset(); }
 

--- a/src/games/supported/JourneyEscape.hpp
+++ b/src/games/supported/JourneyEscape.hpp
@@ -59,13 +59,13 @@ class JourneyEscapeSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   // Journey Escape requires the fire action to start the game
   ActionVect getStartingActions() override;

--- a/src/games/supported/Kaboom.cpp
+++ b/src/games/supported/Kaboom.cpp
@@ -17,6 +17,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 KaboomSettings::KaboomSettings() { reset(); }
 

--- a/src/games/supported/Kaboom.hpp
+++ b/src/games/supported/Kaboom.hpp
@@ -44,13 +44,13 @@ class KaboomSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   ActionVect getStartingActions() override;
 

--- a/src/games/supported/Kangaroo.cpp
+++ b/src/games/supported/Kangaroo.cpp
@@ -30,6 +30,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 KangarooSettings::KangarooSettings() { reset(); }
 

--- a/src/games/supported/Kangaroo.hpp
+++ b/src/games/supported/Kangaroo.hpp
@@ -62,13 +62,13 @@ class KangarooSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return isTerminal() ? 0 : m_lives; }
 
@@ -78,7 +78,7 @@ class KangarooSettings : public RomSettings {
 
   // set the mode of the game
   // the given mode must be one returned by the previous function
-  void setMode(game_mode_t, System& system,
+  void setMode(game_mode_t, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
  private:

--- a/src/games/supported/KeystoneKapers.cpp
+++ b/src/games/supported/KeystoneKapers.cpp
@@ -15,6 +15,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 KeystoneKapersSettings::KeystoneKapersSettings() { reset(); }
 

--- a/src/games/supported/KeystoneKapers.hpp
+++ b/src/games/supported/KeystoneKapers.hpp
@@ -45,13 +45,13 @@ class KeystoneKapersSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   // Keystone Kapers requires the reset button to start the game
   ActionVect getStartingActions() override;

--- a/src/games/supported/Kingkong.cpp
+++ b/src/games/supported/Kingkong.cpp
@@ -30,6 +30,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 KingkongSettings::KingkongSettings() { reset(); }
 

--- a/src/games/supported/Kingkong.hpp
+++ b/src/games/supported/Kingkong.hpp
@@ -59,19 +59,19 @@ class KingkongSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return isTerminal() ? 0 : m_lives; }
 
   ModeVect getAvailableModes() override;
 
-  void setMode(game_mode_t m, System& system,
+  void setMode(game_mode_t m, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
  private:

--- a/src/games/supported/Klax.cpp
+++ b/src/games/supported/Klax.cpp
@@ -29,6 +29,7 @@
 #include "common/Constants.h"
 
 namespace ale {
+using namespace stella;
 
 KlaxSettings::KlaxSettings() { reset(); }
 

--- a/src/games/supported/Klax.hpp
+++ b/src/games/supported/Klax.hpp
@@ -49,15 +49,15 @@ class KlaxSettings : public RomSettings {
 
   bool isMinimal(const Action& a) const override;
 
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   ModeVect getAvailableModes() override;
 
-  void setMode(game_mode_t m, System& system,
+  void setMode(game_mode_t m, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
   ActionVect getStartingActions();
@@ -68,7 +68,7 @@ class KlaxSettings : public RomSettings {
   int m_score;
 
   int getKlaxScore(int lower_index, int middle_index, int higher_index,
-                   const System* system);
+                   const stella::System* system);
 };
 
 }  // namespace ale

--- a/src/games/supported/Koolaid.cpp
+++ b/src/games/supported/Koolaid.cpp
@@ -15,6 +15,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 KoolaidSettings::KoolaidSettings() { reset(); }
 

--- a/src/games/supported/Koolaid.hpp
+++ b/src/games/supported/Koolaid.hpp
@@ -44,13 +44,13 @@ class KoolaidSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return 0; }
 

--- a/src/games/supported/Krull.cpp
+++ b/src/games/supported/Krull.cpp
@@ -30,6 +30,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 KrullSettings::KrullSettings() { reset(); }
 

--- a/src/games/supported/Krull.hpp
+++ b/src/games/supported/Krull.hpp
@@ -59,13 +59,13 @@ class KrullSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return isTerminal() ? 0 : m_lives; }
 

--- a/src/games/supported/KungFuMaster.cpp
+++ b/src/games/supported/KungFuMaster.cpp
@@ -30,6 +30,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 KungFuMasterSettings::KungFuMasterSettings() { reset(); }
 

--- a/src/games/supported/KungFuMaster.hpp
+++ b/src/games/supported/KungFuMaster.hpp
@@ -59,13 +59,13 @@ class KungFuMasterSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return isTerminal() ? 0 : m_lives; }
 

--- a/src/games/supported/LaserGates.cpp
+++ b/src/games/supported/LaserGates.cpp
@@ -15,6 +15,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 LaserGatesSettings::LaserGatesSettings() { reset(); }
 

--- a/src/games/supported/LaserGates.hpp
+++ b/src/games/supported/LaserGates.hpp
@@ -45,13 +45,13 @@ class LaserGatesSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   // LaserGates requires the fire action to start the game
   ActionVect getStartingActions() override;

--- a/src/games/supported/LostLuggage.cpp
+++ b/src/games/supported/LostLuggage.cpp
@@ -15,6 +15,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 LostLuggageSettings::LostLuggageSettings() { reset(); }
 

--- a/src/games/supported/LostLuggage.hpp
+++ b/src/games/supported/LostLuggage.hpp
@@ -48,13 +48,13 @@ class LostLuggageSettings : public RomSettings {
   bool isLegal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   // LostLuggage requires the fire action to start the game
   ActionVect getStartingActions() override;
@@ -63,7 +63,7 @@ class LostLuggageSettings : public RomSettings {
 
   ModeVect getAvailableModes() override;
 
-  void setMode(game_mode_t m, System& system,
+  void setMode(game_mode_t m, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
   DifficultyVect getAvailableDifficulties() override;

--- a/src/games/supported/MarioBros.cpp
+++ b/src/games/supported/MarioBros.cpp
@@ -28,6 +28,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 MarioBrosSettings::MarioBrosSettings() { reset(); }
 

--- a/src/games/supported/MarioBros.hpp
+++ b/src/games/supported/MarioBros.hpp
@@ -51,15 +51,15 @@ class MarioBrosSettings : public RomSettings {
 
   int lives() override { return isTerminal() ? 0 : m_lives; }
 
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   ModeVect getAvailableModes() override;
 
-  void setMode(game_mode_t m, System& system,
+  void setMode(game_mode_t m, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
   ActionVect getStartingActions() override;

--- a/src/games/supported/MiniatureGolf.cpp
+++ b/src/games/supported/MiniatureGolf.cpp
@@ -28,6 +28,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 MiniatureGolfSettings::MiniatureGolfSettings() { reset(); }
 

--- a/src/games/supported/MiniatureGolf.hpp
+++ b/src/games/supported/MiniatureGolf.hpp
@@ -49,11 +49,11 @@ class MiniatureGolfSettings final : public RomSettings {
 
   bool isMinimal(const Action& a) const override;
 
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   DifficultyVect getAvailableDifficulties() override;
 

--- a/src/games/supported/MontezumaRevenge.cpp
+++ b/src/games/supported/MontezumaRevenge.cpp
@@ -30,6 +30,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 MontezumaRevengeSettings::MontezumaRevengeSettings() { reset(); }
 

--- a/src/games/supported/MontezumaRevenge.hpp
+++ b/src/games/supported/MontezumaRevenge.hpp
@@ -59,13 +59,13 @@ class MontezumaRevengeSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return isTerminal() ? 0 : m_lives; }
 

--- a/src/games/supported/MrDo.cpp
+++ b/src/games/supported/MrDo.cpp
@@ -15,6 +15,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 MrDoSettings::MrDoSettings() { reset(); }
 

--- a/src/games/supported/MrDo.hpp
+++ b/src/games/supported/MrDo.hpp
@@ -44,13 +44,13 @@ class MrDoSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   // Mr. Do requires the fire action to start the game
   ActionVect getStartingActions() override;
@@ -59,7 +59,7 @@ class MrDoSettings : public RomSettings {
 
   ModeVect getAvailableModes() override;
 
-  void setMode(game_mode_t m, System& system,
+  void setMode(game_mode_t m, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
  private:

--- a/src/games/supported/MsPacman.cpp
+++ b/src/games/supported/MsPacman.cpp
@@ -30,6 +30,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 MsPacmanSettings::MsPacmanSettings() { reset(); }
 

--- a/src/games/supported/MsPacman.hpp
+++ b/src/games/supported/MsPacman.hpp
@@ -62,13 +62,13 @@ class MsPacmanSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return isTerminal() ? 0 : m_lives; }
 
@@ -78,7 +78,7 @@ class MsPacmanSettings : public RomSettings {
 
   // set the mode of the game
   // the given mode must be one returned by the previous function
-  void setMode(game_mode_t, System& system,
+  void setMode(game_mode_t, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
  private:

--- a/src/games/supported/NameThisGame.cpp
+++ b/src/games/supported/NameThisGame.cpp
@@ -30,6 +30,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 NameThisGameSettings::NameThisGameSettings() { reset(); }
 

--- a/src/games/supported/NameThisGame.hpp
+++ b/src/games/supported/NameThisGame.hpp
@@ -62,13 +62,13 @@ class NameThisGameSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return isTerminal() ? 0 : m_lives; }
 
@@ -78,7 +78,7 @@ class NameThisGameSettings : public RomSettings {
 
   // set the mode of the game
   // the given mode must be one returned by the previous function
-  void setMode(game_mode_t, System& system,
+  void setMode(game_mode_t, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
   // returns a list of difficulties that the game can be played in

--- a/src/games/supported/Othello.cpp
+++ b/src/games/supported/Othello.cpp
@@ -28,6 +28,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 OthelloSettings::OthelloSettings() { reset(); }
 

--- a/src/games/supported/Othello.hpp
+++ b/src/games/supported/Othello.hpp
@@ -49,15 +49,15 @@ class OthelloSettings : public RomSettings {
 
   virtual bool isMinimal(const Action& a) const;
 
-  virtual void step(const System& system);
+  virtual void step(const stella::System& system);
 
-  virtual void saveState(Serializer& ser);
+  virtual void saveState(stella::Serializer& ser);
 
-  virtual void loadState(Deserializer& ser);
+  virtual void loadState(stella::Deserializer& ser);
 
   virtual ModeVect getAvailableModes();
 
-  virtual void setMode(game_mode_t m, System& system,
+  virtual void setMode(game_mode_t m, stella::System& system,
                        std::unique_ptr<StellaEnvironmentWrapper> environment);
 
   virtual DifficultyVect getAvailableDifficulties();

--- a/src/games/supported/Pacman.cpp
+++ b/src/games/supported/Pacman.cpp
@@ -34,6 +34,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 PacmanSettings::PacmanSettings() { reset(); }
 

--- a/src/games/supported/Pacman.hpp
+++ b/src/games/supported/Pacman.hpp
@@ -65,13 +65,13 @@ class PacmanSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return isTerminal() ? 0 : m_lives; }
 
@@ -79,7 +79,7 @@ class PacmanSettings : public RomSettings {
 
   ModeVect getAvailableModes() override;
 
-  void setMode(game_mode_t m, System& system,
+  void setMode(game_mode_t m, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
  private:

--- a/src/games/supported/Phoenix.cpp
+++ b/src/games/supported/Phoenix.cpp
@@ -30,6 +30,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 PhoenixSettings::PhoenixSettings() { reset(); }
 

--- a/src/games/supported/Phoenix.hpp
+++ b/src/games/supported/Phoenix.hpp
@@ -59,13 +59,13 @@ class PhoenixSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return isTerminal() ? 0 : m_lives; }
 

--- a/src/games/supported/Pitfall.cpp
+++ b/src/games/supported/Pitfall.cpp
@@ -30,6 +30,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 PitfallSettings::PitfallSettings() { reset(); }
 

--- a/src/games/supported/Pitfall.hpp
+++ b/src/games/supported/Pitfall.hpp
@@ -59,13 +59,13 @@ class PitfallSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   ActionVect getStartingActions() override;
 

--- a/src/games/supported/Pitfall2.cpp
+++ b/src/games/supported/Pitfall2.cpp
@@ -28,6 +28,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 Pitfall2Settings::Pitfall2Settings() { reset(); }
 

--- a/src/games/supported/Pitfall2.hpp
+++ b/src/games/supported/Pitfall2.hpp
@@ -57,13 +57,13 @@ class Pitfall2Settings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   ActionVect getStartingActions() override;
 

--- a/src/games/supported/Pong.cpp
+++ b/src/games/supported/Pong.cpp
@@ -15,6 +15,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 PongSettings::PongSettings() { reset(); }
 

--- a/src/games/supported/Pong.hpp
+++ b/src/games/supported/Pong.hpp
@@ -62,13 +62,13 @@ class PongSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return 0; }
 
@@ -82,7 +82,7 @@ class PongSettings : public RomSettings {
 
   // set the mode of the game
   // the given mode must be one returned by the previous function
-  void setMode(game_mode_t, System& system,
+  void setMode(game_mode_t, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
  private:

--- a/src/games/supported/Pooyan.cpp
+++ b/src/games/supported/Pooyan.cpp
@@ -30,6 +30,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 PooyanSettings::PooyanSettings() { reset(); }
 

--- a/src/games/supported/Pooyan.hpp
+++ b/src/games/supported/Pooyan.hpp
@@ -62,13 +62,13 @@ class PooyanSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return isTerminal() ? 0 : m_lives; }
 
@@ -78,7 +78,7 @@ class PooyanSettings : public RomSettings {
 
   // set the mode of the game
   // the given mode must be one returned by the previous function
-  void setMode(game_mode_t, System& system,
+  void setMode(game_mode_t, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
  private:

--- a/src/games/supported/PrivateEye.cpp
+++ b/src/games/supported/PrivateEye.cpp
@@ -15,6 +15,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 PrivateEyeSettings::PrivateEyeSettings() { reset(); }
 

--- a/src/games/supported/PrivateEye.hpp
+++ b/src/games/supported/PrivateEye.hpp
@@ -62,13 +62,13 @@ class PrivateEyeSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   ActionVect getStartingActions() override;
 
@@ -80,7 +80,7 @@ class PrivateEyeSettings : public RomSettings {
 
   // set the mode of the game
   // the given mode must be one returned by the previous function
-  void setMode(game_mode_t, System& system,
+  void setMode(game_mode_t, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
   // returns a list of difficulties that the game can be played in

--- a/src/games/supported/QBert.cpp
+++ b/src/games/supported/QBert.cpp
@@ -30,6 +30,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 QBertSettings::QBertSettings() { reset(); }
 

--- a/src/games/supported/QBert.hpp
+++ b/src/games/supported/QBert.hpp
@@ -59,13 +59,13 @@ class QBertSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return isTerminal() ? 0 : m_lives; }
 

--- a/src/games/supported/RiverRaid.cpp
+++ b/src/games/supported/RiverRaid.cpp
@@ -30,6 +30,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 RiverRaidSettings::RiverRaidSettings() {
   m_ram_vals_to_digits[0] = 0;

--- a/src/games/supported/RiverRaid.hpp
+++ b/src/games/supported/RiverRaid.hpp
@@ -61,13 +61,13 @@ class RiverRaidSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return isTerminal() ? 0 : numericLives(); }
 

--- a/src/games/supported/RoadRunner.cpp
+++ b/src/games/supported/RoadRunner.cpp
@@ -30,6 +30,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 RoadRunnerSettings::RoadRunnerSettings() { reset(); }
 

--- a/src/games/supported/RoadRunner.hpp
+++ b/src/games/supported/RoadRunner.hpp
@@ -59,13 +59,13 @@ class RoadRunnerSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return isTerminal() ? 0 : m_lives; }
 

--- a/src/games/supported/RoboTank.cpp
+++ b/src/games/supported/RoboTank.cpp
@@ -30,6 +30,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 RoboTankSettings::RoboTankSettings() { reset(); }
 

--- a/src/games/supported/RoboTank.hpp
+++ b/src/games/supported/RoboTank.hpp
@@ -59,13 +59,13 @@ class RoboTankSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return isTerminal() ? 0 : m_lives; }
 

--- a/src/games/supported/Seaquest.cpp
+++ b/src/games/supported/Seaquest.cpp
@@ -30,6 +30,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 SeaquestSettings::SeaquestSettings() { reset(); }
 

--- a/src/games/supported/Seaquest.hpp
+++ b/src/games/supported/Seaquest.hpp
@@ -59,13 +59,13 @@ class SeaquestSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return isTerminal() ? 0 : m_lives; }
 

--- a/src/games/supported/SirLancelot.cpp
+++ b/src/games/supported/SirLancelot.cpp
@@ -15,6 +15,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 SirLancelotSettings::SirLancelotSettings() { reset(); }
 

--- a/src/games/supported/SirLancelot.hpp
+++ b/src/games/supported/SirLancelot.hpp
@@ -45,13 +45,13 @@ class SirLancelotSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   // SirLancelot requires the reset+left action to start the game
   ActionVect getStartingActions() override;

--- a/src/games/supported/Skiing.cpp
+++ b/src/games/supported/Skiing.cpp
@@ -15,6 +15,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 SkiingSettings::SkiingSettings() { reset(); }
 

--- a/src/games/supported/Skiing.hpp
+++ b/src/games/supported/Skiing.hpp
@@ -61,13 +61,13 @@ class SkiingSettings : public RomSettings {
   bool isLegal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   ActionVect getStartingActions() override;
 

--- a/src/games/supported/Solaris.cpp
+++ b/src/games/supported/Solaris.cpp
@@ -30,6 +30,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 SolarisSettings::SolarisSettings() { reset(); }
 

--- a/src/games/supported/Solaris.hpp
+++ b/src/games/supported/Solaris.hpp
@@ -59,13 +59,13 @@ class SolarisSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return isTerminal() ? 0 : m_lives; }
 

--- a/src/games/supported/SpaceInvaders.cpp
+++ b/src/games/supported/SpaceInvaders.cpp
@@ -30,6 +30,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 ActionVect SpaceInvadersSettings::actions;
 

--- a/src/games/supported/SpaceInvaders.hpp
+++ b/src/games/supported/SpaceInvaders.hpp
@@ -62,13 +62,13 @@ class SpaceInvadersSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return isTerminal() ? 0 : m_lives; }
 
@@ -78,7 +78,7 @@ class SpaceInvadersSettings : public RomSettings {
 
   // set the mode of the game
   // the given mode must be one returned by the previous function
-  void setMode(game_mode_t, System& system,
+  void setMode(game_mode_t, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
   // returns a list of difficulties that the game can be played in

--- a/src/games/supported/SpaceWar.cpp
+++ b/src/games/supported/SpaceWar.cpp
@@ -28,6 +28,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 SpaceWarSettings::SpaceWarSettings() { reset(); }
 

--- a/src/games/supported/SpaceWar.hpp
+++ b/src/games/supported/SpaceWar.hpp
@@ -49,15 +49,15 @@ class SpaceWarSettings : public RomSettings {
 
   bool isMinimal(const Action& a) const override;
 
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   ModeVect getAvailableModes() override;
 
-  void setMode(game_mode_t m, System& system,
+  void setMode(game_mode_t m, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
  private:

--- a/src/games/supported/StarGunner.cpp
+++ b/src/games/supported/StarGunner.cpp
@@ -30,6 +30,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 StarGunnerSettings::StarGunnerSettings() { reset(); }
 

--- a/src/games/supported/StarGunner.hpp
+++ b/src/games/supported/StarGunner.hpp
@@ -62,13 +62,13 @@ class StarGunnerSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return isTerminal() ? 0 : m_lives; }
 
@@ -78,7 +78,7 @@ class StarGunnerSettings : public RomSettings {
 
   // set the mode of the game
   // the given mode must be one returned by the previous function
-  void setMode(game_mode_t, System& system,
+  void setMode(game_mode_t, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
  private:

--- a/src/games/supported/Superman.cpp
+++ b/src/games/supported/Superman.cpp
@@ -28,6 +28,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 SupermanSettings::SupermanSettings() { reset(); }
 

--- a/src/games/supported/Superman.hpp
+++ b/src/games/supported/Superman.hpp
@@ -49,11 +49,11 @@ class SupermanSettings : public RomSettings {
 
   bool isMinimal(const Action& a) const override;
 
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   DifficultyVect getAvailableDifficulties() override;
 

--- a/src/games/supported/Surround.cpp
+++ b/src/games/supported/Surround.cpp
@@ -31,6 +31,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 SurroundSettings::SurroundSettings() { reset(); }
 

--- a/src/games/supported/Surround.hpp
+++ b/src/games/supported/Surround.hpp
@@ -61,17 +61,17 @@ class SurroundSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   ModeVect getAvailableModes() override;
 
-  void setMode(game_mode_t m, System& system,
+  void setMode(game_mode_t m, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
   DifficultyVect getAvailableDifficulties() override;

--- a/src/games/supported/Tennis.cpp
+++ b/src/games/supported/Tennis.cpp
@@ -15,6 +15,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 TennisSettings::TennisSettings() { reset(); }
 

--- a/src/games/supported/Tennis.hpp
+++ b/src/games/supported/Tennis.hpp
@@ -62,13 +62,13 @@ class TennisSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return 0; }
 
@@ -78,7 +78,7 @@ class TennisSettings : public RomSettings {
 
   // set the mode of the game
   // the given mode must be one returned by the previous function
-  void setMode(game_mode_t, System& system,
+  void setMode(game_mode_t, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
   // returns a list of difficulties that the game can be played in

--- a/src/games/supported/Tetris.cpp
+++ b/src/games/supported/Tetris.cpp
@@ -30,6 +30,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 TetrisSettings::TetrisSettings() { reset(); }
 

--- a/src/games/supported/Tetris.hpp
+++ b/src/games/supported/Tetris.hpp
@@ -57,13 +57,13 @@ class TetrisSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   // remaining lives
   int lives() override { return isTerminal() ? 0 : m_lives; }

--- a/src/games/supported/TicTacToe3d.cpp
+++ b/src/games/supported/TicTacToe3d.cpp
@@ -27,6 +27,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 TicTacToe3dSettings::TicTacToe3dSettings() { reset(); }
 

--- a/src/games/supported/TicTacToe3d.hpp
+++ b/src/games/supported/TicTacToe3d.hpp
@@ -50,11 +50,11 @@ public:
 
   bool isMinimal(const Action& a) const override;
 
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   DifficultyVect getAvailableDifficulties() override;
 
@@ -64,7 +64,7 @@ public:
 
   // set the mode of the game
   // the given mode must be one returned by the previous function
-  void setMode(game_mode_t, System& system,
+  void setMode(game_mode_t, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
 private:

--- a/src/games/supported/TimePilot.cpp
+++ b/src/games/supported/TimePilot.cpp
@@ -30,6 +30,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 TimePilotSettings::TimePilotSettings() { reset(); }
 

--- a/src/games/supported/TimePilot.hpp
+++ b/src/games/supported/TimePilot.hpp
@@ -59,13 +59,13 @@ class TimePilotSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return isTerminal() ? 0 : m_lives; }
 

--- a/src/games/supported/Trondead.cpp
+++ b/src/games/supported/Trondead.cpp
@@ -15,6 +15,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 TrondeadSettings::TrondeadSettings() { reset(); }
 

--- a/src/games/supported/Trondead.hpp
+++ b/src/games/supported/Trondead.hpp
@@ -44,13 +44,13 @@ class TrondeadSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return isTerminal() ? 0 : m_lives; }
 

--- a/src/games/supported/Turmoil.cpp
+++ b/src/games/supported/Turmoil.cpp
@@ -15,6 +15,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 TurmoilSettings::TurmoilSettings() { reset(); }
 

--- a/src/games/supported/Turmoil.hpp
+++ b/src/games/supported/Turmoil.hpp
@@ -46,13 +46,13 @@ class TurmoilSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   // Turmoil requires the fire action to start the game
   ActionVect getStartingActions() override;
@@ -61,7 +61,7 @@ class TurmoilSettings : public RomSettings {
 
   ModeVect getAvailableModes() override;
 
-  void setMode(game_mode_t m, System& system,
+  void setMode(game_mode_t m, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
  private:

--- a/src/games/supported/Tutankham.cpp
+++ b/src/games/supported/Tutankham.cpp
@@ -30,6 +30,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 TutankhamSettings::TutankhamSettings() { reset(); }
 

--- a/src/games/supported/Tutankham.hpp
+++ b/src/games/supported/Tutankham.hpp
@@ -62,13 +62,13 @@ class TutankhamSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return isTerminal() ? 0 : m_lives; }
 
@@ -78,7 +78,7 @@ class TutankhamSettings : public RomSettings {
 
   // set the mode of the game
   // the given mode must be one returned by the previous function
-  void setMode(game_mode_t, System& system,
+  void setMode(game_mode_t, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
  private:

--- a/src/games/supported/UpNDown.cpp
+++ b/src/games/supported/UpNDown.cpp
@@ -30,6 +30,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 UpNDownSettings::UpNDownSettings() { reset(); }
 

--- a/src/games/supported/UpNDown.hpp
+++ b/src/games/supported/UpNDown.hpp
@@ -59,13 +59,13 @@ class UpNDownSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   // UpNDown requires the fire action to start the game
   ActionVect getStartingActions() override;

--- a/src/games/supported/Venture.cpp
+++ b/src/games/supported/Venture.cpp
@@ -30,6 +30,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 VentureSettings::VentureSettings() { reset(); }
 

--- a/src/games/supported/Venture.hpp
+++ b/src/games/supported/Venture.hpp
@@ -59,13 +59,13 @@ class VentureSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return isTerminal() ? 0 : m_lives; }
 

--- a/src/games/supported/VideoCheckers.cpp
+++ b/src/games/supported/VideoCheckers.cpp
@@ -41,6 +41,7 @@ void process_board_state(unsigned char state, unsigned char& num_black_pieces,
 }  // namespace
 
 namespace ale {
+using namespace stella;
 
 VideoCheckersSettings::VideoCheckersSettings() { reset(); }
 

--- a/src/games/supported/VideoCheckers.hpp
+++ b/src/games/supported/VideoCheckers.hpp
@@ -51,17 +51,17 @@ class VideoCheckersSettings : public RomSettings {
 
   bool isMinimal(const Action& a) const override;
 
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return isTerminal() ? 0 : 1; }
 
   ModeVect getAvailableModes() override;
 
-  void setMode(game_mode_t, System& system,
+  void setMode(game_mode_t, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
  private:

--- a/src/games/supported/VideoChess.cpp
+++ b/src/games/supported/VideoChess.cpp
@@ -35,6 +35,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 VideoChessSettings::VideoChessSettings() { reset(); }
 

--- a/src/games/supported/VideoChess.hpp
+++ b/src/games/supported/VideoChess.hpp
@@ -64,13 +64,13 @@ class VideoChessSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return isTerminal() ? 0 : m_lives; }
 
@@ -79,7 +79,7 @@ class VideoChessSettings : public RomSettings {
 
   // Set the game mode.
   // The given mode must be one returned by the previous function.
-  void setMode(game_mode_t, System& system,
+  void setMode(game_mode_t, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
  private:

--- a/src/games/supported/VideoCube.cpp
+++ b/src/games/supported/VideoCube.cpp
@@ -31,6 +31,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 VideoCubeSettings::VideoCubeSettings() { reset(); }
 

--- a/src/games/supported/VideoCube.hpp
+++ b/src/games/supported/VideoCube.hpp
@@ -49,17 +49,17 @@ class VideoCubeSettings : public RomSettings {
 
   bool isMinimal(const Action& a) const override;
 
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   ActionVect getStartingActions() override;
 
   ModeVect getAvailableModes() override;
 
-  void setMode(game_mode_t m, System& system,
+  void setMode(game_mode_t m, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
   DifficultyVect getAvailableDifficulties() override;

--- a/src/games/supported/VideoPinball.cpp
+++ b/src/games/supported/VideoPinball.cpp
@@ -30,6 +30,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 VideoPinballSettings::VideoPinballSettings() { reset(); }
 

--- a/src/games/supported/VideoPinball.hpp
+++ b/src/games/supported/VideoPinball.hpp
@@ -62,13 +62,13 @@ class VideoPinballSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return isTerminal() ? 0 : m_lives; }
 
@@ -78,7 +78,7 @@ class VideoPinballSettings : public RomSettings {
 
   // set the mode of the game
   // the given mode must be one returned by the previous function
-  void setMode(game_mode_t, System& system,
+  void setMode(game_mode_t, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
   // returns a list of difficulties that the game can be played in

--- a/src/games/supported/WizardOfWor.cpp
+++ b/src/games/supported/WizardOfWor.cpp
@@ -30,6 +30,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 #include "stdio.h"
 
 WizardOfWorSettings::WizardOfWorSettings() { reset(); }

--- a/src/games/supported/WizardOfWor.hpp
+++ b/src/games/supported/WizardOfWor.hpp
@@ -59,13 +59,13 @@ class WizardOfWorSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return isTerminal() ? 0 : m_lives; }
 

--- a/src/games/supported/WordZapper.cpp
+++ b/src/games/supported/WordZapper.cpp
@@ -27,6 +27,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 WordZapperSettings::WordZapperSettings() { reset(); }
 

--- a/src/games/supported/WordZapper.hpp
+++ b/src/games/supported/WordZapper.hpp
@@ -48,17 +48,17 @@ class WordZapperSettings : public RomSettings {
 
   bool isMinimal(const Action& a) const override;
 
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   ActionVect getStartingActions() override;
 
   ModeVect getAvailableModes() override;
 
-  void setMode(game_mode_t m, System& system,
+  void setMode(game_mode_t m, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
   DifficultyVect getAvailableDifficulties() override;

--- a/src/games/supported/YarsRevenge.cpp
+++ b/src/games/supported/YarsRevenge.cpp
@@ -30,6 +30,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 YarsRevengeSettings::YarsRevengeSettings() { reset(); }
 

--- a/src/games/supported/YarsRevenge.hpp
+++ b/src/games/supported/YarsRevenge.hpp
@@ -62,13 +62,13 @@ class YarsRevengeSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   // Gopher requires the fire action to start the game
   ActionVect getStartingActions() override;
@@ -81,7 +81,7 @@ class YarsRevengeSettings : public RomSettings {
 
   // set the mode of the game
   // the given mode must be one returned by the previous function
-  void setMode(game_mode_t, System& system,
+  void setMode(game_mode_t, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
   // returns a list of difficulties that the game can be played in

--- a/src/games/supported/Zaxxon.cpp
+++ b/src/games/supported/Zaxxon.cpp
@@ -30,6 +30,7 @@
 #include "games/RomUtils.hpp"
 
 namespace ale {
+using namespace stella;
 
 ZaxxonSettings::ZaxxonSettings() { reset(); }
 

--- a/src/games/supported/Zaxxon.hpp
+++ b/src/games/supported/Zaxxon.hpp
@@ -62,13 +62,13 @@ class ZaxxonSettings : public RomSettings {
   bool isMinimal(const Action& a) const override;
 
   // process the latest information from ALE
-  void step(const System& system) override;
+  void step(const stella::System& system) override;
 
   // saves the state of the rom settings
-  void saveState(Serializer& ser) override;
+  void saveState(stella::Serializer& ser) override;
 
   // loads the state of the rom settings
-  void loadState(Deserializer& ser) override;
+  void loadState(stella::Deserializer& ser) override;
 
   int lives() override { return isTerminal() ? 0 : m_lives; }
 
@@ -78,7 +78,7 @@ class ZaxxonSettings : public RomSettings {
 
   // set the mode of the game
   // the given mode must be one returned by the previous function
-  void setMode(game_mode_t, System& system,
+  void setMode(game_mode_t, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
  private:


### PR DESCRIPTION
The emucore code has naked class definitions such as `Device`, which makes it difficult to link with other libraries. One example of this is libtorch C++. This pull request wraps the code in emucore inside the ale namespace. The resulting effect is that this change allows to link against libtorch (which also defined a `Device`) without any linking errors.