### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -14,6 +14,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   thread-sanitizer:
     name: "Thread Sanitizer"


### PR DESCRIPTION
Potential fix for [https://github.com/Farama-Foundation/Arcade-Learning-Environment/security/code-scanning/12](https://github.com/Farama-Foundation/Arcade-Learning-Environment/security/code-scanning/12)

Add an explicit workflow-level `permissions` block in `.github/workflows/sanitizers.yml` so all jobs inherit least-privilege token access.

Best fix here: insert at the top level (after `on:` block, before `jobs:`):

- `permissions:`
  - `contents: read`

This is the minimal and recommended baseline for workflows that only need to read repository contents (e.g., `actions/checkout`) and do not need to write issues, PRs, packages, deployments, etc. No imports, methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
