### PR TITLE
Fix missing cuda installation on `init_vector_xla`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
             arch: aarch64
           - runs-on: windows-latest
             arch: AMD64
-          - runs-on: macos-15
+          - runs-on: macos-latest
             arch: arm64
     runs-on: ${{ matrix.runs-on }}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,13 +16,9 @@ endif()
 option(BUILD_VECTOR_LIB "Build Vector Interface" OFF)
 if (BUILD_VECTOR_LIB)
   list(APPEND VCPKG_MANIFEST_FEATURES "vector")
-  add_definitions(-DBUILD_VECTOR_LIB)
 endif()
 
 option(BUILD_VECTOR_XLA_LIB "Build with Vector XLA Support" OFF)
-if (BUILD_VECTOR_XLA_LIB)
-  add_definitions(-DBUILD_VECTOR_XLA_LIB)
-endif()
 
 # Set cmake module path
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})


### PR DESCRIPTION
From https://github.com/Farama-Foundation/Arcade-Learning-Environment/pull/657 causes 
```
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.12.12/x64/lib/python3.12/site-packages/sphinx/config.py", line 529, in eval_config_file
    exec(code, namespace)  # NoQA: S102
    ^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/Arcade-Learning-Environment/Arcade-Learning-Environment/docs/conf.py", line 20, in <module>
    import ale_py
  File "/opt/hostedtoolcache/Python/3.12.12/x64/lib/python3.12/site-packages/ale_py/__init__.py", line 34, in <module>
    from ale_py._ale_py import SDL_SUPPORT, Action, ALEInterface, ALEState, LoggerMode
ImportError: /opt/hostedtoolcache/Python/3.12.12/x64/lib/python3.12/site-packages/ale_py/_ale_py.cpython-312-x86_64-linux-gnu.so: undefined symbol: _Z22init_vector_module_xlaRN8nanobind7module_E
```
as `init_vector_module_xla` isn't created or used
