### PR TITLE
Add `const` keyword to getters

### DIFF
--- a/src/ale_interface.cpp
+++ b/src/ale_interface.cpp
@@ -260,7 +260,7 @@ reward_t ALEInterface::act(Action action) {
 
 // Returns the vector of modes available for the current game.
 // This should be called only after the rom is loaded.
-ModeVect ALEInterface::getAvailableModes() {
+ModeVect ALEInterface::getAvailableModes() const {
   return romSettings->getAvailableModes();
 }
 
@@ -279,7 +279,7 @@ void ALEInterface::setMode(game_mode_t m) {
 
 //Returns the vector of difficulties available for the current game.
 //This should be called only after the rom is loaded.
-DifficultyVect ALEInterface::getAvailableDifficulties() {
+DifficultyVect ALEInterface::getAvailableDifficulties() const {
   return romSettings->getAvailableDifficulties();
 }
 
@@ -297,7 +297,7 @@ void ALEInterface::setDifficulty(difficulty_t m) {
 
 // Returns the vector of legal actions. This should be called only
 // after the rom is loaded.
-ActionVect ALEInterface::getLegalActionSet() {
+ActionVect ALEInterface::getLegalActionSet() const {
   if (romSettings == nullptr) {
     throw std::runtime_error("ROM not set");
   } else {
@@ -307,7 +307,7 @@ ActionVect ALEInterface::getLegalActionSet() {
 
 // Returns the vector of the minimal set of actions needed to play
 // the game.
-ActionVect ALEInterface::getMinimalActionSet() {
+ActionVect ALEInterface::getMinimalActionSet() const {
   if (romSettings == nullptr) {
     throw std::runtime_error("ROM not set");
   } else {
@@ -316,7 +316,7 @@ ActionVect ALEInterface::getMinimalActionSet() {
 }
 
 // Returns the frame number since the loading of the ROM
-int ALEInterface::getFrameNumber() { return environment->getFrameNumber(); }
+int ALEInterface::getFrameNumber() const { return environment->getFrameNumber(); }
 
 // Returns the frame number since the start of the current episode
 int ALEInterface::getEpisodeFrameNumber() const {
@@ -324,12 +324,12 @@ int ALEInterface::getEpisodeFrameNumber() const {
 }
 
 // Returns the current game screen
-const ALEScreen& ALEInterface::getScreen() { return environment->getScreen(); }
+const ALEScreen& ALEInterface::getScreen() const { return environment->getScreen(); }
 
 //This method should receive an empty vector to fill it with
 //the grayscale colours
 void ALEInterface::getScreenGrayscale(
-    std::vector<unsigned char>& grayscale_output_buffer) {
+    std::vector<unsigned char>& grayscale_output_buffer) const {
   size_t w = environment->getScreen().width();
   size_t h = environment->getScreen().height();
   size_t screen_size = w * h;
@@ -342,7 +342,7 @@ void ALEInterface::getScreenGrayscale(
 //This method should receive a vector to fill it with
 //the RGB colours. The first positions contain the red colours,
 //followed by the green colours and then the blue colours
-void ALEInterface::getScreenRGB(std::vector<unsigned char>& output_rgb_buffer) {
+void ALEInterface::getScreenRGB(std::vector<unsigned char>& output_rgb_buffer) const {
   size_t w = environment->getScreen().width();
   size_t h = environment->getScreen().height();
   size_t screen_size = w * h;
@@ -354,7 +354,7 @@ void ALEInterface::getScreenRGB(std::vector<unsigned char>& output_rgb_buffer) {
 }
 
 // Returns the current RAM content
-const ALERAM& ALEInterface::getRAM() { return environment->getRAM(); }
+const ALERAM& ALEInterface::getRAM() const { return environment->getRAM(); }
 
 // Set byte at memory address
 void ALEInterface::setRAM(size_t memory_index, byte_t value) {

--- a/src/ale_interface.cpp
+++ b/src/ale_interface.cpp
@@ -189,22 +189,22 @@ std::optional<std::string> ALEInterface::isSupportedROM(const fs::path& rom_file
 }
 
 // Get the value of a setting.
-const std::string& ALEInterface::getStringInplace(const std::string& key) {
+const std::string& ALEInterface::getStringInplace(const std::string& key) const {
   assert(theSettings.get());
   return theSettings->getString(key);
 }
-std::string ALEInterface::getString(const std::string& key) {
+std::string ALEInterface::getString(const std::string& key) const {
   return getStringInplace(key);
 }
-int ALEInterface::getInt(const std::string& key) {
+int ALEInterface::getInt(const std::string& key) const {
   assert(theSettings.get());
   return theSettings->getInt(key);
 }
-bool ALEInterface::getBool(const std::string& key) {
+bool ALEInterface::getBool(const std::string& key) const {
   assert(theSettings.get());
   return theSettings->getBool(key);
 }
-float ALEInterface::getFloat(const std::string& key) {
+float ALEInterface::getFloat(const std::string& key) const {
   assert(theSettings.get());
   return theSettings->getFloat(key);
 }

--- a/src/ale_interface.hpp
+++ b/src/ale_interface.hpp
@@ -96,7 +96,7 @@ class ALEInterface {
 
   // Returns the vector of modes available for the current game.
   // This should be called only after the rom is loaded.
-  ModeVect getAvailableModes();
+  ModeVect getAvailableModes() const;
 
   // Sets the mode of the game.
   // The mode must be an available mode (otherwise it throws an exception).
@@ -119,7 +119,7 @@ class ALEInterface {
   //   2         left B/right A
   //   3         left A/right B
   //   4         left A/right A
-  DifficultyVect getAvailableDifficulties();
+  DifficultyVect getAvailableDifficulties() const;
 
   // Sets the difficulty of the game.
   // The difficulty must be an available mode (otherwise it throws an exception).
@@ -131,14 +131,14 @@ class ALEInterface {
 
   // Returns the vector of legal actions. This should be called only
   // after the rom is loaded.
-  ActionVect getLegalActionSet();
+  ActionVect getLegalActionSet() const;
 
   // Returns the vector of the minimal set of actions needed to play
   // the game.
-  ActionVect getMinimalActionSet();
+  ActionVect getMinimalActionSet() const;
 
   // Returns the frame number since the loading of the ROM
-  int getFrameNumber();
+  int getFrameNumber() const;
 
   // The remaining number of lives.
   int lives();
@@ -147,19 +147,19 @@ class ALEInterface {
   int getEpisodeFrameNumber() const;
 
   // Returns the current game screen
-  const ALEScreen& getScreen();
+  const ALEScreen& getScreen() const;
 
   //This method should receive an empty vector to fill it with
   //the grayscale colours
-  void getScreenGrayscale(std::vector<unsigned char>& grayscale_output_buffer);
+  void getScreenGrayscale(std::vector<unsigned char>& grayscale_output_buffer) const;
 
   //This method should receive a vector to fill it with
   //the RGB colours. The first positions contain the red colours,
   //followed by the green colours and then the blue colours
-  void getScreenRGB(std::vector<unsigned char>& output_rgb_buffer);
+  void getScreenRGB(std::vector<unsigned char>& output_rgb_buffer) const;
 
   // Returns the current RAM content
-  const ALERAM& getRAM();
+  const ALERAM& getRAM() const;
 
   // Set byte at memory address. This can be useful to change the environment
   // for example if you were trying to learn a causal model of RAM locations.

--- a/src/ale_interface.hpp
+++ b/src/ale_interface.hpp
@@ -58,16 +58,16 @@ class ALEInterface {
   ALEInterface(bool display_screen);
 
   // Get the value of a setting.
-  std::string getString(const std::string& key);
-  int getInt(const std::string& key);
-  bool getBool(const std::string& key);
-  float getFloat(const std::string& key);
+  std::string getString(const std::string& key) const;
+  int getInt(const std::string& key) const;
+  bool getBool(const std::string& key) const;
+  float getFloat(const std::string& key) const;
 
   // getStringInplace is a version of getString that returns a reference to the
   // actual, stored settings string object, without making a copy. The reference
   // is only valid until the next call of any of the setter functions below, so
   // this function must be used with care.
-  const std::string& getStringInplace(const std::string& key);
+  const std::string& getStringInplace(const std::string& key) const;
 
   // Set the value of a setting. loadRom() must be called before the
   // setting will take effect.


### PR DESCRIPTION
As the title says, this patch add missing const correctness to getters of the `ALEInterface` class.