### PR TITLE
Fix statebuffer race

### DIFF
--- a/src/ale/vector/utils.hpp
+++ b/src/ale/vector/utils.hpp
@@ -142,33 +142,38 @@ namespace ale::vector {
               timesteps_(num_envs_),
               slot_ready_(num_envs_),
               count_(0),
-              sem_ready_(0),
-              sem_read_(1) {
+              sem_ready_(0),      // Initially no batches ready
+              sem_read_(1) {      // Allow one reader at a time
             for (size_t i = 0; i < num_envs_; ++i) {
                 slot_ready_[i].store(false, std::memory_order_relaxed);
             }
         }
 
         /**
-         * Write a timestep to the buffer.
+         * Write a timestep to the buffer
          * Multiple threads can write simultaneously — each env_id maps to a unique slot.
          */
         void write(const Timestep& timestep) {
+            // Place timestep at env_id position
             const int env_id = timestep.env_id;
             timesteps_[env_id] = timestep;
 
             if (ordered_mode_) {
+                // Atomically increment count and check if batch is ready
                 const auto old_count = count_.fetch_add(1);
                 if (old_count + 1 == batch_size_) {
+                    // Exactly one thread will see count == batch_size_ in ordered mode
                     sem_ready_.signal(1);
                 }
             } else {
-                // Mark slot ready BEFORE incrementing count.
+                // In unordered mode, mark slot ready BEFORE incrementing count.
                 // The release fence ensures the timestep write is visible
                 // before any reader sees this slot as ready.
                 slot_ready_[env_id].store(true, std::memory_order_release);
 
+                // Atomically increment count and check if batch is ready
                 const auto old_count = count_.fetch_add(1);
+                // Signal if we just crossed a batch boundary
                 if ((old_count + 1) / batch_size_ > old_count / batch_size_) {
                     sem_ready_.signal(1);
                 }
@@ -176,25 +181,33 @@ namespace ale::vector {
         }
 
         /**
-         * Collect timesteps when ready and return them.
+         * Collect timesteps when ready and return them
          *
          * @return Vector of timesteps
          */
         std::vector<Timestep> collect() {
+            // Wait until a batch is ready
             while (!sem_ready_.wait()) {}
+
+            // Acquire read semaphore
             while (!sem_read_.wait()) {}
 
+            // Collect the results
             std::vector<Timestep> result;
             result.reserve(batch_size_);
 
             if (ordered_mode_) {
+                // In ordered mode, read in env_id order
                 for (size_t i = 0; i < batch_size_; ++i) {
                     result.push_back(std::move(timesteps_[i]));
                 }
+
+                // Reset count for ordered mode (all items consumed)
                 count_.store(0);
             } else {
-                // Scan slots for ready flags. We're guaranteed at least batch_size_
-                // slots are ready because count_ was incremented after each flag was set.
+                // In unordered mode, scan slots for ready flags.
+                // We're guaranteed at least batch_size_ slots are ready
+                // because count_ was incremented after each flag was set.
                 size_t collected = 0;
                 while (collected < batch_size_) {
                     for (size_t i = 0; i < num_envs_ && collected < batch_size_; ++i) {
@@ -208,10 +221,14 @@ namespace ale::vector {
                         std::this_thread::yield();
                     }
                 }
+
+                // Atomically decrease count by batch_size_
                 count_.fetch_sub(batch_size_);
             }
 
+            // Release read semaphore
             sem_read_.signal(1);
+
             return result;
         }
 
@@ -229,8 +246,10 @@ namespace ale::vector {
         std::vector<Timestep> timesteps_;                 // Buffer for timesteps
         std::vector<std::atomic<bool>> slot_ready_;       // Per-slot readiness (unordered mode)
 
+        // Atomic counters for lock-free operations
         std::atomic<std::size_t> count_;                  // Current count of available timesteps
 
+        // Semaphores for coordination
         moodycamel::LightweightSemaphore sem_ready_;      // Signals when a batch is ready for collection
         moodycamel::LightweightSemaphore sem_read_;       // Controls access to read operations
     };

--- a/src/ale/vector/utils.hpp
+++ b/src/ale/vector/utils.hpp
@@ -5,6 +5,7 @@
 #include <atomic>
 #include <mutex>
 #include <memory>
+#include <thread>
 
 #ifndef MOODYCAMEL_DELETE_FUNCTION
     #define MOODYCAMEL_DELETE_FUNCTION = delete
@@ -122,11 +123,15 @@ namespace ale::vector {
     };
 
     /**
-     * StateBuffer handles the collection of timesteps from environments
+     * StateBuffer handles the collection of timesteps from environments.
      *
      * Two modes of operation:
      * 1. Ordered mode (batch_size == num_envs): Waits for all env_ids to be filled
-     * 2. Unordered mode (batch_size != num_envs): Uses circular buffer for continuous operation
+     * 2. Unordered mode (batch_size != num_envs): Uses per-slot ready flags
+     *
+     * Each env_id writes to its own fixed slot (timesteps_[env_id]) and sets
+     * a per-slot atomic ready flag. collect() scans for ready flags instead of
+     * reading sequential positions from a circular buffer.
      */
     class StateBuffer {
     public:
@@ -135,38 +140,35 @@ namespace ale::vector {
               num_envs_(num_envs),
               ordered_mode_(batch_size == num_envs),
               timesteps_(num_envs_),
+              slot_ready_(num_envs_),
               count_(0),
-              write_idx_(0),
-              read_idx_(0),
-              sem_ready_(0),      // Initially no batches ready
-              sem_read_(1) {      // Allow one reader at a time
+              sem_ready_(0),
+              sem_read_(1) {
+            for (size_t i = 0; i < num_envs_; ++i) {
+                slot_ready_[i].store(false, std::memory_order_relaxed);
+            }
         }
 
         /**
-         * Write a timestep to the buffer
-         * Multiple threads can write simultaneously
+         * Write a timestep to the buffer.
+         * Multiple threads can write simultaneously — each env_id maps to a unique slot.
          */
         void write(const Timestep& timestep) {
-            if (ordered_mode_) {
-                // In ordered mode, place timestep at env_id position
-                const int env_id = timestep.env_id;
-                timesteps_[env_id] = timestep;
+            const int env_id = timestep.env_id;
+            timesteps_[env_id] = timestep;
 
-                // Atomically increment count and check if batch is ready
+            if (ordered_mode_) {
                 const auto old_count = count_.fetch_add(1);
                 if (old_count + 1 == batch_size_) {
-                    // Exactly one thread will see count == batch_size_ in ordered mode
                     sem_ready_.signal(1);
                 }
             } else {
-                // In unordered mode, use circular buffer
-                // Each thread gets a unique index atomically
-                const auto idx = write_idx_.fetch_add(1) % num_envs_;
-                timesteps_[idx] = timestep;
+                // Mark slot ready BEFORE incrementing count.
+                // The release fence ensures the timestep write is visible
+                // before any reader sees this slot as ready.
+                slot_ready_[env_id].store(true, std::memory_order_release);
 
-                // Atomically increment count and check if batch is ready
                 const auto old_count = count_.fetch_add(1);
-                // Signal if we just crossed a batch boundary
                 if ((old_count + 1) / batch_size_ > old_count / batch_size_) {
                     sem_ready_.signal(1);
                 }
@@ -174,43 +176,42 @@ namespace ale::vector {
         }
 
         /**
-         * Collect timesteps when ready and return them
+         * Collect timesteps when ready and return them.
          *
          * @return Vector of timesteps
          */
         std::vector<Timestep> collect() {
-            // Wait until a batch is ready
             while (!sem_ready_.wait()) {}
-
-            // Acquire read semaphore
             while (!sem_read_.wait()) {}
 
-            // Collect the results
             std::vector<Timestep> result;
             result.reserve(batch_size_);
 
             if (ordered_mode_) {
-                // In ordered mode, read in env_id order
                 for (size_t i = 0; i < batch_size_; ++i) {
                     result.push_back(std::move(timesteps_[i]));
                 }
-
-                // Reset count for ordered mode (all items consumed)
                 count_.store(0);
             } else {
-                // In unordered mode, read from circular buffer
-                for (size_t i = 0; i < batch_size_; ++i) {
-                    const auto idx = read_idx_.fetch_add(1) % num_envs_;
-                    result.push_back(std::move(timesteps_[idx]));
+                // Scan slots for ready flags. We're guaranteed at least batch_size_
+                // slots are ready because count_ was incremented after each flag was set.
+                size_t collected = 0;
+                while (collected < batch_size_) {
+                    for (size_t i = 0; i < num_envs_ && collected < batch_size_; ++i) {
+                        if (slot_ready_[i].load(std::memory_order_acquire)) {
+                            slot_ready_[i].store(false, std::memory_order_relaxed);
+                            result.push_back(std::move(timesteps_[i]));
+                            ++collected;
+                        }
+                    }
+                    if (collected < batch_size_) {
+                        std::this_thread::yield();
+                    }
                 }
-
-                // Atomically decrease count by batch_size_
                 count_.fetch_sub(batch_size_);
             }
 
-            // Release read semaphore
             sem_read_.signal(1);
-
             return result;
         }
 
@@ -226,13 +227,10 @@ namespace ale::vector {
         const std::size_t num_envs_;                      // Number of environments
         const bool ordered_mode_;                         // Whether we're in ordered mode
         std::vector<Timestep> timesteps_;                 // Buffer for timesteps
+        std::vector<std::atomic<bool>> slot_ready_;       // Per-slot readiness (unordered mode)
 
-        // Atomic counters for lock-free operations
         std::atomic<std::size_t> count_;                  // Current count of available timesteps
-        std::atomic<std::size_t> write_idx_;              // Write position (for unordered mode)
-        std::atomic<std::size_t> read_idx_;               // Read position (for unordered mode)
 
-        // Semaphores for coordination
         moodycamel::LightweightSemaphore sem_ready_;      // Signals when a batch is ready for collection
         moodycamel::LightweightSemaphore sem_read_;       // Controls access to read operations
     };

--- a/tests/python/test_atari_vector_env.py
+++ b/tests/python/test_atari_vector_env.py
@@ -437,6 +437,92 @@ class TestVectorEnv:
         sync_envs.close()
         async_envs.close()
 
+    def test_batch_size_async_stress(
+        self,
+        env_id,
+        num_envs=8,
+        rollout_length=100,
+        num_trials=5,
+    ):
+        """Stress test for the async batch_size feature to catch race conditions.
+
+        Runs multiple short trials with different batch sizes and fresh environments
+        each time, maximizing the chance of triggering thread scheduling races in
+        the StateBuffer's unordered mode.
+        """
+        for batch_size in [2, 4]:
+            for trial in range(num_trials):
+                reset_seed = 100 + trial
+                action_seed = 200 + trial
+
+                sync_envs = gym.make_vec(env_id, num_envs)
+                async_envs = gym.make_vec(env_id, num_envs, batch_size=batch_size)
+
+                sync_envs.action_space.seed(action_seed)
+                actions = [sync_envs.action_space.sample() for _ in range(rollout_length)]
+                async_env_timestep = np.zeros(num_envs, dtype=np.int32)
+
+                sync_obs, sync_info = sync_envs.reset(seed=reset_seed)
+                sync_env_ids = sync_info.pop("env_id")
+                async_obs, async_info = async_envs.reset(seed=reset_seed)
+                async_env_ids = async_info.pop("env_id")
+
+                sync_observations = [sync_obs]
+                sync_rewards = [np.zeros(num_envs, dtype=np.int32)]
+                sync_terminations = [np.zeros(num_envs, dtype=bool)]
+                sync_truncations = [np.zeros(num_envs, dtype=bool)]
+                sync_infos = [sync_info]
+
+                for async_i, eid in enumerate(async_env_ids):
+                    async_t = async_env_timestep[eid]
+                    assert data_equivalence(
+                        sync_observations[async_t][eid], async_obs[async_i]
+                    ), f"Reset obs mismatch: batch_size={batch_size}, trial={trial}, env_id={eid}"
+                async_env_timestep[async_env_ids] += 1
+
+                for t in range(rollout_length):
+                    obs, rewards, terminations, truncations, info = sync_envs.step(actions[t])
+                    sync_observations.append(obs)
+                    sync_rewards.append(rewards)
+                    sync_terminations.append(terminations)
+                    sync_truncations.append(truncations)
+                    sync_env_ids = info.pop("env_id")
+                    sync_infos.append(info)
+
+                    async_actions = np.array(
+                        [
+                            actions[async_env_timestep[eid] - 1][eid]
+                            for eid in async_env_ids
+                        ]
+                    )
+                    (
+                        async_obs,
+                        async_rewards,
+                        async_terminations,
+                        async_truncations,
+                        async_info,
+                    ) = async_envs.step(async_actions)
+                    async_env_ids = async_info.pop("env_id")
+
+                    for async_i, eid in enumerate(async_env_ids):
+                        async_t = async_env_timestep[eid]
+                        assert data_equivalence(
+                            sync_observations[async_t][eid], async_obs[async_i]
+                        ), f"Obs mismatch: batch_size={batch_size}, trial={trial}, t={t}, env_id={eid}"
+                        assert data_equivalence(
+                            sync_rewards[async_t][eid], async_rewards[async_i]
+                        ), f"Reward mismatch: batch_size={batch_size}, trial={trial}, t={t}, env_id={eid}"
+                        assert data_equivalence(
+                            sync_terminations[async_t][eid], async_terminations[async_i]
+                        ), f"Termination mismatch: batch_size={batch_size}, trial={trial}, t={t}, env_id={eid}"
+                        assert data_equivalence(
+                            sync_truncations[async_t][eid], async_truncations[async_i]
+                        ), f"Truncation mismatch: batch_size={batch_size}, trial={trial}, t={t}, env_id={eid}"
+                    async_env_timestep[async_env_ids] += 1
+
+                sync_envs.close()
+                async_envs.close()
+
     def test_episodic_life_equivalence(self, env_id, num_envs=8):
         gym_envs = gym.vector.SyncVectorEnv(
             [

--- a/tests/python/test_atari_vector_env.py
+++ b/tests/python/test_atari_vector_env.py
@@ -459,11 +459,16 @@ class TestVectorEnv:
                 async_envs = gym.make_vec(env_id, num_envs, batch_size=batch_size)
 
                 sync_envs.action_space.seed(action_seed)
-                actions = [sync_envs.action_space.sample() for _ in range(rollout_length)]
+                actions = [
+                    sync_envs.action_space.sample() for _ in range(rollout_length)
+                ]
                 async_env_timestep = np.zeros(num_envs, dtype=np.int32)
 
                 sync_obs, sync_info = sync_envs.reset(seed=reset_seed)
                 sync_env_ids = sync_info.pop("env_id")
+                assert np.array_equal(
+                    sync_env_ids, np.arange(num_envs)
+                ), f"Sync reset env_ids out of order: batch_size={batch_size}, trial={trial}"
                 async_obs, async_info = async_envs.reset(seed=reset_seed)
                 async_env_ids = async_info.pop("env_id")
 
@@ -481,12 +486,17 @@ class TestVectorEnv:
                 async_env_timestep[async_env_ids] += 1
 
                 for t in range(rollout_length):
-                    obs, rewards, terminations, truncations, info = sync_envs.step(actions[t])
+                    obs, rewards, terminations, truncations, info = sync_envs.step(
+                        actions[t]
+                    )
                     sync_observations.append(obs)
                     sync_rewards.append(rewards)
                     sync_terminations.append(terminations)
                     sync_truncations.append(truncations)
                     sync_env_ids = info.pop("env_id")
+                    assert np.array_equal(
+                        sync_env_ids, np.arange(num_envs)
+                    ), f"Sync step env_ids out of order: batch_size={batch_size}, trial={trial}, t={t}"
                     sync_infos.append(info)
 
                     async_actions = np.array(


### PR DESCRIPTION
The test failing in https://github.com/Farama-Foundation/Arcade-Learning-Environment/pull/668 is actually due to a flakey race condition that has failed in previous runs of CI - on master — on Windows, in CI run 20594583659 from December 30.

I think, in unordered mode, write_idx_.fetch_add(1) assigns a circular buffer position, but the actual data write happens after the position is claimed. Another thread can finish its write and increment count_ past the batch boundary, causing collect() to read a position that the first thread hasn't written to yet.

I was able to reproduce on my machine with the following test on the current codebase, but it should pass currently.

