### PR TITLE
FIX: add render_mode attribute

### DIFF
--- a/src/python/env/gym.py
+++ b/src/python/env/gym.py
@@ -125,6 +125,7 @@ class AtariEnv(gym.Env, utils.EzPickle):
             max_num_frames_per_episode,
             render_mode,
         )
+
         # Initialize ALE
         self.ale = ale_py.ALEInterface()
 

--- a/src/python/env/gym.py
+++ b/src/python/env/gym.py
@@ -125,7 +125,6 @@ class AtariEnv(gym.Env, utils.EzPickle):
             max_num_frames_per_episode,
             render_mode,
         )
-
         # Initialize ALE
         self.ale = ale_py.ALEInterface()
 
@@ -416,3 +415,10 @@ class AtariEnv(gym.Env, utils.EzPickle):
         Return Gym's observation space.
         """
         return self._obs_space
+
+    @property
+    def render_mode(self) -> str:
+        """
+        Attribute render_mode to comply Gym API.
+        """
+        return self._render_mode


### PR DESCRIPTION
This PR addresses https://github.com/mgbellemare/Arcade-Learning-Environment/issues/471 and https://github.com/mgbellemare/Arcade-Learning-Environment/issues/475 by adding the property render_mode to AtariEnv.

Quick test:
```python
import gym
from gym.wrappers import RecordVideo

env = RecordVideo(
    gym.make('ALE/Breakout-v5', render_mode="rgb_array"),
    video_folder='video'
)

env.reset()
for _ in range(100):
    env.step(env.action_space.sample())

env.close()
```

@JesseFarebro 