### PR TITLE
Make vector XLA builds works across CUDA and non-CUDA environments

### DIFF
--- a/src/ale/CMakeLists.txt
+++ b/src/ale/CMakeLists.txt
@@ -16,8 +16,11 @@ set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
 add_compile_options(
   "$<$<CONFIG:RELEASE>:-O3>"
   "$<$<CONFIG:DEBUG>:-O0>"
-  "$<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-Wall>"
-  "$<$<CXX_COMPILER_ID:MSVC>:/W4>")
+  "$<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CXX_COMPILER_ID:GNU,Clang,AppleClang>>:-Wall>"
+  "$<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CXX_COMPILER_ID:MSVC>>:/W4>"
+  "$<$<COMPILE_LANGUAGE:CUDA>:-Xcudafe=--display_error_number>"
+  "$<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CXX_COMPILER_ID:GNU,Clang,AppleClang>>:-Xcompiler=-Wall,-Wextra>"
+  "$<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CXX_COMPILER_ID:MSVC>>:-Xcompiler=/W4>")
 
 # ale object containing source files
 add_library(ale OBJECT)

--- a/src/ale/python/CMakeLists.txt
+++ b/src/ale/python/CMakeLists.txt
@@ -22,24 +22,33 @@ if (BUILD_VECTOR_LIB AND BUILD_VECTOR_XLA_LIB)
     )
     message(STATUS "XLA include directory: '${XLA_DIR}'")
 
-    # Find CUDA toolkit for headers and linking (optional - XLA disabled if not found)
+    target_sources(_ale_py PRIVATE ale_vector_python_interface.cpp ale_vector_xla_interface.cpp)
+    target_include_directories(_ale_py PRIVATE ${XLA_DIR})
+    target_compile_definitions(_ale_py PRIVATE BUILD_VECTOR_LIB BUILD_VECTOR_XLA_LIB)
+
+    # Find CUDA toolkit for headers and linking (optional - GPU XLA disabled if not found)
     find_package(CUDAToolkit QUIET)
 
-    if (CUDAToolkit_FOUND)
+    # GPU XLA handlers in ale_vector_xla_interface.cpp are guarded by __CUDACC__,
+    # so the file must be compiled as CUDA when GPU support is enabled.
+    include(CheckLanguage)
+    check_language(CUDA)  # Sets CMAKE_CUDA_COMPILER.
+
+    if (CUDAToolkit_FOUND AND CMAKE_CUDA_COMPILER)
+        enable_language(CUDA)
         message(STATUS "CUDA Toolkit found: ${CUDAToolkit_VERSION}")
-        target_sources(_ale_py PRIVATE ale_vector_python_interface.cpp ale_vector_xla_interface.cpp)
-        target_include_directories(_ale_py PUBLIC ${XLA_DIR})
+        message(STATUS "CUDA compiler found: ${CMAKE_CUDA_COMPILER}")
+        set_source_files_properties(ale_vector_xla_interface.cpp PROPERTIES LANGUAGE CUDA)
         target_include_directories(_ale_py PRIVATE ${CUDAToolkit_INCLUDE_DIRS})
-        target_compile_definitions(_ale_py PRIVATE BUILD_VECTOR_LIB BUILD_VECTOR_XLA_LIB)
         target_link_libraries(_ale_py PRIVATE CUDA::cudart)
 
         set_target_properties(_ale_py PROPERTIES
             POSITION_INDEPENDENT_CODE ON
         )
+    elseif (CUDAToolkit_FOUND)
+        message(WARNING "CUDA Toolkit found but no CUDA compiler detected - building CPU XLA only. Install nvcc to enable GPU XLA handlers.")
     else()
-        message(WARNING "CUDA Toolkit not found - disabling XLA support. Install CUDA Toolkit to enable XLA.")
-        target_sources(_ale_py PRIVATE ale_vector_python_interface.cpp)
-        target_compile_definitions(_ale_py PRIVATE BUILD_VECTOR_LIB)
+        message(WARNING "CUDA Toolkit not found - building CPU XLA only. Install CUDA Toolkit and nvcc to enable GPU XLA handlers.")
     endif()
 elseif (BUILD_VECTOR_LIB)
     target_sources(_ale_py PRIVATE ale_vector_python_interface.cpp)

--- a/src/ale/python/CMakeLists.txt
+++ b/src/ale/python/CMakeLists.txt
@@ -40,7 +40,14 @@ if (BUILD_VECTOR_LIB AND BUILD_VECTOR_XLA_LIB)
         message(STATUS "CUDA compiler found: ${CMAKE_CUDA_COMPILER}")
         set_source_files_properties(ale_vector_xla_interface.cpp PROPERTIES LANGUAGE CUDA)
         target_include_directories(_ale_py PRIVATE ${CUDAToolkit_INCLUDE_DIRS})
-        target_link_libraries(_ale_py PRIVATE CUDA::cudart)
+        if (WIN32 AND TARGET CUDA::cudart_static)
+            # Prefer static cudart on Windows to avoid runtime PATH/DLL lookup issues in CI and local imports.
+            target_link_libraries(_ale_py PRIVATE CUDA::cudart_static)
+        elseif (TARGET CUDA::cudart)
+            target_link_libraries(_ale_py PRIVATE CUDA::cudart)
+        else()
+            message(FATAL_ERROR "Neither CUDA::cudart_static nor CUDA::cudart targets are available.")
+        endif()
 
         set_target_properties(_ale_py PROPERTIES
             POSITION_INDEPENDENT_CODE ON


### PR DESCRIPTION
## Summary
This PR aligns vector XLA build outputs with runtime expectations across different machines:
1. CUDA-capable builds expose both CPU and CUDA XLA handlers.
2. Non-CUDA builds retain CPU XLA support instead of dropping XLA handlers.

## What Changed
Build-system-only change in [src/ale/python/CMakeLists.txt](src/ale/python/CMakeLists.txt).

1. Always include vector XLA sources/definitions when vector + XLA are enabled.
2. Gate GPU-specific build steps on both:
- CUDA toolkit found
- CUDA compiler detected
3. Compile the XLA interface source as CUDA only in the GPU-capable path.
4. Keep fallback builds CPU-XLA-only with clearer warnings.

## Validation

1. GPU path (real CUDA machine):
- Vector+XLA build succeeds
- CPU and CUDA handlers are present
- CPU and CUDA FFI registrations succeed
- `tests/python/test_atari_vector_xla.py::test_seeding` passes with `JAX_PLATFORMS=cuda,cpu`
2. CPU-only fallback path (simulated by disabling CUDA toolkit discovery):
- Build succeeds
- CPU handler present, CUDA handler absent
- CPU FFI registration succeeds
- `tests/python/test_atari_vector_xla.py::test_seeding` passes with `JAX_PLATFORMS=cpu`

I include a script I used to test below.

**Outcomes before this change:**
1. RuntimeError: Expected VectorXLAResetGPU in GPU build
2. RuntimeError: Expected CPU XLA handler in fallback build

**Outcomes after this change:**
It works.

### Script used for testing
```
#!/usr/bin/env bash
set -euo pipefail

echo "=== Environment prep ==="
source .venv/bin/activate
python -m pip install -U pip setuptools wheel
python -m pip install -U scikit-build-core nanobind
python -m pip install -U "jax[cuda12]"

echo "=== GPU-enabled build (real CUDA path) ==="
SKBUILD_BUILD_DIR=build-gpu CMAKE_ARGS="-DBUILD_VECTOR_LIB=ON -DBUILD_VECTOR_XLA_LIB=ON" \
python -m pip install -v -e ".[test]" --no-cache-dir

python - <<'PY'
import ale_py, jax
print("GPU build module:", ale_py._ale_py.__file__)
print("VectorXLAReset exists:", hasattr(ale_py._ale_py, "VectorXLAReset"))
print("VectorXLAResetGPU exists:", hasattr(ale_py._ale_py, "VectorXLAResetGPU"))
jax.ffi.register_ffi_target("ale_check_cpu", ale_py._ale_py.VectorXLAReset(), platform="cpu")
print("CPU target registration: OK")
if hasattr(ale_py._ale_py, "VectorXLAResetGPU"):
    jax.ffi.register_ffi_target("ale_check_cuda", ale_py._ale_py.VectorXLAResetGPU(), platform="CUDA")
    print("CUDA target registration: OK")
else:
    raise RuntimeError("Expected VectorXLAResetGPU in GPU build")
PY

JAX_PLATFORMS=cuda,cpu python -m pytest -q tests/python/test_atari_vector_xla.py::test_seeding

echo "=== CPU-only XLA fallback build (simulate no CUDA toolkit) ==="
SKBUILD_BUILD_DIR=build-nocuda CMAKE_ARGS="-DBUILD_VECTOR_LIB=ON -DBUILD_VECTOR_XLA_LIB=ON -DCMAKE_DISABLE_FIND_PACKAGE_CUDAToolkit=ON" \
python -m pip install -v -e ".[test]" --no-cache-dir

python - <<'PY'
import ale_py, jax
print("Fallback build module:", ale_py._ale_py.__file__)
print("VectorXLAReset exists:", hasattr(ale_py._ale_py, "VectorXLAReset"))
print("VectorXLAResetGPU exists:", hasattr(ale_py._ale_py, "VectorXLAResetGPU"))
if not hasattr(ale_py._ale_py, "VectorXLAReset"):
    raise RuntimeError("Expected CPU XLA handler in fallback build")
if hasattr(ale_py._ale_py, "VectorXLAResetGPU"):
    raise RuntimeError("Did not expect GPU XLA handler in fallback build")
jax.ffi.register_ffi_target("ale_check_cpu_fallback", ale_py._ale_py.VectorXLAReset(), platform="cpu")
print("CPU target registration in fallback build: OK")
PY

JAX_PLATFORMS=cpu python -m pytest -q tests/python/test_atari_vector_xla.py::test_seeding

echo "=== Done: both GPU and CPU-only fallback paths validated ==="
```
