### PR TITLE
update macos version for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
             python: '3.12'
             triplet: x64-windows-mixed
 
-          - runs-on: macos-14
+          - runs-on: macos-latest
             python: '3.12'
             triplet: arm64-osx-mixed
 
@@ -105,7 +105,7 @@ jobs:
             arch: aarch64
           - runs-on: windows-latest
             arch: AMD64
-          - runs-on: macos-13
+          - runs-on: macos-15
             arch: arm64
     runs-on: ${{ matrix.runs-on }}
 
@@ -216,19 +216,19 @@ jobs:
             wheel-name: 'cp313-cp313-win_amd64'
             arch: AMD64
 
-          - runs-on: macos-14
+          - runs-on: macos-latest
             python: '3.10'
             wheel-name: 'cp310-cp310-macosx_13_0_arm64'
             arch: arm64
-          - runs-on: macos-14
+          - runs-on: macos-latest
             python: '3.11'
             wheel-name: 'cp311-cp311-macosx_13_0_arm64'
             arch: arm64
-          - runs-on: macos-14
+          - runs-on: macos-latest
             python: '3.12'
             wheel-name: 'cp312-cp312-macosx_13_0_arm64'
             arch: arm64
-          - runs-on: macos-14
+          - runs-on: macos-latest
             python: '3.13'
             wheel-name: 'cp313-cp313-macosx_13_0_arm64'
             arch: arm64
@@ -272,7 +272,7 @@ jobs:
 #          - runs-on: windows-latest
 #            wheel-name: 'cp313-cp313-win_amd64'
 #            arch: AMD64
-          - runs-on: macos-14
+          - runs-on: macos-latest
             wheel-name: 'cp313-cp313-macosx_13_0_arm64'
             arch: arm64
 

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -23,7 +23,7 @@ jobs:
             arch: aarch64
           - runs-on: windows-latest
             arch: AMD64
-          - runs-on: macos-13
+          - runs-on: macos-latest
             arch: arm64
     runs-on: ${{ matrix.runs-on }}
 
@@ -95,7 +95,7 @@ jobs:
 
       - uses: actions/download-artifact@v6
         with:
-          name: wheels-macos-13-arm64
+          name: wheels-macos-latest-arm64
           path: dist
 
       - run: ls dist/


### PR DESCRIPTION
Macos-13 is a deprecated github image, therefore, updating to macos-latest to avoid this problem in the future hopefully
