### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/tests/wasm/testing-example.html
+++ b/tests/wasm/testing-example.html
@@ -638,7 +638,13 @@
             const timestamp = new Date().toLocaleTimeString();
             const entry = document.createElement('div');
             entry.className = `log-entry ${type}`;
-            entry.innerHTML = `<span class="timestamp">${timestamp}</span><span>${message}</span>`;
+            const timestampSpan = document.createElement('span');
+            timestampSpan.className = 'timestamp';
+            timestampSpan.textContent = timestamp;
+            const messageSpan = document.createElement('span');
+            messageSpan.textContent = message;
+            entry.appendChild(timestampSpan);
+            entry.appendChild(messageSpan);
             gameLog.appendChild(entry);
             gameLog.scrollTop = gameLog.scrollHeight;
         }


### PR DESCRIPTION
Potential fix for [https://github.com/Farama-Foundation/Arcade-Learning-Environment/security/code-scanning/1](https://github.com/Farama-Foundation/Arcade-Learning-Environment/security/code-scanning/1)

The best fix is to stop using `innerHTML` for log message construction and build the DOM elements explicitly, assigning untrusted values with `textContent`. This preserves functionality (timestamp + message in separate spans, same classes/layout) while preventing any injected markup from being interpreted.

In `tests/wasm/testing-example.html`, update `addLog` (around lines 637–643):
- Keep `entry` and class assignment.
- Replace `entry.innerHTML = ...` with:
  - create `timestampSpan`, set class `timestamp`, set `textContent` to timestamp.
  - create `messageSpan`, set `textContent` to `message`.
  - append both spans to `entry`.
- Keep append to `gameLog` and scroll behavior unchanged.

No new imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
