### PR TITLE
Add documentation for how to start some environments

### DIFF
--- a/docs/_scripts/environment-docs.json
+++ b/docs/_scripts/environment-docs.json
@@ -52,7 +52,8 @@
     "bank_heist": {
         "atariage_url": "https://atariage.com/manual_html_page.php?SoftwareLabelID=1008",
         "env_description": "You are a bank robber and (naturally) want to rob as many banks as possible. You control your getaway car and must navigate maze-like cities. The police chases you and will appear whenever you rob a bank. You may destroy police cars by dropping sticks of dynamite. You can fill up your gas tank by entering a new city. At the beginning of the game you have four lives. Lives are lost if you run out of gas, are caught by the police,or run over the dynamite you have previously dropped.",
-        "reward_description": "You score points for robbing banks and destroying police cars. If you rob nine or more banks, and then leave the city, you will score extra points. For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=1008)."
+        "reward_description": "You score points for robbing banks and destroying police cars. If you rob nine or more banks, and then leave the city, you will score extra points. For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=1008).",
+        "start_condition": "BankHeist does not begin until you start driving: press a movement direction such as `LEFT` or `RIGHT` to set the getaway car in motion. Holding `NOOP` leaves the game idle, giving no reward. The car must be steered again to resume after each life lost."
     },
     "basic_math": {
         "atariage_url": "https://atariage.com/manual_html_page.php?SoftwareLabelID=14",
@@ -82,7 +83,8 @@
     "bowling": {
         "atariage_url": "https://atariage.com/manual_html_page.php?SoftwareID=879",
         "env_description": "Your goal is to score as many points as possible in the game of Bowling. A game consists of 10 frames and you have two tries per frame. Knocking down all pins on the first try is called a \"strike\". Knocking down all pins on the second roll is called a \"spar\". Otherwise, the frame is called \"open\".",
-        "reward_description": "You receive points for knocking down pins. The exact score depends on whether you manage a \"strike\", \"spare\" or \"open\" frame. Moreover, the points you score for one frame may depend on following frames. You can score up to 300 points in one game (if you manage to do 12 strikes). For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareID=879)."
+        "reward_description": "You receive points for knocking down pins. The exact score depends on whether you manage a \"strike\", \"spare\" or \"open\" frame. Moreover, the points you score for one frame may depend on following frames. You can score up to 300 points in one game (if you manage to do 12 strikes). For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareID=879).",
+        "start_condition": "Bowling does not roll the ball until you press `FIRE`. Holding `NOOP` leaves the game idle, giving no reward. `FIRE` must be pressed again to bowl each new ball."
     },
     "boxing": {
         "atariage_url": "https://atariage.com/manual_html_page.php?SoftwareID=882",
@@ -92,7 +94,8 @@
     "breakout": {
         "atariage_url": "https://atariage.com/manual_html_page.php?SoftwareID=889",
         "env_description": "You move a paddle and hit the ball in a brick wall at the top of the screen. Your goal is to destroy the brick wall. You can try to break through the wall and let the ball wreak havoc on the other side, all on its own! You have five lives.",
-        "reward_description": "You score points by destroying bricks in the wall. The reward for destroying a brick depends on the color of the brick. For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareID=889)."
+        "reward_description": "You score points by destroying bricks in the wall. The reward for destroying a brick depends on the color of the brick. For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareID=889).",
+        "start_condition": "Breakout does not serve the ball until you press `FIRE`. Holding `NOOP` leaves the game idle, giving no reward and never ending. The ball must be served again with `FIRE` after each life lost, which is why many reference agents wrap Breakout in a \"fire reset\" wrapper."
     },
     "carnival": {
         "atariage_url": "https://atariage.com/manual_html_page.php?SoftwareID=908",
@@ -142,7 +145,8 @@
     "donkey_kong": {
         "atariage_url": "https://atariage.com/manual_html_page.php?SoftwareLabelID=149",
         "env_description": "You play as Mario trying to save your girlfriend who has been kidnapped by Donkey Kong. Remove rivets and jump over fireballs, with a score that starts high and counts down throughout the game.",
-        "reward_description": ""
+        "reward_description": "",
+        "start_condition": "Donkey Kong does not begin until you press `FIRE`. Holding `NOOP` leaves the game idle, giving no reward."
     },
     "double_dunk": {
         "atariage_url": "https://atariage.com/manual_html_page.php?SoftwareLabelID=153",
@@ -232,7 +236,8 @@
     "human_cannonball": {
         "atariage_url": "https://atariage.com/manual_html_page.php?SoftwareLabelID=238",
         "env_description": "Shoot a person out of a cannonball and try to get them into the water tower.",
-        "reward_description": ""
+        "reward_description": "",
+        "start_condition": "Human Cannonball does not launch until you press `FIRE`. Holding `NOOP` leaves the game idle, giving no reward. `FIRE` must be pressed again for each new launch."
     },
     "ice_hockey": {
         "atariage_url": "https://atariage.com/manual_html_page.php?SoftwareLabelID=241",
@@ -417,7 +422,8 @@
     "space_war": {
         "atariage_url": "https://atariage.com/manual_html_page.php?SoftwareLabelID=470",
         "env_description": "Use your Star Ship to compete in a sequence of games where you try to shoot your opponent as many times as possible without being hit yourself.",
-        "reward_description": ""
+        "reward_description": "",
+        "start_condition": "Space War does not begin until you press `FIRE` (or engage a thruster such as `UP`). Holding `NOOP` leaves the game idle, giving no reward. Play must be restarted this way after each life lost."
     },
     "star_gunner": {
         "atariage_url": "http://www.atarimania.com/game-atari-2600-vcs-stargunner_16921.html",
@@ -437,7 +443,8 @@
     "tennis": {
         "atariage_url": "https://atariage.com/manual_html_page.php?SoftwareLabelID=555",
         "env_description": "You control the orange player playing against a computer-controlled blue player. The game follows the rules of tennis. The first player to win at least 6 games with a margin of at least two games wins the match. If the score is tied at 6-6, the first player to go 2 games up wins the match.",
-        "reward_description": "The scoring is as per the sport of tennis, played till one set. For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=555)."
+        "reward_description": "The scoring is as per the sport of tennis, played till one set. For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=555).",
+        "start_condition": "Although the players are animated on the court, no point is played and no reward is given until you press `FIRE` to serve. An agent that only holds `NOOP` never scores. `FIRE` must be pressed to serve each new point."
     },
     "tetris": {
         "atariage_url": "",
@@ -457,7 +464,8 @@
     "trondead": {
         "atariage_url": "https://atariage.com/manual_html_page.php?SoftwareLabelID=569",
         "env_description": "Use your deadly saucer to knock out encroaching opponents before they get to you.",
-        "reward_description": ""
+        "reward_description": "",
+        "start_condition": "Tron: Deadly Discs does not begin until you send any action other than `NOOP`; holding `NOOP` leaves the game frozen with no reward."
     },
     "turmoil": {
         "atariage_url": "https://atariage.com/manual_html_page.php?SoftwareLabelID=571",

--- a/docs/_scripts/gen_environments_md.py
+++ b/docs/_scripts/gen_environments_md.py
@@ -76,9 +76,21 @@ For a more detailed documentation, see [the AtariAge page]({env_data['atariage_u
     else:
         reward_description = ""
 
+    # See ``scripts/detect_fire_to_start.py`` for how these games were identified.
+    if env_data.get("start_condition"):
+        start_condition = f"""### Starting the game
+
+{env_data["start_condition"]}
+
+See the [general Atari page](https://ale.farama.org/environments/#games-that-require-a-button-press-to-start) for the full list of games that require a starting action.
+
+"""
+    else:
+        start_condition = ""
+
     action_table = tabulate.tabulate(
         zip(range(env.action_space.n), env.get_action_meanings()),
-        headers=["Index", "Action", "Description"],
+        headers=["Index", "Action"],
         tablefmt="github",
     )
     if env.action_space.n == 18:
@@ -169,7 +181,7 @@ For more {env_name} variants with different observation and action spaces, see t
 
 See [environment specification](../env-spec) to see more information on the action meaning.
 
-## Observations
+{start_condition}## Observations
 
 Atari environments have three possible observation types:
 

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -172,6 +172,41 @@ a tuple of two positive integers. If `frameskip` is an integer, frame skipping i
 repeated `frameskip` many times. Otherwise, if `frameskip` is a tuple, the number of skipped frames is chosen uniformly at
 random between `frameskip[0]` (inclusive) and `frameskip[1]` (exclusive) in each environment step.
 
+## Games that require a button press to start
+
+A small number of games do not begin until the player presses a button. Until that press, the game is
+effectively frozen: the screen does not change, no reward is given, and the episode never terminates.
+
+| Environment       | Action that starts the game        | Also required after each life loss |
+|-------------------|------------------------------------|------------------------------------|
+| `BankHeist`       | any movement direction             | yes                                |
+| `Bowling`         | `FIRE`                             | yes                                |
+| `Breakout`        | `FIRE`                             | yes                                |
+| `DonkeyKong`      | `FIRE`                             | no                                 |
+| `HumanCannonball` | `FIRE`                             | yes                                |
+| `SpaceWar`        | `FIRE` or `UP`                     | yes                                |
+| `Tennis`          | `FIRE`                             | yes                                |
+| `Trondead`        | any action                         | no                                 |
+
+Where a game is listed as starting on `FIRE`, any composite action containing fire (`UPFIRE`, `LEFTFIRE`, and
+so on) works equally well. The simplest way to handle this is to press the starting action right after resetting:
+
+```python
+import gymnasium as gym
+import ale_py
+
+gym.register_envs(ale_py)
+
+env = gym.make("ALE/Breakout-v5")
+obs, info = env.reset()
+
+# FIRE is action 1; serve the ball so the episode can actually progress
+obs, reward, terminated, truncated, info = env.step(1)
+```
+
+For games marked as also requiring the press after a life loss, the same action must be repeated whenever the
+life count in `info["lives"]` decreases, not only at the start of the episode.
+
 ## Common Arguments
 
 When initializing Atari environments via `gymnasium.make`, you may pass some additional arguments. These work for any

--- a/docs/environments/adventure.md
+++ b/docs/environments/adventure.md
@@ -30,7 +30,7 @@ For a more detailed documentation, see [the AtariAge page](https://atariage.com/
 Adventure has the action space `Discrete(18)` with the table below listing the meaning of each action's meanings.
 As Adventure uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | FIRE          |

--- a/docs/environments/air_raid.md
+++ b/docs/environments/air_raid.md
@@ -29,7 +29,7 @@ AirRaid has the action space of `Discrete(6)` with the table below listing the m
 To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
 initialization or by passing `full_action_space=True` to `gymnasium.make`.
 
-|   Value | Meaning   |
+|   Index | Action    |
 |---------|-----------|
 |       0 | NOOP      |
 |       1 | FIRE      |

--- a/docs/environments/alien.md
+++ b/docs/environments/alien.md
@@ -30,7 +30,7 @@ For a more detailed documentation, see [the AtariAge page](https://atariage.com/
 Alien has the action space `Discrete(18)` with the table below listing the meaning of each action's meanings.
 As Alien uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | FIRE          |

--- a/docs/environments/amidar.md
+++ b/docs/environments/amidar.md
@@ -31,7 +31,7 @@ Amidar has the action space of `Discrete(10)` with the table below listing the m
 To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
 initialization or by passing `full_action_space=True` to `gymnasium.make`.
 
-|   Value | Meaning   |
+|   Index | Action    |
 |---------|-----------|
 |       0 | NOOP      |
 |       1 | FIRE      |

--- a/docs/environments/assault.md
+++ b/docs/environments/assault.md
@@ -31,7 +31,7 @@ Assault has the action space of `Discrete(7)` with the table below listing the m
 To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
 initialization or by passing `full_action_space=True` to `gymnasium.make`.
 
-|   Value | Meaning   |
+|   Index | Action    |
 |---------|-----------|
 |       0 | NOOP      |
 |       1 | FIRE      |

--- a/docs/environments/asterix.md
+++ b/docs/environments/asterix.md
@@ -31,7 +31,7 @@ Asterix has the action space of `Discrete(9)` with the table below listing the m
 To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
 initialization or by passing `full_action_space=True` to `gymnasium.make`.
 
-|   Value | Meaning   |
+|   Index | Action    |
 |---------|-----------|
 |       0 | NOOP      |
 |       1 | UP        |

--- a/docs/environments/asteroids.md
+++ b/docs/environments/asteroids.md
@@ -31,7 +31,7 @@ Asteroids has the action space of `Discrete(14)` with the table below listing th
 To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
 initialization or by passing `full_action_space=True` to `gymnasium.make`.
 
-|   Value | Meaning     |
+|   Index | Action      |
 |---------|-------------|
 |       0 | NOOP        |
 |       1 | FIRE        |

--- a/docs/environments/atlantis.md
+++ b/docs/environments/atlantis.md
@@ -31,7 +31,7 @@ Atlantis has the action space of `Discrete(4)` with the table below listing the 
 To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
 initialization or by passing `full_action_space=True` to `gymnasium.make`.
 
-|   Value | Meaning   |
+|   Index | Action    |
 |---------|-----------|
 |       0 | NOOP      |
 |       1 | FIRE      |

--- a/docs/environments/atlantis2.md
+++ b/docs/environments/atlantis2.md
@@ -31,7 +31,7 @@ Atlantis2 has the action space of `Discrete(4)` with the table below listing the
 To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
 initialization or by passing `full_action_space=True` to `gymnasium.make`.
 
-|   Value | Meaning   |
+|   Index | Action    |
 |---------|-----------|
 |       0 | NOOP      |
 |       1 | FIRE      |

--- a/docs/environments/backgammon.md
+++ b/docs/environments/backgammon.md
@@ -31,11 +31,11 @@ Backgammon has the action space of `Discrete(3)` with the table below listing th
 To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
 initialization or by passing `full_action_space=True` to `gymnasium.make`.
 
-|   Value | Meaning   |
-|---------|-----------|
-|       0 | FIRE      |
-|       1 | RIGHT     |
-|       2 | LEFT      |
+|   Index | Action   |
+|---------|----------|
+|       0 | FIRE     |
+|       1 | RIGHT    |
+|       2 | LEFT     |
 
 See [environment specification](../env-spec) to see more information on the action meaning.
 

--- a/docs/environments/bank_heist.md
+++ b/docs/environments/bank_heist.md
@@ -30,7 +30,7 @@ For a more detailed documentation, see [the AtariAge page](https://atariage.com/
 BankHeist has the action space `Discrete(18)` with the table below listing the meaning of each action's meanings.
 As BankHeist uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | FIRE          |
@@ -52,6 +52,12 @@ As BankHeist uses the full set of actions then specifying `full_action_space=Tru
 |      17 | DOWNLEFTFIRE  |
 
 See [environment specification](../env-spec) to see more information on the action meaning.
+
+### Starting the game
+
+BankHeist does not begin until you start driving: press a movement direction such as `LEFT` or `RIGHT` to set the getaway car in motion. Holding `NOOP` leaves the game idle, giving no reward. The car must be steered again to resume after each life lost.
+
+See the [general Atari page](https://ale.farama.org/environments/#games-that-require-a-button-press-to-start) for the full list of games that require a starting action.
 
 ## Observations
 

--- a/docs/environments/basic_math.md
+++ b/docs/environments/basic_math.md
@@ -31,14 +31,14 @@ BasicMath has the action space of `Discrete(6)` with the table below listing the
 To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
 initialization or by passing `full_action_space=True` to `gymnasium.make`.
 
-|   Value | Meaning   |
-|---------|-----------|
-|       0 | NOOP      |
-|       1 | FIRE      |
-|       2 | UP        |
-|       3 | RIGHT     |
-|       4 | LEFT      |
-|       5 | DOWN      |
+|   Index | Action   |
+|---------|----------|
+|       0 | NOOP     |
+|       1 | FIRE     |
+|       2 | UP       |
+|       3 | RIGHT    |
+|       4 | LEFT     |
+|       5 | DOWN     |
 
 See [environment specification](../env-spec) to see more information on the action meaning.
 

--- a/docs/environments/battle_zone.md
+++ b/docs/environments/battle_zone.md
@@ -30,7 +30,7 @@ For a more detailed documentation, see [the AtariAge page](https://atariage.com/
 BattleZone has the action space `Discrete(18)` with the table below listing the meaning of each action's meanings.
 As BattleZone uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | FIRE          |

--- a/docs/environments/beam_rider.md
+++ b/docs/environments/beam_rider.md
@@ -31,7 +31,7 @@ BeamRider has the action space of `Discrete(9)` with the table below listing the
 To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
 initialization or by passing `full_action_space=True` to `gymnasium.make`.
 
-|   Value | Meaning   |
+|   Index | Action    |
 |---------|-----------|
 |       0 | NOOP      |
 |       1 | FIRE      |

--- a/docs/environments/berzerk.md
+++ b/docs/environments/berzerk.md
@@ -30,7 +30,7 @@ For a more detailed documentation, see [the AtariAge page](https://atariage.com/
 Berzerk has the action space `Discrete(18)` with the table below listing the meaning of each action's meanings.
 As Berzerk uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | FIRE          |

--- a/docs/environments/blackjack.md
+++ b/docs/environments/blackjack.md
@@ -31,12 +31,12 @@ Blackjack has the action space of `Discrete(4)` with the table below listing the
 To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
 initialization or by passing `full_action_space=True` to `gymnasium.make`.
 
-|   Value | Meaning   |
-|---------|-----------|
-|       0 | NOOP      |
-|       1 | FIRE      |
-|       2 | UP        |
-|       3 | DOWN      |
+|   Index | Action   |
+|---------|----------|
+|       0 | NOOP     |
+|       1 | FIRE     |
+|       2 | UP       |
+|       3 | DOWN     |
 
 See [environment specification](../env-spec) to see more information on the action meaning.
 

--- a/docs/environments/bowling.md
+++ b/docs/environments/bowling.md
@@ -31,16 +31,22 @@ Bowling has the action space of `Discrete(6)` with the table below listing the m
 To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
 initialization or by passing `full_action_space=True` to `gymnasium.make`.
 
-|   Value | Meaning   |
-|---------|-----------|
-|       0 | NOOP      |
-|       1 | FIRE      |
-|       2 | UP        |
-|       3 | DOWN      |
-|       4 | UPFIRE    |
-|       5 | DOWNFIRE  |
+|   Index | Action   |
+|---------|----------|
+|       0 | NOOP     |
+|       1 | FIRE     |
+|       2 | UP       |
+|       3 | DOWN     |
+|       4 | UPFIRE   |
+|       5 | DOWNFIRE |
 
 See [environment specification](../env-spec) to see more information on the action meaning.
+
+### Starting the game
+
+Bowling does not roll the ball until you press `FIRE`. Holding `NOOP` leaves the game idle, giving no reward. `FIRE` must be pressed again to bowl each new ball.
+
+See the [general Atari page](https://ale.farama.org/environments/#games-that-require-a-button-press-to-start) for the full list of games that require a starting action.
 
 ## Observations
 

--- a/docs/environments/boxing.md
+++ b/docs/environments/boxing.md
@@ -30,7 +30,7 @@ For a more detailed documentation, see [the AtariAge page](https://atariage.com/
 Boxing has the action space `Discrete(18)` with the table below listing the meaning of each action's meanings.
 As Boxing uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | FIRE          |

--- a/docs/environments/breakout.md
+++ b/docs/environments/breakout.md
@@ -31,14 +31,20 @@ Breakout has the action space of `Discrete(4)` with the table below listing the 
 To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
 initialization or by passing `full_action_space=True` to `gymnasium.make`.
 
-|   Value | Meaning   |
-|---------|-----------|
-|       0 | NOOP      |
-|       1 | FIRE      |
-|       2 | RIGHT     |
-|       3 | LEFT      |
+|   Index | Action   |
+|---------|----------|
+|       0 | NOOP     |
+|       1 | FIRE     |
+|       2 | RIGHT    |
+|       3 | LEFT     |
 
 See [environment specification](../env-spec) to see more information on the action meaning.
+
+### Starting the game
+
+Breakout does not serve the ball until you press `FIRE`. Holding `NOOP` leaves the game idle, giving no reward and never ending. The ball must be served again with `FIRE` after each life lost, which is why many reference agents wrap Breakout in a "fire reset" wrapper.
+
+See the [general Atari page](https://ale.farama.org/environments/#games-that-require-a-button-press-to-start) for the full list of games that require a starting action.
 
 ## Observations
 

--- a/docs/environments/carnival.md
+++ b/docs/environments/carnival.md
@@ -31,7 +31,7 @@ Carnival has the action space of `Discrete(6)` with the table below listing the 
 To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
 initialization or by passing `full_action_space=True` to `gymnasium.make`.
 
-|   Value | Meaning   |
+|   Index | Action    |
 |---------|-----------|
 |       0 | NOOP      |
 |       1 | FIRE      |

--- a/docs/environments/casino.md
+++ b/docs/environments/casino.md
@@ -31,12 +31,12 @@ Casino has the action space of `Discrete(4)` with the table below listing the me
 To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
 initialization or by passing `full_action_space=True` to `gymnasium.make`.
 
-|   Value | Meaning   |
-|---------|-----------|
-|       0 | NOOP      |
-|       1 | FIRE      |
-|       2 | UP        |
-|       3 | DOWN      |
+|   Index | Action   |
+|---------|----------|
+|       0 | NOOP     |
+|       1 | FIRE     |
+|       2 | UP       |
+|       3 | DOWN     |
 
 See [environment specification](../env-spec) to see more information on the action meaning.
 

--- a/docs/environments/centipede.md
+++ b/docs/environments/centipede.md
@@ -30,7 +30,7 @@ For a more detailed documentation, see [the AtariAge page](https://atariage.com/
 Centipede has the action space `Discrete(18)` with the table below listing the meaning of each action's meanings.
 As Centipede uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | FIRE          |

--- a/docs/environments/chopper_command.md
+++ b/docs/environments/chopper_command.md
@@ -30,7 +30,7 @@ For a more detailed documentation, see [the AtariAge page](https://atariage.com/
 ChopperCommand has the action space `Discrete(18)` with the table below listing the meaning of each action's meanings.
 As ChopperCommand uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | FIRE          |

--- a/docs/environments/crazy_climber.md
+++ b/docs/environments/crazy_climber.md
@@ -31,7 +31,7 @@ CrazyClimber has the action space of `Discrete(9)` with the table below listing 
 To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
 initialization or by passing `full_action_space=True` to `gymnasium.make`.
 
-|   Value | Meaning   |
+|   Index | Action    |
 |---------|-----------|
 |       0 | NOOP      |
 |       1 | UP        |

--- a/docs/environments/crossbow.md
+++ b/docs/environments/crossbow.md
@@ -30,7 +30,7 @@ For a more detailed documentation, see [the AtariAge page](https://atariage.com/
 Crossbow has the action space `Discrete(18)` with the table below listing the meaning of each action's meanings.
 As Crossbow uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | FIRE          |

--- a/docs/environments/darkchambers.md
+++ b/docs/environments/darkchambers.md
@@ -30,7 +30,7 @@ For a more detailed documentation, see [the AtariAge page](https://atariage.com/
 Darkchambers has the action space `Discrete(18)` with the table below listing the meaning of each action's meanings.
 As Darkchambers uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | FIRE          |

--- a/docs/environments/defender.md
+++ b/docs/environments/defender.md
@@ -30,7 +30,7 @@ For a more detailed documentation, see [the AtariAge page](https://atariage.com/
 Defender has the action space `Discrete(18)` with the table below listing the meaning of each action's meanings.
 As Defender uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | FIRE          |

--- a/docs/environments/demon_attack.md
+++ b/docs/environments/demon_attack.md
@@ -31,7 +31,7 @@ DemonAttack has the action space of `Discrete(6)` with the table below listing t
 To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
 initialization or by passing `full_action_space=True` to `gymnasium.make`.
 
-|   Value | Meaning   |
+|   Index | Action    |
 |---------|-----------|
 |       0 | NOOP      |
 |       1 | FIRE      |

--- a/docs/environments/donkey_kong.md
+++ b/docs/environments/donkey_kong.md
@@ -30,7 +30,7 @@ For a more detailed documentation, see [the AtariAge page](https://atariage.com/
 DonkeyKong has the action space `Discrete(18)` with the table below listing the meaning of each action's meanings.
 As DonkeyKong uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | FIRE          |
@@ -52,6 +52,12 @@ As DonkeyKong uses the full set of actions then specifying `full_action_space=Tr
 |      17 | DOWNLEFTFIRE  |
 
 See [environment specification](../env-spec) to see more information on the action meaning.
+
+### Starting the game
+
+Donkey Kong does not begin until you press `FIRE`. Holding `NOOP` leaves the game idle, giving no reward.
+
+See the [general Atari page](https://ale.farama.org/environments/#games-that-require-a-button-press-to-start) for the full list of games that require a starting action.
 
 ## Observations
 

--- a/docs/environments/double_dunk.md
+++ b/docs/environments/double_dunk.md
@@ -30,7 +30,7 @@ For a more detailed documentation, see [the AtariAge page](https://atariage.com/
 DoubleDunk has the action space `Discrete(18)` with the table below listing the meaning of each action's meanings.
 As DoubleDunk uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | FIRE          |

--- a/docs/environments/earthworld.md
+++ b/docs/environments/earthworld.md
@@ -30,7 +30,7 @@ For a more detailed documentation, see [the AtariAge page](https://atariage.com/
 Earthworld has the action space `Discrete(18)` with the table below listing the meaning of each action's meanings.
 As Earthworld uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | FIRE          |

--- a/docs/environments/elevator_action.md
+++ b/docs/environments/elevator_action.md
@@ -30,7 +30,7 @@ For a more detailed documentation, see [the AtariAge page](https://atariage.com/
 ElevatorAction has the action space `Discrete(18)` with the table below listing the meaning of each action's meanings.
 As ElevatorAction uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | FIRE          |

--- a/docs/environments/enduro.md
+++ b/docs/environments/enduro.md
@@ -31,7 +31,7 @@ Enduro has the action space of `Discrete(9)` with the table below listing the me
 To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
 initialization or by passing `full_action_space=True` to `gymnasium.make`.
 
-|   Value | Meaning   |
+|   Index | Action    |
 |---------|-----------|
 |       0 | NOOP      |
 |       1 | FIRE      |

--- a/docs/environments/entombed.md
+++ b/docs/environments/entombed.md
@@ -30,7 +30,7 @@ For a more detailed documentation, see [the AtariAge page](https://atariage.com/
 Entombed has the action space `Discrete(18)` with the table below listing the meaning of each action's meanings.
 As Entombed uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | FIRE          |

--- a/docs/environments/et.md
+++ b/docs/environments/et.md
@@ -30,7 +30,7 @@ For a more detailed documentation, see [the AtariAge page](https://atariage.com/
 Et has the action space `Discrete(18)` with the table below listing the meaning of each action's meanings.
 As Et uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | FIRE          |

--- a/docs/environments/fishing_derby.md
+++ b/docs/environments/fishing_derby.md
@@ -30,7 +30,7 @@ For a more detailed documentation, see [the AtariAge page](https://atariage.com/
 FishingDerby has the action space `Discrete(18)` with the table below listing the meaning of each action's meanings.
 As FishingDerby uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | FIRE          |

--- a/docs/environments/flag_capture.md
+++ b/docs/environments/flag_capture.md
@@ -30,7 +30,7 @@ For a more detailed documentation, see [the AtariAge page](https://atariage.com/
 FlagCapture has the action space `Discrete(18)` with the table below listing the meaning of each action's meanings.
 As FlagCapture uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | FIRE          |

--- a/docs/environments/freeway.md
+++ b/docs/environments/freeway.md
@@ -31,11 +31,11 @@ Freeway has the action space of `Discrete(3)` with the table below listing the m
 To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
 initialization or by passing `full_action_space=True` to `gymnasium.make`.
 
-|   Value | Meaning   |
-|---------|-----------|
-|       0 | NOOP      |
-|       1 | UP        |
-|       2 | DOWN      |
+|   Index | Action   |
+|---------|----------|
+|       0 | NOOP     |
+|       1 | UP       |
+|       2 | DOWN     |
 
 See [environment specification](../env-spec) to see more information on the action meaning.
 

--- a/docs/environments/frogger.md
+++ b/docs/environments/frogger.md
@@ -31,13 +31,13 @@ Frogger has the action space of `Discrete(5)` with the table below listing the m
 To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
 initialization or by passing `full_action_space=True` to `gymnasium.make`.
 
-|   Value | Meaning   |
-|---------|-----------|
-|       0 | NOOP      |
-|       1 | UP        |
-|       2 | RIGHT     |
-|       3 | LEFT      |
-|       4 | DOWN      |
+|   Index | Action   |
+|---------|----------|
+|       0 | NOOP     |
+|       1 | UP       |
+|       2 | RIGHT    |
+|       3 | LEFT     |
+|       4 | DOWN     |
 
 See [environment specification](../env-spec) to see more information on the action meaning.
 

--- a/docs/environments/frostbite.md
+++ b/docs/environments/frostbite.md
@@ -30,7 +30,7 @@ For a more detailed documentation, see [the AtariAge page](https://atariage.com/
 Frostbite has the action space `Discrete(18)` with the table below listing the meaning of each action's meanings.
 As Frostbite uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | FIRE          |

--- a/docs/environments/galaxian.md
+++ b/docs/environments/galaxian.md
@@ -31,7 +31,7 @@ Galaxian has the action space of `Discrete(6)` with the table below listing the 
 To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
 initialization or by passing `full_action_space=True` to `gymnasium.make`.
 
-|   Value | Meaning   |
+|   Index | Action    |
 |---------|-----------|
 |       0 | NOOP      |
 |       1 | FIRE      |

--- a/docs/environments/gopher.md
+++ b/docs/environments/gopher.md
@@ -31,7 +31,7 @@ Gopher has the action space of `Discrete(8)` with the table below listing the me
 To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
 initialization or by passing `full_action_space=True` to `gymnasium.make`.
 
-|   Value | Meaning   |
+|   Index | Action    |
 |---------|-----------|
 |       0 | NOOP      |
 |       1 | FIRE      |

--- a/docs/environments/gravitar.md
+++ b/docs/environments/gravitar.md
@@ -30,7 +30,7 @@ For a more detailed documentation, see [the AtariAge page](https://atariage.com/
 Gravitar has the action space `Discrete(18)` with the table below listing the meaning of each action's meanings.
 As Gravitar uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | FIRE          |

--- a/docs/environments/hangman.md
+++ b/docs/environments/hangman.md
@@ -30,7 +30,7 @@ For a more detailed documentation, see [the AtariAge page](https://atariage.com/
 Hangman has the action space `Discrete(18)` with the table below listing the meaning of each action's meanings.
 As Hangman uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | FIRE          |

--- a/docs/environments/haunted_house.md
+++ b/docs/environments/haunted_house.md
@@ -30,7 +30,7 @@ For a more detailed documentation, see [the AtariAge page](https://atariage.com/
 HauntedHouse has the action space `Discrete(18)` with the table below listing the meaning of each action's meanings.
 As HauntedHouse uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | FIRE          |

--- a/docs/environments/hero.md
+++ b/docs/environments/hero.md
@@ -30,7 +30,7 @@ For a more detailed documentation, see [the AtariAge page](https://atariage.com/
 Hero has the action space `Discrete(18)` with the table below listing the meaning of each action's meanings.
 As Hero uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | FIRE          |

--- a/docs/environments/human_cannonball.md
+++ b/docs/environments/human_cannonball.md
@@ -30,7 +30,7 @@ For a more detailed documentation, see [the AtariAge page](https://atariage.com/
 HumanCannonball has the action space `Discrete(18)` with the table below listing the meaning of each action's meanings.
 As HumanCannonball uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | FIRE          |
@@ -52,6 +52,12 @@ As HumanCannonball uses the full set of actions then specifying `full_action_spa
 |      17 | DOWNLEFTFIRE  |
 
 See [environment specification](../env-spec) to see more information on the action meaning.
+
+### Starting the game
+
+Human Cannonball does not launch until you press `FIRE`. Holding `NOOP` leaves the game idle, giving no reward. `FIRE` must be pressed again for each new launch.
+
+See the [general Atari page](https://ale.farama.org/environments/#games-that-require-a-button-press-to-start) for the full list of games that require a starting action.
 
 ## Observations
 

--- a/docs/environments/ice_hockey.md
+++ b/docs/environments/ice_hockey.md
@@ -30,7 +30,7 @@ For a more detailed documentation, see [the AtariAge page](https://atariage.com/
 IceHockey has the action space `Discrete(18)` with the table below listing the meaning of each action's meanings.
 As IceHockey uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | FIRE          |

--- a/docs/environments/jamesbond.md
+++ b/docs/environments/jamesbond.md
@@ -30,7 +30,7 @@ For a more detailed documentation, see [the AtariAge page](https://atariage.com/
 Jamesbond has the action space `Discrete(18)` with the table below listing the meaning of each action's meanings.
 As Jamesbond uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | FIRE          |

--- a/docs/environments/journey_escape.md
+++ b/docs/environments/journey_escape.md
@@ -31,7 +31,7 @@ JourneyEscape has the action space of `Discrete(16)` with the table below listin
 To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
 initialization or by passing `full_action_space=True` to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | UP            |

--- a/docs/environments/kaboom.md
+++ b/docs/environments/kaboom.md
@@ -31,12 +31,12 @@ Kaboom has the action space of `Discrete(4)` with the table below listing the me
 To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
 initialization or by passing `full_action_space=True` to `gymnasium.make`.
 
-|   Value | Meaning   |
-|---------|-----------|
-|       0 | NOOP      |
-|       1 | FIRE      |
-|       2 | RIGHT     |
-|       3 | LEFT      |
+|   Index | Action   |
+|---------|----------|
+|       0 | NOOP     |
+|       1 | FIRE     |
+|       2 | RIGHT    |
+|       3 | LEFT     |
 
 See [environment specification](../env-spec) to see more information on the action meaning.
 

--- a/docs/environments/kangaroo.md
+++ b/docs/environments/kangaroo.md
@@ -30,7 +30,7 @@ For a more detailed documentation, see [the AtariAge page](https://atariage.com/
 Kangaroo has the action space `Discrete(18)` with the table below listing the meaning of each action's meanings.
 As Kangaroo uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | FIRE          |

--- a/docs/environments/keystone_kapers.md
+++ b/docs/environments/keystone_kapers.md
@@ -31,7 +31,7 @@ KeystoneKapers has the action space of `Discrete(14)` with the table below listi
 To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
 initialization or by passing `full_action_space=True` to `gymnasium.make`.
 
-|   Value | Meaning   |
+|   Index | Action    |
 |---------|-----------|
 |       0 | NOOP      |
 |       1 | FIRE      |

--- a/docs/environments/king_kong.md
+++ b/docs/environments/king_kong.md
@@ -31,14 +31,14 @@ KingKong has the action space of `Discrete(6)` with the table below listing the 
 To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
 initialization or by passing `full_action_space=True` to `gymnasium.make`.
 
-|   Value | Meaning   |
-|---------|-----------|
-|       0 | NOOP      |
-|       1 | FIRE      |
-|       2 | UP        |
-|       3 | RIGHT     |
-|       4 | LEFT      |
-|       5 | DOWN      |
+|   Index | Action   |
+|---------|----------|
+|       0 | NOOP     |
+|       1 | FIRE     |
+|       2 | UP       |
+|       3 | RIGHT    |
+|       4 | LEFT     |
+|       5 | DOWN     |
 
 See [environment specification](../env-spec) to see more information on the action meaning.
 

--- a/docs/environments/klax.md
+++ b/docs/environments/klax.md
@@ -30,7 +30,7 @@ For a more detailed documentation, see [the AtariAge page](https://atariage.com/
 Klax has the action space `Discrete(18)` with the table below listing the meaning of each action's meanings.
 As Klax uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | FIRE          |

--- a/docs/environments/koolaid.md
+++ b/docs/environments/koolaid.md
@@ -31,7 +31,7 @@ Koolaid has the action space of `Discrete(9)` with the table below listing the m
 To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
 initialization or by passing `full_action_space=True` to `gymnasium.make`.
 
-|   Value | Meaning   |
+|   Index | Action    |
 |---------|-----------|
 |       0 | NOOP      |
 |       1 | UP        |

--- a/docs/environments/krull.md
+++ b/docs/environments/krull.md
@@ -30,7 +30,7 @@ For a more detailed documentation, see [the AtariAge page](https://atariage.com/
 Krull has the action space `Discrete(18)` with the table below listing the meaning of each action's meanings.
 As Krull uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | FIRE          |

--- a/docs/environments/kung_fu_master.md
+++ b/docs/environments/kung_fu_master.md
@@ -31,7 +31,7 @@ KungFuMaster has the action space of `Discrete(14)` with the table below listing
 To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
 initialization or by passing `full_action_space=True` to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | UP            |

--- a/docs/environments/laser_gates.md
+++ b/docs/environments/laser_gates.md
@@ -30,7 +30,7 @@ For a more detailed documentation, see [the AtariAge page](https://atariage.com/
 LaserGates has the action space `Discrete(18)` with the table below listing the meaning of each action's meanings.
 As LaserGates uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | FIRE          |

--- a/docs/environments/lost_luggage.md
+++ b/docs/environments/lost_luggage.md
@@ -31,7 +31,7 @@ LostLuggage has the action space of `Discrete(9)` with the table below listing t
 To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
 initialization or by passing `full_action_space=True` to `gymnasium.make`.
 
-|   Value | Meaning   |
+|   Index | Action    |
 |---------|-----------|
 |       0 | NOOP      |
 |       1 | UP        |

--- a/docs/environments/mario_bros.md
+++ b/docs/environments/mario_bros.md
@@ -30,7 +30,7 @@ For a more detailed documentation, see [the AtariAge page](https://atariage.com/
 MarioBros has the action space `Discrete(18)` with the table below listing the meaning of each action's meanings.
 As MarioBros uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | FIRE          |

--- a/docs/environments/miniature_golf.md
+++ b/docs/environments/miniature_golf.md
@@ -30,7 +30,7 @@ For a more detailed documentation, see [the AtariAge page](https://atariage.com/
 MiniatureGolf has the action space `Discrete(18)` with the table below listing the meaning of each action's meanings.
 As MiniatureGolf uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | FIRE          |

--- a/docs/environments/montezuma_revenge.md
+++ b/docs/environments/montezuma_revenge.md
@@ -30,7 +30,7 @@ For a more detailed documentation, see [the AtariAge page](https://atariage.com/
 MontezumaRevenge has the action space `Discrete(18)` with the table below listing the meaning of each action's meanings.
 As MontezumaRevenge uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | FIRE          |

--- a/docs/environments/mr_do.md
+++ b/docs/environments/mr_do.md
@@ -31,7 +31,7 @@ MrDo has the action space of `Discrete(10)` with the table below listing the mea
 To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
 initialization or by passing `full_action_space=True` to `gymnasium.make`.
 
-|   Value | Meaning   |
+|   Index | Action    |
 |---------|-----------|
 |       0 | NOOP      |
 |       1 | FIRE      |

--- a/docs/environments/ms_pacman.md
+++ b/docs/environments/ms_pacman.md
@@ -31,7 +31,7 @@ MsPacman has the action space of `Discrete(9)` with the table below listing the 
 To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
 initialization or by passing `full_action_space=True` to `gymnasium.make`.
 
-|   Value | Meaning   |
+|   Index | Action    |
 |---------|-----------|
 |       0 | NOOP      |
 |       1 | UP        |

--- a/docs/environments/name_this_game.md
+++ b/docs/environments/name_this_game.md
@@ -31,7 +31,7 @@ NameThisGame has the action space of `Discrete(6)` with the table below listing 
 To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
 initialization or by passing `full_action_space=True` to `gymnasium.make`.
 
-|   Value | Meaning   |
+|   Index | Action    |
 |---------|-----------|
 |       0 | NOOP      |
 |       1 | FIRE      |

--- a/docs/environments/othello.md
+++ b/docs/environments/othello.md
@@ -31,7 +31,7 @@ Othello has the action space of `Discrete(10)` with the table below listing the 
 To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
 initialization or by passing `full_action_space=True` to `gymnasium.make`.
 
-|   Value | Meaning   |
+|   Index | Action    |
 |---------|-----------|
 |       0 | NOOP      |
 |       1 | FIRE      |

--- a/docs/environments/pacman.md
+++ b/docs/environments/pacman.md
@@ -29,13 +29,13 @@ Pacman has the action space of `Discrete(5)` with the table below listing the me
 To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
 initialization or by passing `full_action_space=True` to `gymnasium.make`.
 
-|   Value | Meaning   |
-|---------|-----------|
-|       0 | NOOP      |
-|       1 | UP        |
-|       2 | RIGHT     |
-|       3 | LEFT      |
-|       4 | DOWN      |
+|   Index | Action   |
+|---------|----------|
+|       0 | NOOP     |
+|       1 | UP       |
+|       2 | RIGHT    |
+|       3 | LEFT     |
+|       4 | DOWN     |
 
 See [environment specification](../env-spec) to see more information on the action meaning.
 

--- a/docs/environments/phoenix.md
+++ b/docs/environments/phoenix.md
@@ -31,7 +31,7 @@ Phoenix has the action space of `Discrete(8)` with the table below listing the m
 To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
 initialization or by passing `full_action_space=True` to `gymnasium.make`.
 
-|   Value | Meaning   |
+|   Index | Action    |
 |---------|-----------|
 |       0 | NOOP      |
 |       1 | FIRE      |

--- a/docs/environments/pitfall.md
+++ b/docs/environments/pitfall.md
@@ -30,7 +30,7 @@ For a more detailed documentation, see [the AtariAge page](https://atariage.com/
 Pitfall has the action space `Discrete(18)` with the table below listing the meaning of each action's meanings.
 As Pitfall uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | FIRE          |

--- a/docs/environments/pitfall2.md
+++ b/docs/environments/pitfall2.md
@@ -30,7 +30,7 @@ For a more detailed documentation, see [the AtariAge page](https://atariage.com/
 Pitfall2 has the action space `Discrete(18)` with the table below listing the meaning of each action's meanings.
 As Pitfall2 uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | FIRE          |

--- a/docs/environments/pong.md
+++ b/docs/environments/pong.md
@@ -31,7 +31,7 @@ Pong has the action space of `Discrete(6)` with the table below listing the mean
 To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
 initialization or by passing `full_action_space=True` to `gymnasium.make`.
 
-|   Value | Meaning   |
+|   Index | Action    |
 |---------|-----------|
 |       0 | NOOP      |
 |       1 | FIRE      |

--- a/docs/environments/pooyan.md
+++ b/docs/environments/pooyan.md
@@ -31,14 +31,14 @@ Pooyan has the action space of `Discrete(6)` with the table below listing the me
 To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
 initialization or by passing `full_action_space=True` to `gymnasium.make`.
 
-|   Value | Meaning   |
-|---------|-----------|
-|       0 | NOOP      |
-|       1 | FIRE      |
-|       2 | UP        |
-|       3 | DOWN      |
-|       4 | UPFIRE    |
-|       5 | DOWNFIRE  |
+|   Index | Action   |
+|---------|----------|
+|       0 | NOOP     |
+|       1 | FIRE     |
+|       2 | UP       |
+|       3 | DOWN     |
+|       4 | UPFIRE   |
+|       5 | DOWNFIRE |
 
 See [environment specification](../env-spec) to see more information on the action meaning.
 

--- a/docs/environments/private_eye.md
+++ b/docs/environments/private_eye.md
@@ -30,7 +30,7 @@ For a more detailed documentation, see [the AtariAge page](https://atariage.com/
 PrivateEye has the action space `Discrete(18)` with the table below listing the meaning of each action's meanings.
 As PrivateEye uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | FIRE          |

--- a/docs/environments/qbert.md
+++ b/docs/environments/qbert.md
@@ -31,14 +31,14 @@ Qbert has the action space of `Discrete(6)` with the table below listing the mea
 To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
 initialization or by passing `full_action_space=True` to `gymnasium.make`.
 
-|   Value | Meaning   |
-|---------|-----------|
-|       0 | NOOP      |
-|       1 | FIRE      |
-|       2 | UP        |
-|       3 | RIGHT     |
-|       4 | LEFT      |
-|       5 | DOWN      |
+|   Index | Action   |
+|---------|----------|
+|       0 | NOOP     |
+|       1 | FIRE     |
+|       2 | UP       |
+|       3 | RIGHT    |
+|       4 | LEFT     |
+|       5 | DOWN     |
 
 See [environment specification](../env-spec) to see more information on the action meaning.
 

--- a/docs/environments/riverraid.md
+++ b/docs/environments/riverraid.md
@@ -30,7 +30,7 @@ For a more detailed documentation, see [the AtariAge page](https://atariage.com/
 Riverraid has the action space `Discrete(18)` with the table below listing the meaning of each action's meanings.
 As Riverraid uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | FIRE          |

--- a/docs/environments/road_runner.md
+++ b/docs/environments/road_runner.md
@@ -30,7 +30,7 @@ For a more detailed documentation, see [the AtariAge page](https://atariage.com/
 RoadRunner has the action space `Discrete(18)` with the table below listing the meaning of each action's meanings.
 As RoadRunner uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | FIRE          |

--- a/docs/environments/robotank.md
+++ b/docs/environments/robotank.md
@@ -30,7 +30,7 @@ For a more detailed documentation, see [the AtariAge page](https://atariage.com/
 Robotank has the action space `Discrete(18)` with the table below listing the meaning of each action's meanings.
 As Robotank uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | FIRE          |

--- a/docs/environments/seaquest.md
+++ b/docs/environments/seaquest.md
@@ -30,7 +30,7 @@ For a more detailed documentation, see [the AtariAge page](https://atariage.com/
 Seaquest has the action space `Discrete(18)` with the table below listing the meaning of each action's meanings.
 As Seaquest uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | FIRE          |

--- a/docs/environments/sir_lancelot.md
+++ b/docs/environments/sir_lancelot.md
@@ -31,7 +31,7 @@ SirLancelot has the action space of `Discrete(6)` with the table below listing t
 To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
 initialization or by passing `full_action_space=True` to `gymnasium.make`.
 
-|   Value | Meaning   |
+|   Index | Action    |
 |---------|-----------|
 |       0 | NOOP      |
 |       1 | FIRE      |

--- a/docs/environments/skiing.md
+++ b/docs/environments/skiing.md
@@ -31,11 +31,11 @@ Skiing has the action space of `Discrete(3)` with the table below listing the me
 To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
 initialization or by passing `full_action_space=True` to `gymnasium.make`.
 
-|   Value | Meaning   |
-|---------|-----------|
-|       0 | NOOP      |
-|       1 | RIGHT     |
-|       2 | LEFT      |
+|   Index | Action   |
+|---------|----------|
+|       0 | NOOP     |
+|       1 | RIGHT    |
+|       2 | LEFT     |
 
 See [environment specification](../env-spec) to see more information on the action meaning.
 

--- a/docs/environments/solaris.md
+++ b/docs/environments/solaris.md
@@ -30,7 +30,7 @@ For a more detailed documentation, see [the AtariAge page](https://atariage.com/
 Solaris has the action space `Discrete(18)` with the table below listing the meaning of each action's meanings.
 As Solaris uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | FIRE          |

--- a/docs/environments/space_invaders.md
+++ b/docs/environments/space_invaders.md
@@ -31,7 +31,7 @@ SpaceInvaders has the action space of `Discrete(6)` with the table below listing
 To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
 initialization or by passing `full_action_space=True` to `gymnasium.make`.
 
-|   Value | Meaning   |
+|   Index | Action    |
 |---------|-----------|
 |       0 | NOOP      |
 |       1 | FIRE      |

--- a/docs/environments/space_war.md
+++ b/docs/environments/space_war.md
@@ -30,7 +30,7 @@ For a more detailed documentation, see [the AtariAge page](https://atariage.com/
 SpaceWar has the action space `Discrete(18)` with the table below listing the meaning of each action's meanings.
 As SpaceWar uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | FIRE          |
@@ -52,6 +52,12 @@ As SpaceWar uses the full set of actions then specifying `full_action_space=True
 |      17 | DOWNLEFTFIRE  |
 
 See [environment specification](../env-spec) to see more information on the action meaning.
+
+### Starting the game
+
+Space War does not begin until you press `FIRE` (or engage a thruster such as `UP`). Holding `NOOP` leaves the game idle, giving no reward. Play must be restarted this way after each life lost.
+
+See the [general Atari page](https://ale.farama.org/environments/#games-that-require-a-button-press-to-start) for the full list of games that require a starting action.
 
 ## Observations
 

--- a/docs/environments/star_gunner.md
+++ b/docs/environments/star_gunner.md
@@ -30,7 +30,7 @@ For a more detailed documentation, see [the AtariAge page](http://www.atarimania
 StarGunner has the action space `Discrete(18)` with the table below listing the meaning of each action's meanings.
 As StarGunner uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | FIRE          |

--- a/docs/environments/superman.md
+++ b/docs/environments/superman.md
@@ -30,7 +30,7 @@ For a more detailed documentation, see [the AtariAge page](https://atariage.com/
 Superman has the action space `Discrete(18)` with the table below listing the meaning of each action's meanings.
 As Superman uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | FIRE          |

--- a/docs/environments/surround.md
+++ b/docs/environments/surround.md
@@ -31,13 +31,13 @@ Surround has the action space of `Discrete(5)` with the table below listing the 
 To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
 initialization or by passing `full_action_space=True` to `gymnasium.make`.
 
-|   Value | Meaning   |
-|---------|-----------|
-|       0 | NOOP      |
-|       1 | UP        |
-|       2 | RIGHT     |
-|       3 | LEFT      |
-|       4 | DOWN      |
+|   Index | Action   |
+|---------|----------|
+|       0 | NOOP     |
+|       1 | UP       |
+|       2 | RIGHT    |
+|       3 | LEFT     |
+|       4 | DOWN     |
 
 See [environment specification](../env-spec) to see more information on the action meaning.
 

--- a/docs/environments/tennis.md
+++ b/docs/environments/tennis.md
@@ -30,7 +30,7 @@ For a more detailed documentation, see [the AtariAge page](https://atariage.com/
 Tennis has the action space `Discrete(18)` with the table below listing the meaning of each action's meanings.
 As Tennis uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | FIRE          |
@@ -52,6 +52,12 @@ As Tennis uses the full set of actions then specifying `full_action_space=True` 
 |      17 | DOWNLEFTFIRE  |
 
 See [environment specification](../env-spec) to see more information on the action meaning.
+
+### Starting the game
+
+Although the players are animated on the court, no point is played and no reward is given until you press `FIRE` to serve. An agent that only holds `NOOP` never scores. `FIRE` must be pressed to serve each new point.
+
+See the [general Atari page](https://ale.farama.org/environments/#games-that-require-a-button-press-to-start) for the full list of games that require a starting action.
 
 ## Observations
 

--- a/docs/environments/tetris.md
+++ b/docs/environments/tetris.md
@@ -29,13 +29,13 @@ Tetris has the action space of `Discrete(5)` with the table below listing the me
 To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
 initialization or by passing `full_action_space=True` to `gymnasium.make`.
 
-|   Value | Meaning   |
-|---------|-----------|
-|       0 | NOOP      |
-|       1 | FIRE      |
-|       2 | RIGHT     |
-|       3 | LEFT      |
-|       4 | DOWN      |
+|   Index | Action   |
+|---------|----------|
+|       0 | NOOP     |
+|       1 | FIRE     |
+|       2 | RIGHT    |
+|       3 | LEFT     |
+|       4 | DOWN     |
 
 See [environment specification](../env-spec) to see more information on the action meaning.
 

--- a/docs/environments/tic_tac_toe_3d.md
+++ b/docs/environments/tic_tac_toe_3d.md
@@ -31,7 +31,7 @@ TicTacToe3D has the action space of `Discrete(10)` with the table below listing 
 To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
 initialization or by passing `full_action_space=True` to `gymnasium.make`.
 
-|   Value | Meaning   |
+|   Index | Action    |
 |---------|-----------|
 |       0 | NOOP      |
 |       1 | FIRE      |

--- a/docs/environments/time_pilot.md
+++ b/docs/environments/time_pilot.md
@@ -31,7 +31,7 @@ TimePilot has the action space of `Discrete(10)` with the table below listing th
 To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
 initialization or by passing `full_action_space=True` to `gymnasium.make`.
 
-|   Value | Meaning   |
+|   Index | Action    |
 |---------|-----------|
 |       0 | NOOP      |
 |       1 | FIRE      |

--- a/docs/environments/trondead.md
+++ b/docs/environments/trondead.md
@@ -30,7 +30,7 @@ For a more detailed documentation, see [the AtariAge page](https://atariage.com/
 Trondead has the action space `Discrete(18)` with the table below listing the meaning of each action's meanings.
 As Trondead uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | FIRE          |
@@ -52,6 +52,12 @@ As Trondead uses the full set of actions then specifying `full_action_space=True
 |      17 | DOWNLEFTFIRE  |
 
 See [environment specification](../env-spec) to see more information on the action meaning.
+
+### Starting the game
+
+Tron: Deadly Discs does not begin until you send any action other than `NOOP`; holding `NOOP` leaves the game frozen with no reward.
+
+See the [general Atari page](https://ale.farama.org/environments/#games-that-require-a-button-press-to-start) for the full list of games that require a starting action.
 
 ## Observations
 

--- a/docs/environments/turmoil.md
+++ b/docs/environments/turmoil.md
@@ -31,7 +31,7 @@ Turmoil has the action space of `Discrete(12)` with the table below listing the 
 To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
 initialization or by passing `full_action_space=True` to `gymnasium.make`.
 
-|   Value | Meaning   |
+|   Index | Action    |
 |---------|-----------|
 |       0 | NOOP      |
 |       1 | FIRE      |

--- a/docs/environments/tutankham.md
+++ b/docs/environments/tutankham.md
@@ -31,7 +31,7 @@ Tutankham has the action space of `Discrete(8)` with the table below listing the
 To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
 initialization or by passing `full_action_space=True` to `gymnasium.make`.
 
-|   Value | Meaning   |
+|   Index | Action    |
 |---------|-----------|
 |       0 | NOOP      |
 |       1 | UP        |

--- a/docs/environments/up_n_down.md
+++ b/docs/environments/up_n_down.md
@@ -31,14 +31,14 @@ UpNDown has the action space of `Discrete(6)` with the table below listing the m
 To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
 initialization or by passing `full_action_space=True` to `gymnasium.make`.
 
-|   Value | Meaning   |
-|---------|-----------|
-|       0 | NOOP      |
-|       1 | FIRE      |
-|       2 | UP        |
-|       3 | DOWN      |
-|       4 | UPFIRE    |
-|       5 | DOWNFIRE  |
+|   Index | Action   |
+|---------|----------|
+|       0 | NOOP     |
+|       1 | FIRE     |
+|       2 | UP       |
+|       3 | DOWN     |
+|       4 | UPFIRE   |
+|       5 | DOWNFIRE |
 
 See [environment specification](../env-spec) to see more information on the action meaning.
 

--- a/docs/environments/venture.md
+++ b/docs/environments/venture.md
@@ -30,7 +30,7 @@ For a more detailed documentation, see [the AtariAge page](https://atariage.com/
 Venture has the action space `Discrete(18)` with the table below listing the meaning of each action's meanings.
 As Venture uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | FIRE          |

--- a/docs/environments/video_checkers.md
+++ b/docs/environments/video_checkers.md
@@ -31,7 +31,7 @@ VideoCheckers has the action space of `Discrete(5)` with the table below listing
 To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
 initialization or by passing `full_action_space=True` to `gymnasium.make`.
 
-|   Value | Meaning   |
+|   Index | Action    |
 |---------|-----------|
 |       0 | FIRE      |
 |       1 | UPRIGHT   |

--- a/docs/environments/video_chess.md
+++ b/docs/environments/video_chess.md
@@ -31,7 +31,7 @@ VideoChess has the action space of `Discrete(10)` with the table below listing t
 To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
 initialization or by passing `full_action_space=True` to `gymnasium.make`.
 
-|   Value | Meaning   |
+|   Index | Action    |
 |---------|-----------|
 |       0 | NOOP      |
 |       1 | FIRE      |

--- a/docs/environments/video_cube.md
+++ b/docs/environments/video_cube.md
@@ -30,7 +30,7 @@ For a more detailed documentation, see [the AtariAge page](https://atariage.com/
 VideoCube has the action space `Discrete(18)` with the table below listing the meaning of each action's meanings.
 As VideoCube uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | FIRE          |

--- a/docs/environments/video_pinball.md
+++ b/docs/environments/video_pinball.md
@@ -31,7 +31,7 @@ VideoPinball has the action space of `Discrete(9)` with the table below listing 
 To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
 initialization or by passing `full_action_space=True` to `gymnasium.make`.
 
-|   Value | Meaning   |
+|   Index | Action    |
 |---------|-----------|
 |       0 | NOOP      |
 |       1 | FIRE      |

--- a/docs/environments/wizard_of_wor.md
+++ b/docs/environments/wizard_of_wor.md
@@ -31,7 +31,7 @@ WizardOfWor has the action space of `Discrete(10)` with the table below listing 
 To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
 initialization or by passing `full_action_space=True` to `gymnasium.make`.
 
-|   Value | Meaning   |
+|   Index | Action    |
 |---------|-----------|
 |       0 | NOOP      |
 |       1 | FIRE      |

--- a/docs/environments/word_zapper.md
+++ b/docs/environments/word_zapper.md
@@ -30,7 +30,7 @@ For a more detailed documentation, see [the AtariAge page](https://atariage.com/
 WordZapper has the action space `Discrete(18)` with the table below listing the meaning of each action's meanings.
 As WordZapper uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | FIRE          |

--- a/docs/environments/yars_revenge.md
+++ b/docs/environments/yars_revenge.md
@@ -30,7 +30,7 @@ For a more detailed documentation, see [the AtariAge page](https://atariage.com/
 YarsRevenge has the action space `Discrete(18)` with the table below listing the meaning of each action's meanings.
 As YarsRevenge uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | FIRE          |

--- a/docs/environments/zaxxon.md
+++ b/docs/environments/zaxxon.md
@@ -30,7 +30,7 @@ For a more detailed documentation, see [the AtariAge page](https://atariage.com/
 Zaxxon has the action space `Discrete(18)` with the table below listing the meaning of each action's meanings.
 As Zaxxon uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
 
-|   Value | Meaning       |
+|   Index | Action        |
 |---------|---------------|
 |       0 | NOOP          |
 |       1 | FIRE          |


### PR DESCRIPTION
For some atari environments, they need the user to take a particular actions (normally) fire before the game starts. This PR adds documentation using an partially automated script from claude, and superseeds https://github.com/Farama-Foundation/Arcade-Learning-Environment/pull/663