### PR TITLE
Remove MacOS X86 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,10 +45,6 @@ jobs:
             python: '3.12'
             triplet: x64-linux-mixed
 
-          - runs-on: macos-13
-            python: '3.12'
-            triplet: x64-osx-mixed
-
           - runs-on: windows-latest
             python: '3.12'
             triplet: x64-windows
@@ -89,8 +85,6 @@ jobs:
             arch: aarch64
           - runs-on: windows-latest
             arch: AMD64
-          - runs-on: macos-13
-            arch: x86_64
           - runs-on: macos-13
             arch: arm64
     runs-on: ${{ matrix.runs-on }}
@@ -204,27 +198,6 @@ jobs:
             python: '3.13'
             wheel-name: 'cp313-cp313-win_amd64'
             arch: AMD64
-
-          - runs-on: macos-13
-            python: '3.9'
-            wheel-name: 'cp39-cp39-macosx_13_0_x86_64'
-            arch: x86_64
-          - runs-on: macos-13
-            python: '3.10'
-            wheel-name: 'cp310-cp310-macosx_13_0_x86_64'
-            arch: x86_64
-          - runs-on: macos-13
-            python: '3.11'
-            wheel-name: 'cp311-cp311-macosx_13_0_x86_64'
-            arch: x86_64
-          - runs-on: macos-13
-            python: '3.12'
-            wheel-name: 'cp312-cp312-macosx_13_0_x86_64'
-            arch: x86_64
-          - runs-on: macos-13
-            python: '3.13'
-            wheel-name: 'cp313-cp313-macosx_13_0_x86_64'
-            arch: x86_64
 
           - runs-on: macos-14
             python: '3.9'

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -24,8 +24,6 @@ jobs:
           - runs-on: windows-latest
             arch: AMD64
           - runs-on: macos-13
-            arch: x86_64
-          - runs-on: macos-13
             arch: arm64
     runs-on: ${{ matrix.runs-on }}
 
@@ -93,11 +91,6 @@ jobs:
       - uses: actions/download-artifact@v6
         with:
           name: wheels-ubuntu-24.04-arm-aarch64
-          path: dist
-
-      - uses: actions/download-artifact@v6
-        with:
-          name: wheels-macos-13-x86_64
           path: dist
 
       - uses: actions/download-artifact@v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,11 +90,6 @@ manylinux-aarch64-image = "manylinux-aarch64-vcpkg:latest"
 [tool.cibuildwheel.linux]
 environment-pass = ["GITHUB_REF"]
 
-# macOS x86-64
-[[tool.cibuildwheel.overrides]]
-select = "*-macosx_x86_64"
-environment = { PIP_ONLY_BINARY = "numpy", VCPKG_DEFAULT_TRIPLET = "x64-osx-mixed", VCPKG_FEATURE_FLAGS = "-compilertracking", MACOSX_DEPLOYMENT_TARGET = "13.0" }
-
 # macOS arm64
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_arm64"


### PR DESCRIPTION
With the Mac M5 chip being release and no x86 laptop been released in 4 years, I believe it is safe to remove this as an option we build wheels for. 
It should still be available for users to build the project locally if they need macos x86 wheels