### PR TITLE
Unpin cmake dependency and remove wheel.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "setuptools>=61",
-    "wheel",
-    "cmake~=3.22",
+    "cmake>=3.22",
     "ninja; sys_platform != 'win32' and platform_machine != 'arm64'",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
In [nixpkgs](https://github.com/NixOS/nixpkgs), we'd like to build using newer versions of CMake. If nothing is known to be broken in later versions, would it be possible to relax this constraint?

Separately, I have removed the wheel dependency, as it is not explicitly needed. When a PEP 517 compliant build frontend invokes setuptools to build a wheel, it'll ask setuptools if it needs any additional dependencies, and setuptools will indicate it needs wheel (through the [get-requires-for-build-wheel](https://peps.python.org/pep-0517/#get-requires-for-build-wheel) hook).