### PR TITLE
Fix README header image not showing outside the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 
 <p align="center">
     <a href="https://ale.farama.org/" target = "_blank">
-    <img src="ale-text-v2-centered.png" width="500px" />
+    <img src="https://raw.githubusercontent.com/Farama-Foundation/Arcade-Learning-Environment/main/ale-text-v2-centered.png" width="500px" />
 </a>
+</p>
 
 **The Arcade Learning Environment (ALE) is a simple framework that allows researchers and hobbyists to develop AI agents for Atari 2600 games.**
 It is built on top of the Atari 2600 emulator [Stella](https://stella-emu.github.io) and separates the details of emulation from agent design.


### PR DESCRIPTION
The header image at the top of the README used a relative `src` (`ale-text-v2-centered.png`). Since `pyproject.toml` sets `readme = "README.md"`, this README is `ale-py`'s PyPI long-description, where relative image paths don't resolve — so the header image rendered blank on the PyPI project page (and other non-repo renderings).

This points the `<img>` at the absolute `raw.githubusercontent.com` URL (matching how other Farama project READMEs reference their header images) and closes the unclosed `<p>` in that header block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)