### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -118,6 +118,8 @@ jobs:
   build-wasm:
     name: Build WASM
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
Potential fix for [https://github.com/Farama-Foundation/Arcade-Learning-Environment/security/code-scanning/9](https://github.com/Farama-Foundation/Arcade-Learning-Environment/security/code-scanning/9)

Add an explicit `permissions` block to the `build-wasm` job in `.github/workflows/build-release.yml`.

Best fix (minimal functional change): define only the scopes needed by that job:
- `contents: write` (required for `softprops/action-gh-release` to upload release assets)
- no additional scopes unless required by other steps in this job

Edit location:
- File: `.github/workflows/build-release.yml`
- Region: `build-wasm` job definition, immediately under `runs-on`

No imports/dependencies/methods are needed (YAML config-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
