### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -18,6 +18,9 @@ on:
     branches:
       - "*"
 
+permissions:
+  contents: read
+
 jobs:
   build-wasm:
     name: Build WASM


### PR DESCRIPTION
Potential fix for [https://github.com/Farama-Foundation/Arcade-Learning-Environment/security/code-scanning/3](https://github.com/Farama-Foundation/Arcade-Learning-Environment/security/code-scanning/3)

Add an explicit `permissions` block with least privilege to the workflow.  
Best fix here: set workflow-level permissions to `contents: read`, which is sufficient for checkout and does not change functionality. This applies to all jobs (currently one job) unless overridden.

Edit file:
- `.github/workflows/build-wasm.yml`
- Insert `permissions:` after the `on:` block (before `jobs:`), with:
  - `contents: read`

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
