### PR TITLE
Adding timeout termination to PitFall

### DIFF
--- a/src/ale/games/supported/Pitfall.cpp
+++ b/src/ale/games/supported/Pitfall.cpp
@@ -49,9 +49,14 @@ void PitfallSettings::step(const System& system) {
 
   // update terminal status
   int lives_byte = readRam(&system, 0x80) >> 4;
-  // The value at 09xE will be nonzero if we cannot control the player
+  // The value at 0x9E will be nonzero if we cannot control the player
   int logo_timer = readRam(&system, 0x9E);
-  m_terminal = lives_byte == 0 && logo_timer != 0;
+  // The game timer (displayed as MM:SS) is stored in BCD format at 0xD8 (minutes) and 0xD9 (seconds)
+  int timer_minutes = readRam(&system, 0xD8);
+  int timer_seconds = readRam(&system, 0xD9);
+  // Game terminates when: (1) all lives lost and logo screen shown, OR (2) timer runs out (00:00)
+  bool timer_expired = (timer_minutes == 0 && timer_seconds == 0);
+  m_terminal = (lives_byte == 0 && logo_timer != 0) || timer_expired;
 
   m_lives = (lives_byte == 0xA) ? 3 : ((lives_byte == 0x8) ? 2 : 1);
 }

--- a/src/ale/games/supported/Pitfall.cpp
+++ b/src/ale/games/supported/Pitfall.cpp
@@ -55,7 +55,7 @@ void PitfallSettings::step(const System& system) {
   // The game timer (displayed as MM:SS) is stored in BCD format at 0xD8 (minutes) and 0xD9 (seconds)
   int timer_minutes = readRam(&system, 0xD8);
   int timer_seconds = readRam(&system, 0xD9);
-  // Game terminates when: (1) all lives lost and logo screen shown, OR (2) timer runs out (00:00)
+  // Game terminates when: (1) all lives lost and logo is scrolling in bottom left, OR (2) timer runs out (00:00)
   // In legacy mode (mode 1), timer expiration is not checked for backwards compatibility
   bool timer_expired = m_terminateOnTimeout && (timer_minutes == 0 && timer_seconds == 0);
   m_terminal = (lives_byte == 0 && logo_timer != 0) || timer_expired;
@@ -128,8 +128,8 @@ ActionVect PitfallSettings::getStartingActions() {
 }
 
 // Returns a list of modes that the game can be played in.
-// Mode 0: Default mode with timer-based termination (terminates when 20-minute timer expires)
-// Mode 1: Legacy mode without timer-based termination (for backwards compatibility)
+// Mode 0: Default mode with timer-based termination (terminates when 20-minute timer expires, as intended)
+// Mode 1: Legacy mode without timer-based termination (for backwards compatibility, agent will be unable to move after 20 minutes but game will not terminate)
 ModeVect PitfallSettings::getAvailableModes() {
   return {0, 1};
 }
@@ -139,10 +139,8 @@ void PitfallSettings::setMode(
     game_mode_t m, System& system,
     std::unique_ptr<StellaEnvironmentWrapper> environment) {
   if (m == 0) {
-    // Default mode: terminate when 20-minute timer expires
     m_terminateOnTimeout = true;
   } else if (m == 1) {
-    // Legacy mode: do not terminate on timer expiration (original buggy behavior)
     m_terminateOnTimeout = false;
   } else {
     throw std::runtime_error("This mode is not supported for Pitfall.");

--- a/src/ale/games/supported/Pitfall.cpp
+++ b/src/ale/games/supported/Pitfall.cpp
@@ -28,6 +28,7 @@
 #include "ale/games/supported/Pitfall.hpp"
 
 #include "ale/games/RomUtils.hpp"
+#include "ale/environment/stella_environment_wrapper.hpp"
 
 namespace ale {
 using namespace stella;
@@ -55,7 +56,8 @@ void PitfallSettings::step(const System& system) {
   int timer_minutes = readRam(&system, 0xD8);
   int timer_seconds = readRam(&system, 0xD9);
   // Game terminates when: (1) all lives lost and logo screen shown, OR (2) timer runs out (00:00)
-  bool timer_expired = (timer_minutes == 0 && timer_seconds == 0);
+  // In legacy mode (mode 1), timer expiration is not checked for backwards compatibility
+  bool timer_expired = m_terminateOnTimeout && (timer_minutes == 0 && timer_seconds == 0);
   m_terminal = (lives_byte == 0 && logo_timer != 0) || timer_expired;
 
   m_lives = (lives_byte == 0xA) ? 3 : ((lives_byte == 0x8) ? 2 : 1);
@@ -100,6 +102,7 @@ void PitfallSettings::reset() {
   m_score = 2000;
   m_terminal = false;
   m_lives = 3;
+  m_terminateOnTimeout = true;
 }
 
 /* saves the state of the rom settings */
@@ -108,6 +111,7 @@ void PitfallSettings::saveState(Serializer& ser) {
   ser.putInt(m_score);
   ser.putBool(m_terminal);
   ser.putInt(m_lives);
+  ser.putBool(m_terminateOnTimeout);
 }
 
 // loads the state of the rom settings
@@ -116,10 +120,33 @@ void PitfallSettings::loadState(Deserializer& ser) {
   m_score = ser.getInt();
   m_terminal = ser.getBool();
   m_lives = ser.getInt();
+  m_terminateOnTimeout = ser.getBool();
 }
 
 ActionVect PitfallSettings::getStartingActions() {
   return {PLAYER_A_UP};
+}
+
+// Returns a list of modes that the game can be played in.
+// Mode 0: Default mode with timer-based termination (terminates when 20-minute timer expires)
+// Mode 1: Legacy mode without timer-based termination (for backwards compatibility)
+ModeVect PitfallSettings::getAvailableModes() {
+  return {0, 1};
+}
+
+// Set the mode of the game.
+void PitfallSettings::setMode(
+    game_mode_t m, System& system,
+    std::unique_ptr<StellaEnvironmentWrapper> environment) {
+  if (m == 0) {
+    // Default mode: terminate when 20-minute timer expires
+    m_terminateOnTimeout = true;
+  } else if (m == 1) {
+    // Legacy mode: do not terminate on timer expiration (original buggy behavior)
+    m_terminateOnTimeout = false;
+  } else {
+    throw std::runtime_error("This mode is not supported for Pitfall.");
+  }
 }
 
 }  // namespace ale

--- a/src/ale/games/supported/Pitfall.cpp
+++ b/src/ale/games/supported/Pitfall.cpp
@@ -55,7 +55,7 @@ void PitfallSettings::step(const System& system) {
   // The game timer (displayed as MM:SS) is stored in BCD format at 0xD8 (minutes) and 0xD9 (seconds)
   int timer_minutes = readRam(&system, 0xD8);
   int timer_seconds = readRam(&system, 0xD9);
-  // Game terminates when: (1) all lives lost and logo is scrolling in bottom left, OR (2) timer runs out (00:00)
+  // Game terminates when: (1) all lives lost and logo screen shown, OR (2) timer runs out (00:00)
   // In legacy mode (mode 1), timer expiration is not checked for backwards compatibility
   bool timer_expired = m_terminateOnTimeout && (timer_minutes == 0 && timer_seconds == 0);
   m_terminal = (lives_byte == 0 && logo_timer != 0) || timer_expired;
@@ -128,8 +128,8 @@ ActionVect PitfallSettings::getStartingActions() {
 }
 
 // Returns a list of modes that the game can be played in.
-// Mode 0: Default mode with timer-based termination (terminates when 20-minute timer expires, as intended)
-// Mode 1: Legacy mode without timer-based termination (for backwards compatibility, agent will be unable to move after 20 minutes but game will not terminate)
+// Mode 0: Default mode with timer-based termination (terminates when 20-minute timer expires)
+// Mode 1: Legacy mode without timer-based termination (for backwards compatibility)
 ModeVect PitfallSettings::getAvailableModes() {
   return {0, 1};
 }
@@ -139,8 +139,10 @@ void PitfallSettings::setMode(
     game_mode_t m, System& system,
     std::unique_ptr<StellaEnvironmentWrapper> environment) {
   if (m == 0) {
+    // Default mode: terminate when 20-minute timer expires
     m_terminateOnTimeout = true;
   } else if (m == 1) {
+    // Legacy mode: do not terminate on timer expiration (original buggy behavior)
     m_terminateOnTimeout = false;
   } else {
     throw std::runtime_error("This mode is not supported for Pitfall.");

--- a/src/ale/games/supported/Pitfall.cpp
+++ b/src/ale/games/supported/Pitfall.cpp
@@ -28,7 +28,6 @@
 #include "ale/games/supported/Pitfall.hpp"
 
 #include "ale/games/RomUtils.hpp"
-#include "ale/environment/stella_environment_wrapper.hpp"
 
 namespace ale {
 using namespace stella;
@@ -56,8 +55,7 @@ void PitfallSettings::step(const System& system) {
   int timer_minutes = readRam(&system, 0xD8);
   int timer_seconds = readRam(&system, 0xD9);
   // Game terminates when: (1) all lives lost and logo screen shown, OR (2) timer runs out (00:00)
-  // In legacy mode (mode 1), timer expiration is not checked for backwards compatibility
-  bool timer_expired = m_terminateOnTimeout && (timer_minutes == 0 && timer_seconds == 0);
+  bool timer_expired = (timer_minutes == 0 && timer_seconds == 0);
   m_terminal = (lives_byte == 0 && logo_timer != 0) || timer_expired;
 
   m_lives = (lives_byte == 0xA) ? 3 : ((lives_byte == 0x8) ? 2 : 1);
@@ -102,7 +100,6 @@ void PitfallSettings::reset() {
   m_score = 2000;
   m_terminal = false;
   m_lives = 3;
-  m_terminateOnTimeout = true;
 }
 
 /* saves the state of the rom settings */
@@ -111,7 +108,6 @@ void PitfallSettings::saveState(Serializer& ser) {
   ser.putInt(m_score);
   ser.putBool(m_terminal);
   ser.putInt(m_lives);
-  ser.putBool(m_terminateOnTimeout);
 }
 
 // loads the state of the rom settings
@@ -120,33 +116,10 @@ void PitfallSettings::loadState(Deserializer& ser) {
   m_score = ser.getInt();
   m_terminal = ser.getBool();
   m_lives = ser.getInt();
-  m_terminateOnTimeout = ser.getBool();
 }
 
 ActionVect PitfallSettings::getStartingActions() {
   return {PLAYER_A_UP};
-}
-
-// Returns a list of modes that the game can be played in.
-// Mode 0: Default mode with timer-based termination (terminates when 20-minute timer expires)
-// Mode 1: Legacy mode without timer-based termination (for backwards compatibility)
-ModeVect PitfallSettings::getAvailableModes() {
-  return {0, 1};
-}
-
-// Set the mode of the game.
-void PitfallSettings::setMode(
-    game_mode_t m, System& system,
-    std::unique_ptr<StellaEnvironmentWrapper> environment) {
-  if (m == 0) {
-    // Default mode: terminate when 20-minute timer expires
-    m_terminateOnTimeout = true;
-  } else if (m == 1) {
-    // Legacy mode: do not terminate on timer expiration (original buggy behavior)
-    m_terminateOnTimeout = false;
-  } else {
-    throw std::runtime_error("This mode is not supported for Pitfall.");
-  }
 }
 
 }  // namespace ale

--- a/src/ale/games/supported/Pitfall.hpp
+++ b/src/ale/games/supported/Pitfall.hpp
@@ -69,12 +69,8 @@ class PitfallSettings : public RomSettings {
 
   ActionVect getStartingActions() override;
 
-  // Returns a list of modes that the game can be played in.
-  // Mode 0: Default mode with timer-based termination (terminates when 20-minute timer expires)
-  // Mode 1: Legacy mode without timer-based termination (for backwards compatibility)
   ModeVect getAvailableModes() override;
 
-  // Set the mode of the game.
   void setMode(game_mode_t m, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
@@ -85,7 +81,7 @@ class PitfallSettings : public RomSettings {
   reward_t m_reward;
   reward_t m_score;
   int m_lives;
-  bool m_terminateOnTimeout;  // If true (default), game terminates when 20-minute timer expires
+  bool m_terminateOnTimeout;
 };
 
 }  // namespace ale

--- a/src/ale/games/supported/Pitfall.hpp
+++ b/src/ale/games/supported/Pitfall.hpp
@@ -69,6 +69,15 @@ class PitfallSettings : public RomSettings {
 
   ActionVect getStartingActions() override;
 
+  // Returns a list of modes that the game can be played in.
+  // Mode 0: Default mode with timer-based termination (terminates when 20-minute timer expires)
+  // Mode 1: Legacy mode without timer-based termination (for backwards compatibility)
+  ModeVect getAvailableModes() override;
+
+  // Set the mode of the game.
+  void setMode(game_mode_t m, stella::System& system,
+               std::unique_ptr<StellaEnvironmentWrapper> environment) override;
+
   int lives() override { return isTerminal() ? 0 : m_lives; }
 
  private:
@@ -76,6 +85,7 @@ class PitfallSettings : public RomSettings {
   reward_t m_reward;
   reward_t m_score;
   int m_lives;
+  bool m_terminateOnTimeout;  // If true (default), game terminates when 20-minute timer expires
 };
 
 }  // namespace ale

--- a/src/ale/games/supported/Pitfall.hpp
+++ b/src/ale/games/supported/Pitfall.hpp
@@ -69,8 +69,12 @@ class PitfallSettings : public RomSettings {
 
   ActionVect getStartingActions() override;
 
+  // Returns a list of modes that the game can be played in.
+  // Mode 0: Default mode with timer-based termination (terminates when 20-minute timer expires)
+  // Mode 1: Legacy mode without timer-based termination (for backwards compatibility)
   ModeVect getAvailableModes() override;
 
+  // Set the mode of the game.
   void setMode(game_mode_t m, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
@@ -81,7 +85,7 @@ class PitfallSettings : public RomSettings {
   reward_t m_reward;
   reward_t m_score;
   int m_lives;
-  bool m_terminateOnTimeout;
+  bool m_terminateOnTimeout;  // If true (default), game terminates when 20-minute timer expires
 };
 
 }  // namespace ale

--- a/src/ale/games/supported/Pitfall.hpp
+++ b/src/ale/games/supported/Pitfall.hpp
@@ -69,15 +69,6 @@ class PitfallSettings : public RomSettings {
 
   ActionVect getStartingActions() override;
 
-  // Returns a list of modes that the game can be played in.
-  // Mode 0: Default mode with timer-based termination (terminates when 20-minute timer expires)
-  // Mode 1: Legacy mode without timer-based termination (for backwards compatibility)
-  ModeVect getAvailableModes() override;
-
-  // Set the mode of the game.
-  void setMode(game_mode_t m, stella::System& system,
-               std::unique_ptr<StellaEnvironmentWrapper> environment) override;
-
   int lives() override { return isTerminal() ? 0 : m_lives; }
 
  private:
@@ -85,7 +76,6 @@ class PitfallSettings : public RomSettings {
   reward_t m_reward;
   reward_t m_score;
   int m_lives;
-  bool m_terminateOnTimeout;  // If true (default), game terminates when 20-minute timer expires
 };
 
 }  // namespace ale


### PR DESCRIPTION
It seems that the current code actually does not contain any intended detection for the Timeout.

`logo_timer` is non zero when the Activision Logo scrolls in the bottom left.

This is happening
1) At the beginning of the game before the player moved
2) When the player lost all lives
3) When the timer ran out 
Apparently the `logo_timer` was put here because the `lives_bytes` alone can temporarily take on a zero value during the death transition.

The current Termination condition `m_terminal` thus only checks if all lives have been lost. There is no detection for the timer reaching zero. I added two variables tracking minutes and seconds and added it to the termination condition.

I don't see how to reasonably add tests for this as the timer only exists
1) in ram what I am using now
2) Visually which is hard to use in a test.

I wrote a little script that records the last view frames of a episode to visually confirm that the timer runs out right before timeout termination which I can provide if needed.

Edit: I did not know that I can not add issue references in the title: #654, #268 