### PR TITLE
build: allow installing without git

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -142,11 +142,14 @@ def parse_version(version_file):
         version = ci_version
     else:
         sha = (
-            subprocess.check_output(["git", "rev-parse", "--short", "HEAD"], cwd=here)
-            .decode("ascii")
+            subprocess.run(
+                ["git", "rev-parse", "--short", "HEAD"], capture_output=True, cwd=here
+            )
+            .stdout.decode("ascii")
             .strip()
         )
-        version += f"+{sha}"
+        if sha:
+            version += f"+{sha}"
 
     return version
 


### PR DESCRIPTION
This allows installing from a tarball rather than requiring a git clone, which is helpful for downstream distributors (such as Homebrew).

Before:

```console
$ pip3 install https://github.com/mgbellemare/Arcade-Learning-
Environment/archive/refs/tags/v0.8.1.tar.gz
...
× Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [25 lines of output]
      fatal: not a git repository (or any of the parent directories): .git
```

After:

```console
$ pip3 install https://github.com/branchvincent/Arcade-Learning-Environment/archive/refs/heads/tarball.tar.gz
...
Successfully built ale-py
```
