### PR TITLE
Add python 3.14 support

### DIFF
--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -185,10 +185,6 @@ jobs:
             python: '3.14'
             wheel-name: 'cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64'
             arch: 'x86_64'
-          - runs-on: ubuntu-latest
-            python: '3.14t'
-            wheel-name: 'cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64'
-            arch: 'x86_64'
 
           - runs-on: ubuntu-24.04-arm
             python: '3.10'
@@ -209,10 +205,6 @@ jobs:
           - runs-on: ubuntu-24.04-arm
             python: '3.14'
             wheel-name: 'cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64'
-            arch: 'aarch64'
-          - runs-on: ubuntu-24.04-arm
-            python: '3.14t'
-            wheel-name: 'cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64'
             arch: 'aarch64'
 
           - runs-on: windows-latest
@@ -260,10 +252,6 @@ jobs:
           - runs-on: macos-latest
             python: '3.14'
             wheel-name: 'cp314-cp314-macosx_13_0_arm64'
-            arch: arm64
-          - runs-on: macos-latest
-            python: '3.14t'
-            wheel-name: 'cp314-cp314t-macosx_13_0_arm64'
             arch: arm64
 
     runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -142,7 +142,7 @@ jobs:
         run: ./scripts/download_unpack_roms.sh
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.0
+        uses: pypa/cibuildwheel@v3.4
         env:
           CIBW_ARCHS: "${{ matrix.arch }}"
 
@@ -169,68 +169,100 @@ jobs:
             python: '3.10'
             wheel-name: 'cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64'
             arch: 'x86_64'
-          - runs-on: ubuntu-latest
-            python: '3.11'
-            wheel-name: 'cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64'
-            arch: 'x86_64'
-          - runs-on: ubuntu-latest
-            python: '3.12'
-            wheel-name: 'cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64'
-            arch: 'x86_64'
+#          - runs-on: ubuntu-latest
+#            python: '3.11'
+#            wheel-name: 'cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64'
+#            arch: 'x86_64'
+#          - runs-on: ubuntu-latest
+#            python: '3.12'
+#            wheel-name: 'cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64'
+#            arch: 'x86_64'
           - runs-on: ubuntu-latest
             python: '3.13'
             wheel-name: 'cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64'
+            arch: 'x86_64'
+          - runs-on: ubuntu-latest
+            python: '3.14'
+            wheel-name: 'cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64'
+            arch: 'x86_64'
+          - runs-on: ubuntu-latest
+            python: '3.14t'
+            wheel-name: 'cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64'
             arch: 'x86_64'
 
           - runs-on: ubuntu-24.04-arm
             python: '3.10'
             wheel-name: 'cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64'
             arch: 'aarch64'
-          - runs-on: ubuntu-24.04-arm
-            python: '3.11'
-            wheel-name: 'cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64'
-            arch: 'aarch64'
-          - runs-on: ubuntu-24.04-arm
-            python: '3.12'
-            wheel-name: 'cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64'
-            arch: 'aarch64'
+#          - runs-on: ubuntu-24.04-arm
+#            python: '3.11'
+#            wheel-name: 'cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64'
+#            arch: 'aarch64'
+#          - runs-on: ubuntu-24.04-arm
+#            python: '3.12'
+#            wheel-name: 'cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64'
+#            arch: 'aarch64'
           - runs-on: ubuntu-24.04-arm
             python: '3.13'
             wheel-name: 'cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64'
+            arch: 'aarch64'
+          - runs-on: ubuntu-24.04-arm
+            python: '3.14'
+            wheel-name: 'cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64'
+            arch: 'aarch64'
+          - runs-on: ubuntu-24.04-arm
+            python: '3.14t'
+            wheel-name: 'cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64'
             arch: 'aarch64'
 
           - runs-on: windows-latest
             python: '3.10'
             wheel-name: 'cp310-cp310-win_amd64'
             arch: AMD64
-          - runs-on: windows-latest
-            python: '3.11'
-            wheel-name: 'cp311-cp311-win_amd64'
-            arch: AMD64
-          - runs-on: windows-latest
-            python: '3.12'
-            wheel-name: 'cp312-cp312-win_amd64'
-            arch: AMD64
+#          - runs-on: windows-latest
+#            python: '3.11'
+#            wheel-name: 'cp311-cp311-win_amd64'
+#            arch: AMD64
+#          - runs-on: windows-latest
+#            python: '3.12'
+#            wheel-name: 'cp312-cp312-win_amd64'
+#            arch: AMD64
           - runs-on: windows-latest
             python: '3.13'
             wheel-name: 'cp313-cp313-win_amd64'
+            arch: AMD64
+          - runs-on: windows-latest
+            python: '3.14'
+            wheel-name: 'cp314-cp314-win_amd64'
+            arch: AMD64
+          - runs-on: windows-latest
+            python: '3.14t'
+            wheel-name: 'cp314-cp314t-win_amd64'
             arch: AMD64
 
           - runs-on: macos-latest
             python: '3.10'
             wheel-name: 'cp310-cp310-macosx_13_0_arm64'
             arch: arm64
-          - runs-on: macos-latest
-            python: '3.11'
-            wheel-name: 'cp311-cp311-macosx_13_0_arm64'
-            arch: arm64
-          - runs-on: macos-latest
-            python: '3.12'
-            wheel-name: 'cp312-cp312-macosx_13_0_arm64'
-            arch: arm64
+#          - runs-on: macos-latest
+#            python: '3.11'
+#            wheel-name: 'cp311-cp311-macosx_13_0_arm64'
+#            arch: arm64
+#          - runs-on: macos-latest
+#            python: '3.12'
+#            wheel-name: 'cp312-cp312-macosx_13_0_arm64'
+#            arch: arm64
           - runs-on: macos-latest
             python: '3.13'
             wheel-name: 'cp313-cp313-macosx_13_0_arm64'
+            arch: arm64
+          - runs-on: macos-latest
+            python: '3.14'
+            wheel-name: 'cp314-cp314-macosx_13_0_arm64'
+            arch: arm64
+          - runs-on: macos-latest
+            python: '3.14t'
+            wheel-name: 'cp314-cp314t-macosx_13_0_arm64'
             arch: arm64
 
     runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -235,10 +235,11 @@ jobs:
             python: '3.14'
             wheel-name: 'cp314-cp314-win_amd64'
             arch: AMD64
-          - runs-on: windows-latest
-            python: '3.14t'
-            wheel-name: 'cp314-cp314t-win_amd64'
-            arch: AMD64
+            # Jax doesn't support 3.14t on Windows
+#          - runs-on: windows-latest
+#            python: '3.14t'
+#            wheel-name: 'cp314-cp314t-win_amd64'
+#            arch: AMD64
 
           - runs-on: macos-latest
             python: '3.10'

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ pip install ale-py
 ```
 Note: Make sure you're using an up-to-date version of `pip` or the installation may fail.
 
-Note: Free-threaded CPython (the `t` ABI, e.g. `python3.14t`) is supported on Linux and macOS but not on Windows, because `jaxlib` does not publish a Windows free-threading wheel.
+Note: Free-threaded CPython (the `t` ABI, e.g. `python3.14t`) aren't supported as OpenCV doesn't build compatible wheels on any system which is necessary for preprocessing. We will look to add support when OpenCV does.
 
 You can now import the ALE in your Python projects with providing a direct interface to Stella for interacting with games
 ```python

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ pip install ale-py
 ```
 Note: Make sure you're using an up-to-date version of `pip` or the installation may fail.
 
+Note: Free-threaded CPython (the `t` ABI, e.g. `python3.14t`) is supported on Linux and macOS but not on Windows, because `jaxlib` does not publish a Windows free-threading wheel.
+
 You can now import the ALE in your Python projects with providing a direct interface to Stella for interacting with games
 ```python
 from ale_py import ALEInterface, roms

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,8 +98,9 @@ cmake.args = [
 ]
 
 [tool.cibuildwheel]
-# Skip 32-bit wheels, PyPy, musllinux & 3.13t (free-threading is only supported on 3.14+)
-skip = ["*-win32", "*i686", "*-musllinux*", "cp313t-*"]
+# Skip 32-bit wheels, PyPy, musllinux, cp313t (free-threading was experimental in 3.13),
+# and cp314t-win_amd64 (jaxlib does not publish a Windows free-threading wheel).
+skip = ["*-win32", "*i686", "*-musllinux*", "cp313t-*", "cp314t-win_amd64"]
 
 build-frontend = "build"
 manylinux-x86_64-image = "manylinux-x86_64-vcpkg:latest"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "scikit-build-core>=0.10",
-    "nanobind>=2.1.0",
+    "nanobind>=2.5.0",
     "jax >= 0.4.31; sys_platform == 'win32' or sys_platform == 'linux'"
 ]
 build-backend = "scikit_build_core.build"
@@ -32,6 +32,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
@@ -99,6 +100,9 @@ cmake.args = [
 [tool.cibuildwheel]
 # Skip 32-bit wheels, PyPy & musllinux
 skip = ["*-win32", "*i686", "*-musllinux*"]
+
+# Build free-threaded CPython wheels (3.13t, 3.14t) in addition to standard builds
+enable = ["cpython-freethreading"]
 
 build-frontend = "build"
 manylinux-x86_64-image = "manylinux-x86_64-vcpkg:latest"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ cmake.args = [
 [tool.cibuildwheel]
 # Skip 32-bit wheels, PyPy, musllinux, cp313t (free-threading was experimental in 3.13),
 # and cp314t-win_amd64 (jaxlib does not publish a Windows free-threading wheel).
-skip = ["*-win32", "*i686", "*-musllinux*", "cp313t-*", "cp314t-win_amd64"]
+skip = ["*-win32", "*i686", "*-musllinux*", "cp313t-*", "cp314t-*"]
 
 build-frontend = "build"
 manylinux-x86_64-image = "manylinux-x86_64-vcpkg:latest"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,11 +98,8 @@ cmake.args = [
 ]
 
 [tool.cibuildwheel]
-# Skip 32-bit wheels, PyPy & musllinux
-skip = ["*-win32", "*i686", "*-musllinux*"]
-
-# Build free-threaded CPython wheels (3.13t, 3.14t) in addition to standard builds
-enable = ["cpython-freethreading"]
+# Skip 32-bit wheels, PyPy, musllinux & 3.13t (free-threading is only supported on 3.14+)
+skip = ["*-win32", "*i686", "*-musllinux*", "cp313t-*"]
 
 build-frontend = "build"
 manylinux-x86_64-image = "manylinux-x86_64-vcpkg:latest"

--- a/src/ale/python/CMakeLists.txt
+++ b/src/ale/python/CMakeLists.txt
@@ -6,8 +6,10 @@ execute_process(
     OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE nanobind_ROOT)
 find_package(nanobind CONFIG REQUIRED)
 
-# Use nanobind_add_module for proper scikit-build-core integration
-nanobind_add_module(_ale_py MODULE ale_python_interface.cpp)
+# Use nanobind_add_module for proper scikit-build-core integration.
+# FREE_THREADED marks the module Py_MOD_GIL_NOT_USED so it loads without
+# re-enabling the GIL on free-threaded CPython builds (3.13t, 3.14t, ...).
+nanobind_add_module(_ale_py MODULE FREE_THREADED ale_python_interface.cpp)
 if (BUILD_VECTOR_LIB AND BUILD_VECTOR_XLA_LIB)
     # XLA Integration setup
     message(STATUS "Python Executable: '${Python_EXECUTABLE}'")


### PR DESCRIPTION
This PR adds support for 3.14
Originally, this PR added support for 3.14t (a thread free version with no GIL), however found that for windows, Jax doesn't have 3.14t support and OpenCV doesn't support any OS