### PR TITLE
Remove Python 3.9 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,14 +132,10 @@ jobs:
       matrix:
         include:
           # example wheel names (if the wheel names change, look at the `ls wheels/` for the new names)
-          # ale_py-0.x.x-cp310-cp310-macosx_10_15_x86_64.whl
           # ale_py-0.x.x-cp310-cp310-macosx_11_0_arm64.whl
           # ale_py-0.x.x-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+          # ale_py-0.x.x-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
           # ale_py-0.x.x-cp310-cp310-win_amd64.whl
-          - runs-on: ubuntu-latest
-            python: '3.9'
-            wheel-name: 'cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64'
-            arch: 'x86_64'
           - runs-on: ubuntu-latest
             python: '3.10'
             wheel-name: 'cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64'
@@ -158,10 +154,6 @@ jobs:
             arch: 'x86_64'
 
           - runs-on: ubuntu-24.04-arm
-            python: '3.9'
-            wheel-name: 'cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64'
-            arch: 'aarch64'
-          - runs-on: ubuntu-24.04-arm
             python: '3.10'
             wheel-name: 'cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64'
             arch: 'aarch64'
@@ -179,10 +171,6 @@ jobs:
             arch: 'aarch64'
 
           - runs-on: windows-latest
-            python: '3.9'
-            wheel-name: 'cp39-cp39-win_amd64'
-            arch: AMD64
-          - runs-on: windows-latest
             python: '3.10'
             wheel-name: 'cp310-cp310-win_amd64'
             arch: AMD64
@@ -199,10 +187,6 @@ jobs:
             wheel-name: 'cp313-cp313-win_amd64'
             arch: AMD64
 
-          - runs-on: macos-14
-            python: '3.9'
-            wheel-name: 'cp39-cp39-macosx_13_0_arm64'
-            arch: arm64
           - runs-on: macos-14
             python: '3.10'
             wheel-name: 'cp310-cp310-macosx_13_0_arm64'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-symlinks
       - id: destroyed-symlinks
@@ -25,7 +25,7 @@ repos:
 #        args:
 #          - --ignore-words-list=
   - repo: https://github.com/PyCQA/flake8
-    rev: 7.2.0
+    rev: 7.3.0
     hooks:
       - id: flake8
         args:
@@ -36,17 +36,17 @@ repos:
           - --show-source
           - --statistics
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.20.0
+    rev: v3.21.1
     hooks:
       - id: pyupgrade
         args: ["--py39-plus"]
   - repo: https://github.com/PyCQA/isort
-    rev: 6.0.1
+    rev: 7.0.0
     hooks:
       - id: isort
         args: ["--profile", "black"]
   - repo: https://github.com/python/black
-    rev: 25.1.0
+    rev: 25.9.0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/pydocstyle

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 name = "ale-py"
 description = "The Arcade Learning Environment (ALE) - a platform for AI research."
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = "GPL-2.0-only"
 license-files = ["LICENSE.md"]
 keywords = ["reinforcement-learning", "arcade-learning-environment", "atari"]
@@ -27,7 +27,6 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Science/Research",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -37,7 +36,6 @@ classifiers = [
 ]
 dependencies = [
     "numpy>1.20",
-    "importlib-metadata>=4.10.0; python_version < '3.10'",
     "typing-extensions; python_version < '3.11'"
 ]
 dynamic = ["version"]
@@ -50,14 +48,14 @@ vector = [
 xla = [
     "gymnasium>=1.1.0",
     "opencv-python>=3.0",
-    "jax >= 0.4.31; python_version > '3.9' and (sys_platform == 'win32' or sys_platform == 'linux')"
+    "jax >= 0.4.31; sys_platform == 'win32' or sys_platform == 'linux'"
 ]
 test = [
     "pytest>=7.0",
     "gymnasium>=1.1.0",
     "opencv-python>=3.0",
-    "jax >= 0.4.31; python_version > '3.9' and (sys_platform == 'win32' or sys_platform == 'linux')",
-    "chex; python_version > '3.9' and (sys_platform == 'win32' or sys_platform == 'linux')"
+    "jax >= 0.4.31; sys_platform == 'win32' or sys_platform == 'linux'",
+    "chex; sys_platform == 'win32' or sys_platform == 'linux'"
 ]
 
 [project.urls]


### PR DESCRIPTION
Python 3.9 has reached end of life, therefore, removing it from the available, maintained list of python versions