### PR TITLE
Add testing for NumPy 1.X

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,7 +268,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.10"
+          python-version: "3.13"
 
       - uses: actions/download-artifact@v6
         with:


### PR DESCRIPTION
We support Numpy > 1.20 however have no testing to make sure that this works.
This PR adds a test on each of the OSes with NumPy < 2.0