### PR TITLE
Disable windows CI while broken

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,21 +68,21 @@ jobs:
             python: '3.11'
             triplet: x64-osx-mixed
 
-          - runs-on: windows-latest
-            python: '3.7'
-            triplet: x64-windows
-          - runs-on: windows-latest
-            python: '3.8'
-            triplet: x64-windows
-          - runs-on: windows-latest
-            python: '3.9'
-            triplet: x64-windows
-          - runs-on: windows-latest
-            python: '3.10'
-            triplet: x64-windows
-          - runs-on: windows-latest
-            python: '3.11'
-            triplet: x64-windows
+#          - runs-on: windows-latest
+#            python: '3.7'
+#            triplet: x64-windows
+#          - runs-on: windows-latest
+#            python: '3.8'
+#            triplet: x64-windows
+#          - runs-on: windows-latest
+#            python: '3.9'
+#            triplet: x64-windows
+#          - runs-on: windows-latest
+#            python: '3.10'
+#            triplet: x64-windows
+#          - runs-on: windows-latest
+#            python: '3.11'
+#            triplet: x64-windows
     env:
       VCPKG_DEFAULT_TRIPLET: ${{ matrix.triplet }}
     runs-on: ${{ matrix.runs-on }}

--- a/cmake/custom-triplets/x64-linux-mixed.cmake
+++ b/cmake/custom-triplets/x64-linux-mixed.cmake
@@ -1,4 +1,7 @@
 set(VCPKG_TARGET_ARCHITECTURE x64)
+
+set(VCPKG_CMAKE_SYSTEM_NAME Linux)
+
 if(PORT MATCHES "sdl")
   set(VCPKG_LIBRARY_LINKAGE dynamic)
   set(VCPKG_CRT_LINKAGE dynamic)
@@ -6,5 +9,3 @@ else()
   set(VCPKG_LIBRARY_LINKAGE static)
   set(VCPKG_CRT_LINKAGE static)
 endif()
-
-set(VCPKG_CMAKE_SYSTEM_NAME Linux)

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "arcade-learning-environment",
   "version": "0.8.1",
   "dependencies": [


### PR DESCRIPTION
Windows CI seems broken due to a change in vcpkg with the default triplet from x86-windows

In the meantime, I check that the CI works, this PR removes the window CI
