### PR TITLE
Change reference of old "master" branch & old repo path

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -2,7 +2,7 @@ name: Build main branch documentation website
 
 on:
   push:
-    branches: [master]
+    branches: [main]
 
 permissions:
   contents: write

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -1,5 +1,5 @@
 # Sanitizers and memory checkers for detecting threading issues and memory leaks.
-# TSan and ASan run on every PR and push to master.
+# TSan and ASan run on every PR and push to main.
 # Valgrind Memcheck runs on releases, manual dispatch, or when a PR has the
 # "run-valgrind" label. Valgrind Helgrind runs on releases only.
 
@@ -10,7 +10,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
   release:
     types: [published]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ We welcome all forms of contributions! Please give the following a read before s
 
 ## Pull Requests
 
-1. Fork the repo and create your branch from master.
+1. Fork the repo and create your branch from main.
 2. If you've added code that should be tested, add tests.
 3. If you've changed APIs, update the documentation.
 4. Ensure the test suite passes. e.g., `cmake --build . --config Release --target test`

--- a/docs/env-spec.md
+++ b/docs/env-spec.md
@@ -4,7 +4,7 @@ This section provides additional information regarding the environment implement
 
 ## Available Actions
 
-The following regular actions are defined by the `Action` enum in [`common/Constants.h`](https://github.com/mgbellemare/Arcade-Learning-Environment/blob/master/src/common/Constants.h). These can also be accessed in Python through the enum object `ale_py.Action`. These actions are interpreted by ALE as follows:
+The following regular actions are defined by the `Action` enum in [`common/Constants.h`](https://github.com/Farama-Foundation/Arcade-Learning-Environment/blob/master/src/common/Constants.h). These can also be accessed in Python through the enum object `ale_py.Action`. These actions are interpreted by ALE as follows:
 
 | Index | Action                  | Description                                                                     |
 |-------|-------------------------|---------------------------------------------------------------------------------|

--- a/docs/multi-agent-environments.md
+++ b/docs/multi-agent-environments.md
@@ -33,7 +33,7 @@ multi-agent-environments/warlords
 multi-agent-environments/wizard_of_wor
 ```
 
-The Atari environments are based off the [Arcade Learning Environment](https://github.com/mgbellemare/Arcade-Learning-Environment). This environment was instrumental in the development of modern reinforcement learning, and so we hope that our [multi-agent version](https://github.com/Farama-Foundation/Multi-Agent-ALE) of it will be useful in the development of multi-agent reinforcement learning.
+The Atari environments are based off the [Arcade Learning Environment](https://github.com/Farama-Foundation/Arcade-Learning-Environment). This environment was instrumental in the development of modern reinforcement learning, and so we hope that our [multi-agent version](https://github.com/Farama-Foundation/Multi-Agent-ALE) of it will be useful in the development of multi-agent reinforcement learning.
 
 ```{raw} html
     :file: multi-agent-environments/list.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ test = [
 [project.urls]
 homepage = "https://github.com/Farama-Foundation/Arcade-Learning-Environment"
 documentation = "https://ale.farama.org"
-changelog = "https://github.com/Farama-Foundation/Arcade-Learning-Environment/blob/master/CHANGELOG.md"
+changelog = "https://github.com/Farama-Foundation/Arcade-Learning-Environment/blob/main/CHANGELOG.md"
 
 [tool.pytest.ini_options]
 minversion = "7.0"

--- a/src/ale/ale_interface.cpp
+++ b/src/ale/ale_interface.cpp
@@ -139,7 +139,7 @@ void ALEInterface::loadROM(fs::path rom_file) {
 
     Logger::Error
       << "For a list of supported ROMs see "
-      << "https://github.com/mgbellemare/Arcade-Learning-Environment"
+      << "https://github.com/Farama-Foundation/Arcade-Learning-Environment"
       << std::endl;
 
     std::exit(1);


### PR DESCRIPTION
## Description
- Change references of `master` branch to `main`
- Change references of `mgbellemare/Arcade-Learning-Environment` to `Farama-Foundation/Arcade-Learning-Environment`

Fixes #702 