### PR TITLE
Fix warnings produced during building

### DIFF
--- a/src/ale/games/supported/BasicMath.cpp
+++ b/src/ale/games/supported/BasicMath.cpp
@@ -103,7 +103,7 @@ void BasicMathSettings::setMode(
     std::unique_ptr<StellaEnvironmentWrapper> environment) {
   if (isModeSupported(m)) {
     // Press select until the correct mode is reached.
-    while (readRam(&system, 0xc5) != m) {
+    while (readRam(&system, 0xc5) != static_cast<int>(m)) {
       environment->pressSelect(2);
     }
 

--- a/src/ale/games/supported/Casino.cpp
+++ b/src/ale/games/supported/Casino.cpp
@@ -132,7 +132,7 @@ void CasinoSettings::setMode(
     int mode = readRam(&system, 0xd4);
 
     // Press select until the correct mode is reached for single player only.
-    while (mode != m) {
+    while (mode != static_cast<int>(m)) {
       environment->pressSelect(2);
       mode = readRam(&system, 0xd4);
     }

--- a/src/ale/games/supported/FlagCapture.cpp
+++ b/src/ale/games/supported/FlagCapture.cpp
@@ -105,7 +105,7 @@ void FlagCaptureSettings::setMode(
     std::unique_ptr<StellaEnvironmentWrapper> environment) {
   if (isModeSupported(m)) {
     // Press select until the correct mode is reached for single player only.
-    while (readRam(&system, 0xd6) != m) {
+    while (readRam(&system, 0xd6) != static_cast<int>(m)) {
       environment->pressSelect(2);
     }
 

--- a/src/ale/games/supported/Klax.cpp
+++ b/src/ale/games/supported/Klax.cpp
@@ -148,7 +148,7 @@ void KlaxSettings::setMode(
     std::unique_ptr<StellaEnvironmentWrapper> environment) {
   if (m < 3) {
     // Press select until the correct mode is reached.
-    while (readMappedRam(&system, 0xf0ea) != m) {
+    while (readMappedRam(&system, 0xf0ea) != static_cast<int>(m)) {
       environment->pressSelect(2);
     }
 

--- a/src/ale/games/supported/Klax.hpp
+++ b/src/ale/games/supported/Klax.hpp
@@ -60,7 +60,7 @@ class KlaxSettings : public RomSettings {
   void setMode(game_mode_t m, stella::System& system,
                std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
-  ActionVect getStartingActions();
+  ActionVect getStartingActions() override;
 
  private:
   bool m_terminal;

--- a/src/ale/games/supported/MarioBros.cpp
+++ b/src/ale/games/supported/MarioBros.cpp
@@ -109,7 +109,7 @@ void MarioBrosSettings::setMode(
     std::unique_ptr<StellaEnvironmentWrapper> environment) {
   if (isModeSupported(m)) {
     // Press select until the correct mode is reached.
-    while (readRam(&system, 0x80) != m) {
+    while (readRam(&system, 0x80) != static_cast<int>(m)) {
       environment->pressSelect(5);
     }
 

--- a/src/ale/games/supported/MrDo.cpp
+++ b/src/ale/games/supported/MrDo.cpp
@@ -102,7 +102,7 @@ void MrDoSettings::setMode(
     std::unique_ptr<StellaEnvironmentWrapper> environment) {
   if (m < 4) {
     // Press select until the correct mode is reached.
-    while (readRam(&system, 0x80) != m) { environment->pressSelect(5); }
+    while (readRam(&system, 0x80) != static_cast<int>(m)) { environment->pressSelect(5); }
 
     // Reset the environment to apply changes.
     environment->softReset();

--- a/src/ale/games/supported/Othello.hpp
+++ b/src/ale/games/supported/Othello.hpp
@@ -34,33 +34,33 @@ class OthelloSettings : public RomSettings {
  public:
   OthelloSettings();
 
-  virtual void reset();
+  void reset() override;
 
-  virtual bool isTerminal() const;
+  bool isTerminal() const override;
 
-  virtual reward_t getReward() const;
+  reward_t getReward() const override;
 
-  virtual const char* rom() const { return "othello"; }
+  const char* rom() const override { return "othello"; }
 
   // The md5 checksum of the ROM that this game supports
   const char* md5() const override { return "113cd09c9771ac278544b7e90efe7df2"; }
 
-  virtual RomSettings* clone() const;
+  RomSettings* clone() const override;
 
-  virtual bool isMinimal(const Action& a) const;
+  bool isMinimal(const Action& a) const override;
 
-  virtual void step(const stella::System& system);
+  void step(const stella::System& system) override;
 
-  virtual void saveState(stella::Serializer& ser);
+  void saveState(stella::Serializer& ser) override;
 
-  virtual void loadState(stella::Deserializer& ser);
+  void loadState(stella::Deserializer& ser) override;
 
-  virtual ModeVect getAvailableModes();
+  ModeVect getAvailableModes() override;
 
-  virtual void setMode(game_mode_t m, stella::System& system,
-                       std::unique_ptr<StellaEnvironmentWrapper> environment);
+  void setMode(game_mode_t m, stella::System& system,
+               std::unique_ptr<StellaEnvironmentWrapper> environment) override;
 
-  virtual DifficultyVect getAvailableDifficulties();
+  DifficultyVect getAvailableDifficulties() override;
 
  private:
   bool m_terminal;

--- a/src/ale/games/supported/SpaceWar.cpp
+++ b/src/ale/games/supported/SpaceWar.cpp
@@ -111,7 +111,7 @@ void SpaceWarSettings::setMode(
     std::unique_ptr<StellaEnvironmentWrapper> environment) {
   if (isModeSupported(m)) {
     // Press select until the correct mode is reached.
-    while (getDecimalScore(0xa7, &system) != m) {
+    while (getDecimalScore(0xa7, &system) != static_cast<int>(m)) {
       environment->pressSelect(2);
     }
 

--- a/src/ale/games/supported/Turmoil.cpp
+++ b/src/ale/games/supported/Turmoil.cpp
@@ -107,7 +107,7 @@ void TurmoilSettings::setMode(
     std::unique_ptr<StellaEnvironmentWrapper> environment) {
   if (m < 9) {
     // Press select until the correct mode is reached.
-    while (readRam(&system, 0xea) != m) { environment->pressSelect(2); }
+    while (readRam(&system, 0xea) != static_cast<int>(m)) { environment->pressSelect(2); }
 
     // Reset the environment to apply changes.
     environment->softReset();

--- a/src/ale/games/supported/VideoCheckers.cpp
+++ b/src/ale/games/supported/VideoCheckers.cpp
@@ -133,7 +133,7 @@ void VideoCheckersSettings::setMode(
       m += 6;
     }
 
-    while (readRam(&system, 0xF6) != m) { environment->pressSelect(1); }
+    while (readRam(&system, 0xF6) != static_cast<int>(m)) { environment->pressSelect(1); }
 
     // reset the environment to apply changes.
     environment->softReset();

--- a/src/ale/games/supported/VideoCube.cpp
+++ b/src/ale/games/supported/VideoCube.cpp
@@ -87,7 +87,7 @@ void VideoCubeSettings::step(const System& system) {
   // feel quite right that agents should be punished for exploring.  However
   // we're still capturing this data should it be required during a later
   // rethink of the reward function.
-  int turnsTaken = getDecimalScore(0xdf, 0xe0, 0xe1, &system);
+  // int turnsTaken = getDecimalScore(0xdf, 0xe0, 0xe1, &system);
 
   // We need to go through each face to see if the colour blocks match, and
   // count the total numbers of matched faces.

--- a/src/ale/python/ale_vector_xla_interface.cpp
+++ b/src/ale/python/ale_vector_xla_interface.cpp
@@ -65,7 +65,7 @@ ffi::Error XLAResetImpl(
 
         if (timesteps.empty()) {
             return ffi::Error::Internal("No timesteps received after step");
-        } else if (timesteps.size() != vectorizer->get_batch_size()) {
+        } else if (timesteps.size() != static_cast<size_t>(vectorizer->get_batch_size())) {
             return ffi::Error::Internal("Number of timesteps is wrong");
         }
 
@@ -207,7 +207,7 @@ ffi::Error XLAResetGPUImpl(
 
         if (timesteps.empty()) {
             return ffi::Error::Internal("No timesteps received after reset (GPU)");
-        } else if (timesteps.size() != vectorizer->get_batch_size()) {
+        } else if (timesteps.size() != static_cast<size_t>(vectorizer->get_batch_size())) {
             return ffi::Error::Internal("Number of timesteps is wrong (GPU)");
         }
 
@@ -367,7 +367,7 @@ ffi::Error XLAStepImpl(
 
         if (timesteps.empty()) {
             return ffi::Error::Internal("No timesteps received after step");
-        } else if (timesteps.size() != vectorizer->get_batch_size()) {
+        } else if (timesteps.size() != static_cast<size_t>(vectorizer->get_batch_size())) {
             return ffi::Error::Internal("Number of timesteps is wrong");
         }
 

--- a/src/ale/vector/preprocessed_env.hpp
+++ b/src/ale/vector/preprocessed_env.hpp
@@ -71,13 +71,13 @@ namespace ale::vector {
             const int seed = -1
         ) : env_id_(env_id),
             rom_path_(rom_path),
-            obs_frame_height_(obs_height),
-            obs_frame_width_(obs_width),
-            frame_skip_(frame_skip),
-            maxpool_(maxpool),
             obs_format_(obs_format),
             channels_per_frame_(obs_format == ObsFormat::Grayscale ? 1 : 3),
+            obs_frame_height_(obs_height),
+            obs_frame_width_(obs_width),
             stack_num_(stack_num),
+            frame_skip_(frame_skip),
+            maxpool_(maxpool),
             noop_max_(noop_max),
             use_fire_reset_(use_fire_reset),
             episodic_life_(episodic_life),
@@ -209,7 +209,7 @@ namespace ale::vector {
         void step() {
             // Convert the current action to Action and Paddle Strength
             const int action_id = current_action_.action_id;
-            if (action_id < 0 || action_id >= action_set_.size()) {
+            if (action_id < 0 || static_cast<size_t>(action_id) >= action_set_.size()) {
                 throw std::out_of_range("Stepping sub-environment with action_id: " + std::to_string(action_id) + ", however, this is either less than zero or greater than available actions (" + std::to_string(action_set_.size()) + ")");
             }
             const Action action = action_set_[action_id];


### PR DESCRIPTION
Running `pip install -v .` will produce a number of warnings which makes it hard to realise if there are important issues hidden within the warnings. 
Therefore, this PR aims to fix several of the basic warnings produced during the build process. We haven't address any issues within the stella based code or from jax.